### PR TITLE
Fix for ClassLoader::canLoadClass() using PHP include_path

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -162,9 +162,13 @@ class ClassLoader
         if ($this->namespace !== null && strpos($className, $this->namespace.$this->namespaceSeparator) !== 0) {
             return false;
         }
-        return file_exists(($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
-               . str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className)
-               . $this->fileExtension);
+
+        $file = str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className) . $this->fileExtension;
+        if ($this->includePath !== null) {
+            return file_exists($this->includePath . DIRECTORY_SEPARATOR . $file);
+        } else {
+            return self::fileExistsInIncludePath($file);
+        }
     }
 
     /**
@@ -236,5 +240,18 @@ class ClassLoader
         }
 
         return null;
+    }
+    
+    /**
+     * @param string $file The file relative path.
+     * @return boolean Whether file exists in include_path.
+     */
+    private static function fileExistsInIncludePath($file)
+    {
+        foreach (explode(PATH_SEPARATOR, get_include_path()) as $dir) {
+            if (file_exists($dir . DIRECTORY_SEPARATOR . $file)) {
+                return true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Current implementation only works when checked file is relative to current directory.
