### PR TITLE
Extendable ArrayCollection

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -36,7 +36,7 @@ class ArrayCollection implements Collection
      *
      * @var array
      */
-    private $_elements;
+    protected $_elements;
 
     /**
      * Initializes a new ArrayCollection.


### PR DESCRIPTION
I needed a "Valid" ArrayCollection for use with Symfony 2, which seemed to be best provided by extending the Doctrine ArrayCollection. But _elements was private.

Here's what I extended it with:

<pre>
class ValidArrayCollection extends ArrayCollection {

  public static function loadValidatorMetadata(ClassMetadata $metadata) {
    $metadata->addPropertyConstraint('_elements', new Valid());
  }

  public function __construct(array $elements = array()) {
    parent::__construct($elements);
  }
}
</pre>
