### PR TITLE
Fixed bug where filter/map/partition explicitly return ArrayCollection

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -347,7 +347,7 @@ class ArrayCollection implements Collection
      */
     public function map(Closure $func)
     {
-        return new ArrayCollection(array_map($func, $this->_elements));
+        return new $this(array_map($func, $this->_elements));
     }
 
     /**
@@ -359,7 +359,7 @@ class ArrayCollection implements Collection
      */
     public function filter(Closure $p)
     {
-        return new ArrayCollection(array_filter($this->_elements, $p));
+        return new $this(array_filter($this->_elements, $p));
     }
 
     /**
@@ -399,7 +399,7 @@ class ArrayCollection implements Collection
                 $coll2[$key] = $element;
             }
         }
-        return array(new ArrayCollection($coll1), new ArrayCollection($coll2));
+        return array(new $this($coll1), new $this($coll2));
     }
 
     /**


### PR DESCRIPTION
If you extend `ArrayCollection` and use any function that returns a new collection, it explicitly uses `ArrayCollection` rather than the current instantiating class (ie, `FooCollection`).

So, if you perform a `filter` operation on the collection chained with a custom method (`FooCollection::barMethod`), it'll throw an error because the filtered collection is now an `ArrayCollection`.
