### PR TITLE
Fix autoloader with correct return code and file check

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -143,11 +143,16 @@ class ClassLoader
             return false;
         }
 
-        require ($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
+        $file = ($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
                . str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className)
                . $this->fileExtension;
-        
-        return true;
+        $file = realpath($file);
+        if(file_exists($file) === true) {
+            require_once $file;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Please pull in these changes on the autloader.

Some larger projects like one i work on have multiple autoloaders registered,
so there is a need for the correct return code.

The next thing is, that the original doctrine autoloader made no checks if the file required even exists or may already is required. This will be fixed with this patch.
