### PR TITLE
Bug-Fix Annotation Parser

### DIFF
--- a/lib/Doctrine/Common/Annotations/Parser.php
+++ b/lib/Doctrine/Common/Annotations/Parser.php
@@ -99,7 +99,7 @@ class Parser
 
     /**
      * Gets the lexer used by this parser.
-     * 
+     *
      * @return Lexer The lexer.
      */
     public function getLexer()
@@ -198,7 +198,10 @@ class Parser
         $input = str_replace(self::$strippedTags, '', $docBlockString);
 
         // Cut of the beginning of the input until the first '@'.
-        $input = substr($input, strpos($input, '@'));
+        if (!preg_match('/^\s*\*\s*(@.*)/ms', $input, $match)) {
+            return array();
+        }
+        $input = $match[1];
 
         $this->lexer->reset();
         $this->lexer->setInput(trim($input, '* /'));


### PR DESCRIPTION
Fixes a bug in the annotation parser which resulted in every @ sign being considered an annotation.

See http://www.doctrine-project.org/jira/browse/DCOM-41

Unfortunately, I couldn't find information on how to run the test suite, so it's not tested.
