### PR TITLE
Propose for a smaller (but impacting) performance issue

### DIFF
--- a/lib/Doctrine/Common/Cache/AbstractCache.php
+++ b/lib/Doctrine/Common/Cache/AbstractCache.php
@@ -34,7 +34,7 @@ abstract class AbstractCache implements Cache
     private $_cacheIdsIndexId = 'doctrine_cache_ids';
 
     /** @var string The namespace to prefix all cache ids with */
-    private $_namespace = null;
+    private $_namespace = '';
 
     /**
      * Set the namespace to prefix all cache ids with.
@@ -44,7 +44,7 @@ abstract class AbstractCache implements Cache
      */
     public function setNamespace($namespace)
     {
-        $this->_namespace = $namespace;
+        $this->_namespace = (string) $namespace;
     }
 
     /**
@@ -176,11 +176,7 @@ abstract class AbstractCache implements Cache
      */
     private function _getNamespacedId($id)
     {
-        if ( ! $this->_namespace || strpos($id, $this->_namespace) === 0) {
-            return $id;
-        } else {
-            return $this->_namespace . $id;
-        }
+        return $this->_namespace . $id;
     }
 
     /**


### PR DESCRIPTION
Just noticed that Doctrine\Common\Cache\AbstractCache#_getNamespacedId($id) does this strange stuff:

```
private function _getNamespacedId($id)

{
    if ( ! $this->_namespace || strpos($id, $this->_namespace) === 0) {

        return $id;
    } else {

        return $this->_namespace . $id;

    }
}
```

This degrades performance if I want to use my cache dozens or thousands of times (currently 1.2% of runtime of my app goes there), and I don't really see a motivation for it.
Is this a desired behaviour? I never used deletions by regex anyway...
This is my proposal for a smaller performance enhancement, please let me know if I didn't understand this method purpose.
