### PR TITLE
DCOM-28: add ObjectRepository::findMany()

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -62,4 +62,12 @@ interface ObjectRepository
      * @return object The object.
      */
     public function findOneBy(array $criteria);
+
+    /**
+     * Find Many documents of the given repositories type by id.
+     *
+     * @param array $ids of identifiers
+     * @return array of object instances
+     */
+    public function findMany(array $ids);
 }


### PR DESCRIPTION
Another thing I noticed is that its unnecessary to keep the "public" keyword in interfaces, but it seems customary in Doctrine source, so I left it as is.
