### PR TITLE
Added cast to int/float to Annotations/Lexer->GetNumeric($value)

### DIFF
--- a/lib/Doctrine/Common/Annotations/Lexer.php
+++ b/lib/Doctrine/Common/Annotations/Lexer.php
@@ -148,7 +148,7 @@ class Lexer extends \Doctrine\Common\Lexer
 
         // Checking for valid numeric numbers: 1.234, -1.234e-2
         if (is_numeric($value)) {
-            if(strpos($value, '.') !== false || stripos($value, 'e') !== false){
+            if (strpos($value, '.') !== false || stripos($value, 'e') !== false) {
                 return (float) $value;
             } else {
                 return (int) $value;


### PR DESCRIPTION
Symfony2 Choice Validator did not work with numeric choices, because Annotations/Lexer->GetNumeric returned the values as string, and the comparison of the Symfony2 validator was type-sensitive (which it should be).

The comment of GetNumeric implies that it returns boolean (false on failure), integer and float. It did return boolean and string before this fix.
