### PR TITLE
added null support for annotation values

### DIFF
--- a/lib/Doctrine/Common/Annotations/Lexer.php
+++ b/lib/Doctrine/Common/Annotations/Lexer.php
@@ -51,6 +51,7 @@ class Lexer extends \Doctrine\Common\Lexer
     const T_OPEN_CURLY_BRACES   = 108;
     const T_OPEN_PARENTHESIS    = 109;
     const T_TRUE                = 110;
+    const T_NULL                = 111;
     
     /**
      * @inheritdoc
@@ -121,6 +122,9 @@ class Lexer extends \Doctrine\Common\Lexer
 
                 case 'false': 
                     return self::T_FALSE;
+
+                case 'null':
+                    return self::T_NULL;
 
                 default:
                     if (ctype_alpha($value[0]) || $value[0] === '_') {

--- a/lib/Doctrine/Common/Annotations/Parser.php
+++ b/lib/Doctrine/Common/Annotations/Parser.php
@@ -469,6 +469,10 @@ class Parser
                 $this->match(Lexer::T_FALSE);
                 return false;
 
+            case Lexer::T_NULL:
+                $this->match(Lexer::T_NULL);
+                return null;
+
             default:
                 $this->syntaxError('PlainValue');
         }


### PR DESCRIPTION
The annotation lexer/parser supports true and false as values, but not null. This patch fixes this issue. Is it possible to also apply it to the 2.0.x branch?
