### PR TITLE
Make subclassing ArrayCollection easier

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -347,7 +347,7 @@ class ArrayCollection implements Collection
      */
     public function map(Closure $func)
     {
-        return new ArrayCollection(array_map($func, $this->_elements));
+        return new static(array_map($func, $this->_elements));
     }
 
     /**
@@ -359,7 +359,7 @@ class ArrayCollection implements Collection
      */
     public function filter(Closure $p)
     {
-        return new ArrayCollection(array_filter($this->_elements, $p));
+        return new static(array_filter($this->_elements, $p));
     }
 
     /**
@@ -399,7 +399,7 @@ class ArrayCollection implements Collection
                 $coll2[$key] = $element;
             }
         }
-        return array(new ArrayCollection($coll1), new ArrayCollection($coll2));
+        return array(new static($coll1), new static($coll2));
     }
 
     /**


### PR DESCRIPTION
Replaced "new ArrayCollection" with "new static". This allows subclasses to create new instances of the subclass
