### PR TITLE
Add magic properties and methods to list of globally-ignored annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -60,7 +60,7 @@ final class AnnotationReader implements Reader
         'return'=> true, 'staticvar'=> true, 'category'=> true, 'staticVar'=> true,
         'static'=> true, 'var'=> true, 'throws'=> true, 'inheritdoc'=> true,
         'inheritDoc'=> true, 'license'=> true, 'todo'=> true, 'deprecated'=> true,
-        'deprec'=> true, 'author'=> true, 'property' => true,
+        'deprec'=> true, 'author'=> true, 'property' => true, 'method' => true,
     );
 
     /**


### PR DESCRIPTION
Use case described at e.g. http://manual.phpdoc.org/HTMLSmartyConverter/PHP/phpDocumentor/tutorial_tags.property.pkg.html .
