### PR TITLE
2.1 dev

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -102,7 +102,7 @@ final class DocParser
     /**
      * @var boolean
      */
-    private $autoloadAnnotations = false;
+    private $autoloadAnnotations = true;
     
     /**
      * @var Closure


### PR DESCRIPTION
The autoloading of annotations should be enabled by default as 3.0.x, if not it breaks a lot of bundles in Symfony
