### PR TITLE
ignore @private in annotation reader

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -62,6 +62,7 @@ final class AnnotationReader implements Reader
         'inheritDoc'=> true, 'license'=> true, 'todo'=> true, 'deprecated'=> true,
         'deprec'=> true, 'author'=> true, 'property' => true, 'method' => true,
         'abstract'=> true, 'exception'=> true, 'magic' => true, 'api' => true,
+        'private' => true,
     );
 
     /**


### PR DESCRIPTION
ignore @private in annotation reader (use in Doctrine2 ORM Generated Proxy)
