### PR TITLE
[Annotions] Added an optional  $parser argument to the AnnotationReader´s constructor.

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -126,9 +126,14 @@ final class AnnotationReader implements Reader
      *
      * @param DocParser $parser The parser to use. If none is provided, the default parser is used.
      */
-    public function __construct()
+    public function __construct(DocParser $parser = null)
     {
-        $this->parser = new DocParser;
+        $this->parser = $parser;
+        
+        if(null === $this->parser) {
+            
+            $this->parser = new DocParser;
+        }
 
         $this->preParser = new DocParser;
         $this->preParser->setImports(self::$globalImports);


### PR DESCRIPTION
[Annotions] Added an optional  $parser argument to the AnnotationReader´s constructor, as "promised" by the construcor´s doccomment.

One should be able to inject the "main" parser to fine-tune annotation whitelists, annotation autoloading or the globally ignore flag when using the common library in a private application - in short - one should be able to configure the annotation reader´s behaviour.

ATM this could be only archived by using the property injection feature of the symfony´s DIC, thus injecting a private member in my opinion has a litte smell.

A note to line 395ff. of the AnnotationReader.php: $imports is never used in it´s context, possibly $this->imports is meant?

Thanks for your work and best regards
de joshi
