### PR TITLE
Use stream_resolve_include_path

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -266,6 +266,9 @@ class ClassLoader
      */
     public static function fileExistsInIncludePath($file)
     {
+        if (function_exists('stream_resolve_include_path')) {
+            return stream_resolve_include_path($file);
+        }
         foreach (explode(PATH_SEPARATOR, get_include_path()) as $dir) {
             if (file_exists($dir . DIRECTORY_SEPARATOR . $file)) {
                 return true;


### PR DESCRIPTION
`Doctrine\Common\ClassLoader::fileExistsInIncludePath` behaves the same as `stream_resolve_include_path`, use that instead when available (PHP >= 5.3.2). It should be faster than doing that manually.
