### PR TITLE
DCOM-58

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -142,6 +142,7 @@ final class AnnotationReader implements Reader
     {
         $this->parser->setTarget(Target::TARGET_CLASS);
         $this->parser->setImports($this->getImports($class));
+        $this->parser->addNamespace($class->getNamespaceName());
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
 
         return $this->parser->parse($class->getDocComment(), 'class ' . $class->getName());
@@ -181,6 +182,7 @@ final class AnnotationReader implements Reader
         $context = 'property ' . $class->getName() . "::\$" . $property->getName();
         $this->parser->setTarget(Target::TARGET_PROPERTY);
         $this->parser->setImports($this->getImports($class));
+        $this->parser->addNamespace($class->getNamespaceName());
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
 
         return $this->parser->parse($property->getDocComment(), $context);
@@ -219,6 +221,7 @@ final class AnnotationReader implements Reader
         $context = 'method ' . $class->getName() . '::' . $method->getName() . '()';
         $this->parser->setTarget(Target::TARGET_METHOD);
         $this->parser->setImports($this->getImports($class));
+        $this->parser->addNamespace($class->getNamespaceName());
         $this->parser->setIgnoredAnnotationNames($this->getIgnoredAnnotationNames($class));
 
         return $this->parser->parse($method->getDocComment(), $context);
@@ -277,7 +280,6 @@ final class AnnotationReader implements Reader
      */
     private function collectParsingMetadata(ReflectionClass $class)
     {
-        $imports = self::$globalImports;
         $ignoredAnnotationNames = self::$globalIgnoredNames;
 
         $annotations = $this->preParser->parse($class->getDocComment(), 'class '.$class->name);
@@ -292,8 +294,7 @@ final class AnnotationReader implements Reader
         $name = $class->getName();
         $this->imports[$name] = array_merge(
             self::$globalImports,
-            $this->phpParser->parseClass($class),
-            array('__NAMESPACE__' => $class->getNamespaceName())
+            $this->phpParser->parseClass($class)
         );
         $this->ignoredAnnotationNames[$name] = $ignoredAnnotationNames;
     }

--- a/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
+++ b/tests/Doctrine/Tests/Common/Annotations/DocParserTest.php
@@ -1001,7 +1001,6 @@ DOCBLOCK;
 DOCBLOCK;
 
         $this->createTestParser()->parse($docblock, 'some class');
-        $this->assertEquals(count($result), 1);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Entity.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Entity.php
@@ -1,9 +1,8 @@
 <?php
-
+// Some class named Entity in the global namespace
 /**
  * @Annotation
  */
 class Entity
 {
-    
 }

--- a/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Test.php
+++ b/tests/Doctrine/Tests/Common/Annotations/Ticket/DCOM58Test.php
@@ -1,35 +1,135 @@
 <?php
 namespace Doctrine\Tests\Common\Annotations\Ticket;
 
-include __DIR__. '/DCOM58Entity.php';
+//Some class named Entity in the global namespace
+include __DIR__ .'/DCOM58Entity.php';
 
 /**
  * @group DCOM58
  */
 class DCOM58Test extends \PHPUnit_Framework_TestCase
 {
- 
+    
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Class "xxx" is not a valid entity or mapped super class.
+     */
     public function testIssue()
+    {
+        $reader     = new \Doctrine\Common\Annotations\AnnotationReader();
+        $result     = $reader->getClassAnnotations(new \ReflectionClass(__NAMESPACE__."\MappedClass"));
+        
+        foreach ($result as $annot) {
+            $classAnnotations[get_class($annot)] = $annot;
+        }
+        // Evaluate Entity annotation
+        if (!isset($classAnnotations['Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping\Entity'])) {
+            throw new \Exception('Class "xxx" is not a valid entity or mapped super class.');
+        }
+    }
+    
+    public function testIssueGlobalNamespace()
+    {
+        $docblock   = "@Entity";
+        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser->setImports(array(
+            "__NAMESPACE__" =>"Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping"
+        ));
+        
+        $annots     = $parser->parse($docblock);
+        
+        $this->assertEquals(1, count($annots));
+        $this->assertInstanceOf("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping\Entity", $annots[0]);
+    }
+    
+    public function testIssueNamespaces()
+    {
+        $docblock   = "@Entity";
+        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM");
+        
+        $annots     = $parser->parse($docblock);
+        
+        $this->assertEquals(1, count($annots));
+        $this->assertInstanceOf("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Entity", $annots[0]);
+    }
+    
+    public function testIssueMultipleNamespaces()
+    {
+        $docblock   = "@Entity";
+        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping");
+        $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM");
+        
+        $annots     = $parser->parse($docblock);
+        
+        $this->assertEquals(1, count($annots));
+        $this->assertInstanceOf("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping\Entity", $annots[0]);
+    }
+    
+    
+    public function testIssueNamespacesAndImports()
+    {
+        $docblock   = "@Entity";
+        $parser     = new \Doctrine\Common\Annotations\DocParser();
+        $parser->setImports(array(
+            '__NAMESPACE__' => "Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping",
+        ));
+        $parser->addNamespace("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM");
+        
+        $annots     = $parser->parse($docblock);
+        
+        $this->assertEquals(1, count($annots));
+        $this->assertInstanceOf("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping\Entity", $annots[0]);
+    }
+    
+    public function testIssueWithNamespacesOrImports()
     {
         $docblock   = "@Entity";
         $parser     = new \Doctrine\Common\Annotations\DocParser();
         $annots     = $parser->parse($docblock);
         
-        $parser->setImports(array(
-            'entity'=> __NAMESPACE__ . '\Entity'
-        ));
+        $this->assertEquals(1, count($annots));
+        $this->assertInstanceOf("Entity", $annots[0]);
+        $this->assertEquals(1, count($annots));
+    }
+    
+    
+    public function testIssueSimpleAnnotationReader()
+    {
+        $reader     = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
+        $reader->addNamespace('Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping');
+        $annots     = $reader->getClassAnnotations(new \ReflectionClass(__NAMESPACE__."\MappedClass"));
         
         $this->assertEquals(1, count($annots));
-        
-        var_dump($annots);
+        $this->assertInstanceOf("Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping\Entity", $annots[0]);
     }
 
 }
 
-
 /**
- * @Annotation
+ * @Entity
  */
+class MappedClass
+{
+
+}
+
+
+namespace Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM\Mapping;
+/**
+* @Annotation
+*/
 class Entity
 {
+
+}
+
+namespace Doctrine\Tests\Common\Annotations\Ticket\Doctrine\ORM;
+/**
+* @Annotation
+*/
+class Entity
+{
+
 }


### PR DESCRIPTION
Hello all.
This patch fix DCOM-58
http://www.doctrine-project.org/jira/browse/DCOM-58

If I understand right  the bug caused by the search order from annotation class name.

In Common 2.1 >=  the DocParser looks first at gobal namespace for class name
I changed the order in which the class name is searched.

1 Imports
2 namespaces
3 Gobal namespace

I think this solves the problem.

Please take a look

Thanks ...

Best Regards,
Fabio B. SIlva
