### PR TITLE
Make it possible to globally import a namespace

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -297,4 +297,13 @@ final class AnnotationReader implements Reader
         );
         $this->ignoredAnnotationNames[$name] = $ignoredAnnotationNames;
     }
+
+    /**
+     * @param string $name The alias for the namespace
+     * @param string $namespace The actual namespace to import
+     */
+    public static function addGlobalImport($name, $namespace)
+    {
+        self::$globalImports[strtolower($name)] = $namespace;
+    }
 }


### PR DESCRIPTION
Hey guys!

I wanted to make this pull request to open up the idea of globally importing annotation namespaces. This could make using annotations easier, since you won't need to import the annotations in each file. It is, however, a deviation from how PHP namespaces work, though one could make the argument that importing PHP namespaces could be easier.

Apologies if I'm over-looking any other side effects. I did test this by importing a global annotation namespace during the bootstrap of a project. It worked great.

Thanks!
