### PR TITLE
Just a little performance improvement in contains($element)

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -214,13 +214,7 @@ class ArrayCollection implements Collection
      */
     public function contains($element)
     {
-        foreach ($this->_elements as $collectionElement) {
-            if ($element === $collectionElement) {
-                return true;
-            }
-        }
-        
-        return false;
+        return false !== $this->indexOf($element);
     }
 
     /**


### PR DESCRIPTION
Just a little performance improvement while Amazon continues spamming its products at the #ipc11 conference.
This has just been tested to be around 3.5 times faster than the previous "foreach" solution on some quick benchmarks, but NOT UNIT TESTED!
If someone has a test environment ready to check if this is actually a valid improvement just let me know.
