### PR TITLE
Bug fix when using console autogenerator of seters/getters

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -75,7 +75,7 @@ class StaticReflectionService implements ReflectionService
      */
     public function getClass($class)
     {
-        return null;
+        return new \ReflectionClass($class);
     }
 
     /**


### PR DESCRIPTION
[ErrorException]  
  Catchable Fatal Error: Argument 1 passed to Doctrine\Common\Annotations\FileCacheReader::getClassAnnotations() must be an instance of ReflectionClass, null given, called in vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php on line 140 and defined in vendor/doctrine-common/lib/Doctrine/Common/Annotations/FileCacheReader.php line 53  
when using console autogenerator of seters/getters
