### PR TITLE
Fixed classIsNotAValidEntity problem

### DIFF
--- a/lib/Doctrine/Common/Annotations/CachedReader.php
+++ b/lib/Doctrine/Common/Annotations/CachedReader.php
@@ -73,6 +73,7 @@ final class CachedReader implements Reader
         // Attempt to grab data from cache
         if (($data = $this->cache->fetch($cacheKey)) !== false) {
             if (!$this->debug || $this->isCacheFresh($cacheKey, $class)) {
+                reset($data);
                 return $data;
             }
         }


### PR DESCRIPTION
I don't know how it works earlier, but after update symfony and all Doctrine packages I have a headache on my production server: AnnotationDriver throws exception classIsNotAValidEntityOrMappedSuperClass, because in this code
        // Compatibility with Doctrine Common 3.x
        if ($classAnnotations && is_int(key($classAnnotations))) {
            foreach ($classAnnotations as $annot) {
                $classAnnotations[get_class($annot)] = $annot;
            }
        }
key($classAnnotations) returns null, because annotations readed from cache and internal pointer is set to last element! In development all works fine, because annotations is readed from file, not from cache.
I resolve this problem adding code reset($data) to CachedReader, but has many ways for resolve that
