### PR TITLE
[Persistence] Add clear() to ObjectManager interface

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -70,6 +70,14 @@ interface ObjectManager
      * @param object $object
      */
     function merge($object);
+    
+    /**
+     * Clears the ObjectManager. All objects that are currently managed
+     * by this ObjectManager become detached.
+     *
+     * @param string $objectName if given, only objects of this type will get detached
+     */
+    function clear($objectName = null)
 
     /**
      * Detaches an object from the ObjectManager, causing a managed object to


### PR DESCRIPTION
I'm not sure why this method was omitted from the interface, since `detach()` is present and both ORM/ODM implement a `clear()` method (despite ODM currently not supporting the `$objectName` filter).

If this is worth merging, someone might also want to consider adding `close()` to the interface.
