### PR TITLE
ApcCache::doContains should use apc_exists() instead of apc_fetch(). It ...

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -49,9 +49,7 @@ class ApcCache extends CacheProvider
     {
         $found = false;
 
-        apc_fetch($id, $found);
-
-        return $found;
+        return apc_exists($id);
     }
 
     /**


### PR DESCRIPTION
...makes a huge difference in execution time if stored value is large.
