### PR TITLE
Fixes a missing semicolon in lib/Doctrine/Common/Persistence/ObjectManager.php

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -77,7 +77,7 @@ interface ObjectManager
      *
      * @param string $objectName if given, only objects of this type will get detached
      */
-    function clear($objectName = null)
+    function clear($objectName = null);
 
     /**
      * Detaches an object from the ObjectManager, causing a managed object to


### PR DESCRIPTION
This was causing the build to fail and any project that pulls in common from composer to break.
