### PR TITLE
Improved performance of the caching system

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -118,7 +118,11 @@ abstract class CacheProvider implements Cache
     public function deleteAll()
     {
         $namespaceCacheKey = sprintf(self::DOCTRINE_NAMESPACE_CACHEKEY, $this->namespace);
-        $namespaceVersion  = ($this->doContains($namespaceCacheKey)) ? $this->doFetch($namespaceCacheKey) : 1;
+
+        $namespaceVersion = $this->doFetch($namespaceCacheKey);
+        if(false === $namespaceVersion){
+            $namespaceVersion = 1;
+        }
 
         return $this->doSave($namespaceCacheKey, $namespaceVersion + 1);
     }
@@ -132,7 +136,12 @@ abstract class CacheProvider implements Cache
     private function getNamespacedId($id)
     {
         $namespaceCacheKey = sprintf(self::DOCTRINE_NAMESPACE_CACHEKEY, $this->namespace);
-        $namespaceVersion  = ($this->doContains($namespaceCacheKey)) ? $this->doFetch($namespaceCacheKey) : 1;
+
+        $namespaceVersion = $this->doFetch($namespaceCacheKey);
+        if(false === $namespaceVersion){
+            $namespaceVersion = 1;
+            $this->doSave($namespaceCacheKey, $namespaceVersion);
+        }
 
         return sprintf('%s[%s][%s]', $this->namespace, $id, $namespaceVersion);
     }


### PR DESCRIPTION
This will improve the performance of the caching system by not doing too many round-trips to the caching service.

Also this will fix the problem where the caching key is searched in cache and if it's not found a default is assigned without it being saved to cache.

Hope this makes sense but for me it improved the caching hit rate by a lot since there are no more unnecessary/empty cache queries.
