### PR TITLE
Fix for CacheProvider serious performance issue

### DIFF
--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -42,7 +42,7 @@ abstract class CacheProvider implements Cache
     /**
      * @var string The namespace version
      */
-    private $namespaceVersion = NULL;
+    private $namespaceVersion;
 
     /**
      * Set the namespace to prefix all cache ids with.
@@ -124,6 +124,7 @@ abstract class CacheProvider implements Cache
     {
         $namespaceCacheKey = $this->getNamespaceCacheKey();
         $namespaceVersion  = $this->getNamespaceVersion() + 1;
+
         $this->namespaceVersion = $namespaceVersion;
 
         return $this->doSave($namespaceCacheKey, $namespaceVersion);
@@ -159,16 +160,20 @@ abstract class CacheProvider implements Cache
      */
     private function getNamespaceVersion()
     {
-        if (NULL === $this->namespaceVersion)
-        {
-            $namespaceCacheKey = $this->getNamespaceCacheKey();
-            $namespaceVersion = $this->doFetch($namespaceCacheKey);
-            if (false === $namespaceVersion) {
-                $namespaceVersion = 1;
-                $this->doSave($namespaceCacheKey, $namespaceVersion);
-            }
-            $this->namespaceVersion = $namespaceVersion;
+        if (null !== $this->namespaceVersion) {
+            return $this->namespaceVersion;
         }
+
+        $namespaceCacheKey = $this->getNamespaceCacheKey();
+        $namespaceVersion = $this->doFetch($namespaceCacheKey);
+
+        if (false === $namespaceVersion) {
+            $namespaceVersion = 1;
+
+            $this->doSave($namespaceCacheKey, $namespaceVersion);
+        }
+
+        $this->namespaceVersion = $namespaceVersion;
 
         return $this->namespaceVersion;
     }


### PR DESCRIPTION
Prior implementation for CacheProvider was seriously flawed from performance point of view as each fetch() call results in 2 additional cache storage calls due to $this->getNamespaceId(), which always checks for $namespaceCacheKey (and fetches it if exists, which will be the case for 2nd and next calls).

It is big overhead (3 calls instead just one for each fetch), and actually can be easily solved by memoizing namespace version value.
