### PR TITLE
Improved memcache(d) drivers plus added some clean-up

### DIFF
--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -66,7 +66,19 @@ class MemcacheCache extends CacheProvider
      */
     protected function doFetch($id)
     {
-        return $this->memcache->get($id);
+        $content = $this->memcache->get($id);
+
+        if ($content == 'doctrine__true__') {
+            $content = true;
+        } elseif ($content == 'doctrine__false__') {
+            $content = false;
+        } elseif ($content == 'doctrine__empty__') {
+            $content = '';
+        } elseif ($content == 'doctrine__zero__') {
+            $content = 0;
+        }
+
+        return $content;
     }
 
     /**
@@ -74,7 +86,9 @@ class MemcacheCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return (bool) $this->memcache->get($id);
+        $content = $this->memcache->get($id);
+
+        return ($content === 0 || (bool) $content);
     }
 
     /**
@@ -85,6 +99,17 @@ class MemcacheCache extends CacheProvider
         if ($lifeTime > 30 * 24 * 3600) {
             $lifeTime = time() + $lifeTime;
         }
+
+        if (true === $data) {
+                $data = 'doctrine__true__';
+        } elseif(false === $data) {
+            $data = 'doctrine__false__';
+        } elseif ('' === $data) {
+            $data = 'doctrine__empty__';
+        } elseif (0 === $data) {
+            $data = 'doctrine__zero__';
+        }
+
         return $this->memcache->set($id, $data, 0, (int) $lifeTime);
     }
 

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -74,7 +74,9 @@ class MemcachedCache extends CacheProvider
      */
     protected function doContains($id)
     {
-        return (false !== $this->memcached->get($id));
+        $this->memcached->get($id);
+
+        return $this->memcached->getResultCode() != Memcached::RES_NOTFOUND;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -18,15 +18,15 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
 
         // Test fetch
         $this->assertEquals('testing this out', $cache->fetch('test_key'));
-        
+
         // Test delete
         $cache->save('test_key2', 'test2');
         $cache->delete('test_key2');
         $this->assertFalse($cache->contains('test_key2'));
-        
+
         // Fetch/save test with objects (Is cache driver serializes/unserializes objects correctly ?)
         $cache->save('test_object_key', new \ArrayObject());
-        $this->assertTrue($cache->fetch('test_object_key') instanceof \ArrayObject);        
+        $this->assertTrue($cache->fetch('test_object_key') instanceof \ArrayObject);
     }
 
     public function testDeleteAll()
@@ -64,6 +64,34 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($cache->contains('key1'));
     }
 
+    public function testZeroNotFalse()
+    {
+        $cache = $this->_getCacheDriver();
+
+        // Test save of int 0
+        $cache->save('test_key_zero', 0);
+        $cache->save('test_key_false', false);
+        $cache->save('test_key_empty', '');
+
+        // Test contains on int 0
+        $this->assertTrue($cache->contains('test_key_zero'));
+
+        // Test contains FALSE value
+        $this->assertTrue($cache->contains('test_key_false'));
+
+        // Test contains FALSE value
+        $this->assertTrue($cache->contains('test_key_empty'));
+
+        // Test fetch of int 0
+        $this->assertEquals(0, $cache->fetch('test_key_zero'));
+
+        // Test fetch FALSE value
+        $this->assertFalse($cache->fetch('test_key_false'));
+
+        // Test fetch FALSE value
+        $this->assertEquals('', $cache->fetch('test_key_empty'));
+    }
+
     /**
      * @group DCOM-43
      */
@@ -88,4 +116,29 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
      * @return \Doctrine\Common\Cache\CacheProvider
      */
     abstract protected function _getCacheDriver();
+
+    /**
+     * Clean-up
+     */
+    protected function tearDown()
+    {
+        if (0 != $this->getStatus()) {
+            return;
+        }
+
+        $cache = $this->_getCacheDriver();
+
+        $cache->delete('test_key');
+        $cache->delete('test_key1');
+        $cache->delete('test_key2');
+        $cache->delete('test_object_key');
+        $cache->delete('test_key_zero');
+        $cache->delete('test_key_false');
+        $cache->delete('test_key_empty');
+
+        $cache->setNamespace('test_');
+        $cache->delete('key1');
+        $cache->setNamespace('test2_');
+        $cache->delete('key1');
+    }
 }


### PR DESCRIPTION
Hi,


As per #101, Memcache has some issues with the values in cache.

Added a basic test for some other values that crossed my mind but then I discovered that there are even more problems. Hence I've hacked the memcache part so ugly. I'm not proud of it but if you want to merge this without that part let me know as I'll remove it asap. It's 2 AM here @ time of this PR.

Also while running the tests I've created I've noticed that Memcached a similar issue and since I've noticed that we don't do any clean-up for the tests I've added the tearDown() function that should solve it.

Again, I'm not proud of how I did the memcache part so if anyone comes up with better ideas let me know and I'll update this. Also if you want to merge this PR without the memcache ugly hack, let me know and I'll remove it asap.

Build status: [![Build Status](https://secure.travis-ci.org/dlsniper/common.png?branch=improved-memcached-driver)](http://travis-ci.org/dlsniper/common)