### PR TITLE
Small performance fix on setter with expire time. (1 call instead of 2)

### DIFF
--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -80,11 +80,9 @@ class RedisCache extends CacheProvider
     protected function doSave($id, $data, $lifeTime = 0)
     {
         if ($lifeTime > 0) {
-            $result = $this->redis->setex($id, $lifetime, $data);        
-        } else {    
-            $result = $this->redis->set($id, $data);
+            return $this->redis->setex($id, $lifetime, $data);        
         }
-        return $result;
+        return $this->redis->set($id, $data);
     }
 
     /**


### PR DESCRIPTION
Instead of setting then arranging expire time used redis command setex  (which sets with expire).
