### PR TITLE
Classutil performance

### DIFF
--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -53,7 +53,7 @@ class ClassUtils
      */
     public static function getClass($object)
     {
-        return self::getRealClass(get_class($object));
+        return $object instanceof Proxy ? self::getRealClass(get_parent_class($object)) : get_class($object);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -73,20 +73,52 @@ namespace Doctrine\Tests\Common\Util
 
 namespace MyProject\Proxies\__CG__
 {
-    class stdClass extends \stdClass
+    use Doctrine\Common\Persistence\Proxy;
+
+    class stdClass extends \stdClass implements Proxy
     {
+        /**
+         * {@inheritDoc}
+         */
+        public function __load()
+        {
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public function __isInitialized()
+        {
+        }
     }
 }
 
 namespace MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util
 {
-    class ChildObject extends \Doctrine\Tests\Common\Util\ChildObject
+    use Doctrine\Common\Persistence\Proxy;
+
+    class ChildObject extends \Doctrine\Tests\Common\Util\ChildObject implements Proxy
     {
+        /**
+         * {@inheritDoc}
+         */
+        public function __load()
+        {
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public function __isInitialized()
+        {
+        }
     }
 }
 
 namespace MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__
 {
+    use Doctrine\Common\Persistence\Proxy;
+
     class stdClass extends \MyProject\Proxies\__CG__\stdClass
     {
     }
@@ -94,6 +126,8 @@ namespace MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__
 
 namespace MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\Doctrine\Tests\Common\Util
 {
+    use Doctrine\Common\Persistence\Proxy;
+
     class ChildObject extends \MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject
     {
     }


### PR DESCRIPTION
This PR introduces minor performance optimizations that are required for doctrine/doctrine2#315 as the usage of `class_name` is replaced by `Doctrine\Common\Util\ClassUtils::getClass`.

[![Build Status](https://secure.travis-ci.org/Ocramius/common.png?branch=master)](http://travis-ci.org/Ocramius/common)
