### PR TITLE
Syncing changes of ORM ClassMetadataFactory in common

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -19,7 +19,8 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Cache,
+    Doctrine\Common\Util\ClassUtils;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the


### PR DESCRIPTION
This change allows usage of proxy class names when requesting class metadata.

Build is [![Build Status](https://secure.travis-ci.org/Ocramius/common.png?branch=classmetadatafactory-orm-sync)](http://travis-ci.org/Ocramius/common) , changes ported back can be viewed at doctrine/doctrine2#315
