### PR TITLE
Add getConfig method to objectManager interface

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -148,4 +148,11 @@ interface ObjectManager
      * @return bool
      */
     function contains($object);
+    
+    /**
+     * Gets the Configuration used by the ObjectManager.
+     *
+     * @return object Configuration
+     */
+    function getConfiguration();    
 }


### PR DESCRIPTION
Please review this idea carefully. Expanding the scope of the ObjectManager interface will allow more code to be placed in doctrine-common and shared by ORM/ODM. However, I realise altering this interface might break things?? What do you think?
