### PR TITLE
Added the branch-alias in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,10 @@
     },
     "autoload": {
         "psr-0": { "Doctrine\\Common": "lib/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.3.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Once this is done for all ORM deps (other PRs coming soon), I will be able to change the requirement in DoctrineBundle to allow both 2.2 and 2.3 for Doctrine. Without this alias, I would have to allow anything higher than 2.2 (as dev-master is considered as 99999.x-dev), which would be bad as it would forbid tagging the bundle (I don't know the future to ensure that it will work with any future doctrine release).
Except for the composer constraint, DoctrineBundle should already work with Doctrine master.
