### PR TITLE
Wrong cache tests for fetch and save

### DIFF
--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -45,7 +45,7 @@ interface Cache
      * Fetches an entry from the cache.
      *
      * @param string $id cache id The id of the cache entry to fetch.
-     * @return string The cached data or FALSE, if no cache entry exists for the given id.
+     * @return mixed The cached data or FALSE, if no cache entry exists for the given id.
      */
     function fetch($id);
 
@@ -61,7 +61,7 @@ interface Cache
      * Puts data into the cache.
      *
      * @param string $id The cache id.
-     * @param string $data The cache entry/data.
+     * @param mixed $data The cache entry/data.
      * @param int $lifeTime The lifetime. If != 0, sets a specific lifetime for this cache entry (0 => infinite lifeTime).
      * @return boolean TRUE if the entry was successfully stored in the cache, FALSE otherwise.
      */


### PR DESCRIPTION
The commit doctrine/common@35d68ce1f01d8eacd688d9be4dcab092be199e3c should be reverted. It does not respect the `Cache` interface:

https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Cache/Cache.php#L64
https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Cache/Cache.php#L48

The functions expect strings and not objects.
