### PR TITLE
Updating interface to allow passing parent class names to the process of...

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -288,7 +288,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             $class = $this->newClassMetadataInstance($className);
             $this->initializeReflection($class, $reflService);
 
-            $this->doLoadMetadata($class, $parent, $rootEntityFound);
+            $this->doLoadMetadata($class, $parent, $rootEntityFound, $visited);
 
             $this->loadedMetadata[$className] = $class;
 
@@ -311,11 +311,12 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Actually load the metadata from the underlying metadata
      *
      * @param ClassMetadata $class
-     * @param ClassMetadata $parent
+     * @param ClassMetadata|null $parent
      * @param bool $rootEntityFound
+     * @param array $nonSuperclassParents classnames all parent classes that are not marked as mapped superclasses
      * @return void
      */
-    abstract protected function doLoadMetadata($class, $parent, $rootEntityFound);
+    abstract protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents);
 
     /**
      * Creates a new ClassMetadata instance for the given class name.

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -90,7 +90,7 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
         $this->metadata = $metadata;
     }
 
-    protected function doLoadMetadata($class, $parent, $rootEntityFound)
+    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
     {
 
     }


### PR DESCRIPTION
This change is required by doctrine/doctrine2#314 to allow metadata loading process to know all the class parents of a particular `ClassMetadata` instance.
