### PR TITLE
FOSOAuthServerBundle uses new doxygen annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -68,6 +68,7 @@ class AnnotationReader implements Reader
         'codeCoverageIgnore' => true, 'codeCoverageIgnoreStart' => true, 'codeCoverageIgnoreEnd' => true,
         'Required' => true, 'Attribute' => true, 'Attributes' => true,
         'Target' => true, 'SuppressWarnings' => true,
+        'ingroup' => true, 'code' => true, 'endcode' => true
     );
 
     /**


### PR DESCRIPTION
Hello there. In FosOAuthServerBundle a few new annotations from doxygen are used.

Symfony 2.0.15
FosOAuthServerBundle dev-master
...
