### PR TITLE
Document that merge() returns an object.

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -68,6 +68,7 @@ interface ObjectManager
      * The object passed to merge will not become associated/managed with this ObjectManager.
      *
      * @param object $object
+     * @return object
      */
     function merge($object);
 


### PR DESCRIPTION
It is documented in the text that `merge()` returns an object but it is not documented by `@return`.
