### PR TITLE
Added the support of namespace alias in getManagerForClass

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -190,6 +190,12 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      */
     public function getManagerForClass($class)
     {
+        // Check for namespace alias
+        if (strpos($class, ':') !== false) {
+            list($namespaceAlias, $simpleClassName) = explode(':', $class);
+            $class = $this->getAliasNamespace($namespaceAlias) . '\\' . $simpleClassName;
+        }
+
         $proxyClass = new \ReflectionClass($class);
         if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
             $class = $proxyClass->getParentClass()->getName();


### PR DESCRIPTION
See doctrine/DoctrineBundle#95

@beberlei it would be great to have it in the 2.3 branch at least, otherwise I will have to overwrite the method in the Symfony bridge to avoid a regression due to the change in the DoctrineType.
