### PR TITLE
Add from array functionality in ArrayCollection

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -47,7 +47,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function __construct(array $elements = array())
     {
-        $this->_elements = $elements;
+        $this->fromArray($elements);
     }
 
     /**
@@ -58,6 +58,18 @@ class ArrayCollection implements Collection, Selectable
     public function toArray()
     {
         return $this->_elements;
+    }
+
+    /**
+     * Reinitialize the ArrayCollection.
+     *
+     * @param array $values
+     * @return boolean Always TRUE.
+     */
+    public function fromArray(array $values = array())
+    {
+        $this->_elements = $values;
+        return true;
     }
 
     /**
@@ -337,6 +349,18 @@ class ArrayCollection implements Collection, Selectable
     public function add($value)
     {
         $this->_elements[] = $value;
+        return true;
+    }
+
+    /**
+     * Append an array of values to the collection.
+     *
+     * @param array $values Array to append
+     * @return boolean Always TRUE.
+     */
+    public function addArray(array $values)
+    {
+        $this->_elements = array_merge($this->_elements, array_values($values));
         return true;
     }
 

--- a/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
+++ b/tests/Doctrine/Tests/Common/Collections/CollectionTest.php
@@ -248,4 +248,27 @@ class CollectionTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertEquals(1, count($col));
         $this->assertEquals('baz', $col[0]->foo);
     }
+
+    public function testAddArray()
+    {
+        $this->_coll[] = 'foo';
+        $values = array('bar', 'baz');
+
+        $this->_coll->addArray($values);
+
+        $this->assertEquals(array('foo', 'bar', 'baz'), $this->_coll->getValues());
+    }
+
+    public function textFromArray()
+    {
+        $this->_coll[] = 'foo';
+        $this->_coll[] = 'bar';
+        $this->_coll[] = 'baz';
+
+        $newValues = array('one', 'two', 'three');
+
+        $this->_coll->fromArray($newValues);
+
+        $this->assertEquals(array('one', 'two', 'three'), $this->_coll->getValues());
+    }
 }


### PR DESCRIPTION
ArrayCollection seemed to be missing a bit of simple functionality - adding values in bulk/from an array!

So I have implemented two functions to do just that:

addArray - this function takes an array as a parameter and adds each element to the end of the collection

fromArray - this function takes an array as a parameter and reinitializes the collection (in the same way you can pass an array in __construct - infact: I have updated __construct to call this anyway...)

Tests have also been written for these new functions, which hopefully also give a good example of what functionality I felt was missing.

The only thing I am not sure of is the function names themselves, I think they're alright; however I have no idea if there are any naming standards, and thus no idea if they are acceptable.
