### PR TITLE
Ensure PEAR's @package_version@ is not evaluated when Doctrine parses an...

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationReader.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationReader.php
@@ -68,7 +68,8 @@ class AnnotationReader implements Reader
         'codeCoverageIgnore' => true, 'codeCoverageIgnoreStart' => true, 'codeCoverageIgnoreEnd' => true,
         'Required' => true, 'Attribute' => true, 'Attributes' => true,
         'Target' => true, 'SuppressWarnings' => true,
-        'ingroup' => true, 'code' => true, 'endcode' => true
+        'ingroup' => true, 'code' => true, 'endcode' => true,
+        'package_version' => true,
     );
 
     /**


### PR DESCRIPTION
...notations.

[I also added a trailing ',' to the array. Hope you don't mind.]
