### PR TITLE
Fix Criteria PHPDoc and add some strict checks

### DIFF
--- a/lib/Doctrine/Common/Collections/Criteria.php
+++ b/lib/Doctrine/Common/Collections/Criteria.php
@@ -51,14 +51,14 @@ class Criteria
     private $expression;
 
     /**
-     * @var array
+     * @var array|null
      */
-    private $orderings = array();
+    private $orderings;
 
     /**
-     * @var int
+     * @var int|null
      */
-    private $firstResult = 0;
+    private $firstResult;
 
     /**
      * @var int|null
@@ -169,7 +169,7 @@ class Criteria
     /**
      * Get current orderings of this Criteria
      *
-     * @return array
+     * @return array|null
      */
     public function getOrderings()
     {
@@ -206,7 +206,7 @@ class Criteria
     /**
      * Set number of first result that this criteria should return.
      *
-     * @param int $firstResult
+     * @param int $firstResult Result offset
      * @return Criteria
      */
     public function setFirstResult($firstResult)


### PR DESCRIPTION
Ordering now always an array (empty if no orderings). 
FirstResult is default '0' and always int.
MaxResults is int or null (for no limit).

It is easier for external code to use.
