### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.2"
     },
     "autoload": {
-        "psr-0": { "Doctrine\\Common": "lib/" }
+        "psr-0": { "Doctrine\\Common\\": "lib/" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made.
