### PR TITLE
Bad function call in Debug::toString()

### DIFF
--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -134,6 +134,6 @@ final class Debug
      */
     public static function toString($obj)
     {
-        return method_exists('__toString', $obj) ? (string) $obj : get_class($obj) . '@' . spl_object_hash($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_hash($obj);
     }
 }


### PR DESCRIPTION
Fixed an (obviously) over used function which were calling [method_exists](http://php.net/method_exists) function the wrong way.

In `Doctrine\Common\Util\Debug::toString($obj)`
From `method_exists('__toString',$obj)`
To  `method_exists($obj,'__toString')`
