### PR TITLE
Fixed a typo in PHPdoc

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -150,7 +150,6 @@ class ClassLoader
      * Loads the given class or interface.
      *
      * @param string $className The name of the class to load.
-
      * @return boolean TRUE if the class has been successfully loaded, FALSE otherwise.
      */
     public function loadClass($className)


### PR DESCRIPTION
A unnecessary new line was inserted in ClassLoader.php
