### PR TITLE
Allow AnnotationReader to be extended and stil cached

### DIFF
--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -266,4 +266,16 @@ class FileCacheReader implements Reader
     {
         $this->loadedAnnotations = array();
     }
+
+    /**
+     * Proxy all methods to the underlying reader.
+     *
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        return call_user_func_array(array($this->reader, $method), $args);
+    }
 }


### PR DESCRIPTION
Recently, I wanted to subclass AnnotationReader to add some convenience methods that would've been useful, but wouldn't have really affected what needed to be cached. However, when I went to extend AnnotationReader, I was unable to do so because, when it got wrapped in FileCacheReader, all the new methods I added were inaccessible. This PR would fix that by delegating those calls to the extended AnnotationReader.

(If it helps, I can provide an details about exactly what I was trying to add to AnnotationReader, but I won't bother if it's unnecessary.)
