### PR TITLE
MappingDriverChain::getAllClassNames should load all classes from the defaultDriver

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -139,6 +139,18 @@ class MappingDriverChain implements MappingDriver
             }
         }
 
+        if (null !== $this->defaultDriver) {
+            $oid = spl_object_hash($this->defaultDriver);
+
+            if (!isset($driverClasses[$oid])) {
+                $driverClasses[$oid] = $this->defaultDriver->getAllClassNames();
+            }
+
+            foreach ($driverClasses[$oid] as $className) {
+                $classNames[$className] = true;
+            }
+        }
+
         return array_keys($classNames);
     }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
@@ -65,13 +65,20 @@ class DriverChainTest extends DoctrineTestCase
                 ->method('getAllClassNames')
                 ->will($this->returnValue(array('Doctrine\Tests\ORM\Mapping\Bar', 'Doctrine\Tests\ORM\Mapping\Baz', 'FooBarBaz')));
 
+        $defaultDriver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $defaultDriver->expects($this->once())
+                ->method('getAllClassNames')
+                ->will($this->returnValue(array('Doctrine\Tests\Models\OtherCompany\FooBar')));
+
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\Company');
         $chain->addDriver($driver2, 'Doctrine\Tests\ORM\Mapping');
+        $chain->setDefaultDriver($defaultDriver);
 
         $this->assertEquals(array(
             'Doctrine\Tests\Models\Company\Foo',
             'Doctrine\Tests\ORM\Mapping\Bar',
-            'Doctrine\Tests\ORM\Mapping\Baz'
+            'Doctrine\Tests\ORM\Mapping\Baz',
+            'Doctrine\Tests\Models\OtherCompany\FooBar'
         ), $chain->getAllClassNames());
     }
 


### PR DESCRIPTION
I actually tried working around this by adding a driver using an empty string as the namespace, only to find out that `strpos()` doesn't accept an empty delimiter.

Anyway, this makes sure that all loadable classes for the defaultDriver are actually returned by MappingDriverChain as well.
