### PR TITLE
Cache interface fix

### DIFF
--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -42,6 +42,21 @@ interface Cache
     const STATS_MEMORY_AVAILIABLE   = 'memory_available';
 
     /**
+     * Set the namespace to prefix all cache ids with.
+     *
+     * @param string $namespace
+     * @return void
+     */
+    function setNamespace($namespace);
+
+    /**
+     * Retrieve the namespace that prefixes all cache ids.
+     *
+     * @return string
+     */
+    function getNamespace();
+
+    /**
      * Fetches an entry from the cache.
      *
      * @param string $id cache id The id of the cache entry to fetch.
@@ -74,6 +89,20 @@ interface Cache
      * @return boolean TRUE if the cache entry was successfully deleted, FALSE otherwise.
      */
     function delete($id);
+
+    /**
+     * Delete all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully deleted, FALSE otherwise.
+     */
+    function deleteAll();
+
+    /**
+     * Deletes all cache entries.
+     *
+     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     */
+    function flushAll();
 
     /**
      * Retrieves cached information from data store

--- a/lib/Doctrine/Common/Cache/CacheProvider.php
+++ b/lib/Doctrine/Common/Cache/CacheProvider.php
@@ -45,10 +45,7 @@ abstract class CacheProvider implements Cache
     private $namespaceVersion;
 
     /**
-     * Set the namespace to prefix all cache ids with.
-     *
-     * @param string $namespace
-     * @return void
+     * {@inheritdoc}
      */
     public function setNamespace($namespace)
     {
@@ -56,9 +53,7 @@ abstract class CacheProvider implements Cache
     }
 
     /**
-     * Retrieve the namespace that prefixes all cache ids.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getNamespace()
     {
@@ -106,9 +101,7 @@ abstract class CacheProvider implements Cache
     }
 
     /**
-     * Deletes all cache entries.
-     *
-     * @return boolean TRUE if the cache entries were successfully flushed, FALSE otherwise.
+     * {@inheritdoc}
      */
     public function flushAll()
     {
@@ -116,9 +109,7 @@ abstract class CacheProvider implements Cache
     }
 
     /**
-     * Delete all cache entries.
-     *
-     * @return boolean TRUE if the cache entries were successfully deleted, FALSE otherwise.
+     * {@inheritdoc}
      */
     public function deleteAll()
     {


### PR DESCRIPTION
The CacheProvider contained more public methods,
which were not defined in the Cache interface.
