### PR TITLE
BC breaking constant name fix

### DIFF
--- a/lib/Doctrine/Common/Cache/ApcCache.php
+++ b/lib/Doctrine/Common/Cache/ApcCache.php
@@ -87,7 +87,7 @@ class ApcCache extends CacheProvider
             Cache::STATS_MISSES            => $info['num_misses'],
             Cache::STATS_UPTIME            => $info['start_time'],
             Cache::STATS_MEMORY_USAGE      => $info['mem_size'],
-            Cache::STATS_MEMORY_AVAILIABLE => $sma['avail_mem'],
+            Cache::STATS_MEMORY_AVAILABLE => $sma['avail_mem'],
         );
     }
 }

--- a/lib/Doctrine/Common/Cache/Cache.php
+++ b/lib/Doctrine/Common/Cache/Cache.php
@@ -38,8 +38,8 @@ interface Cache
     const STATS_HITS    = 'hits';
     const STATS_MISSES  = 'misses';
     const STATS_UPTIME  = 'uptime';
-    const STATS_MEMORY_USAGE        = 'memory_usage';
-    const STATS_MEMORY_AVAILIABLE   = 'memory_available';
+    const STATS_MEMORY_USAGE = 'memory_usage';
+    const STATS_MEMORY_AVAILABLE = 'memory_available';
 
     /**
      * Fetches an entry from the cache.

--- a/lib/Doctrine/Common/Cache/MemcacheCache.php
+++ b/lib/Doctrine/Common/Cache/MemcacheCache.php
@@ -115,7 +115,7 @@ class MemcacheCache extends CacheProvider
             Cache::STATS_MISSES => $stats['get_misses'],
             Cache::STATS_UPTIME => $stats['uptime'],
             Cache::STATS_MEMORY_USAGE       => $stats['bytes'],
-            Cache::STATS_MEMORY_AVAILIABLE  => $stats['limit_maxbytes'],
+            Cache::STATS_MEMORY_AVAILABLE  => $stats['limit_maxbytes'],
         );
     }
 }

--- a/lib/Doctrine/Common/Cache/MemcachedCache.php
+++ b/lib/Doctrine/Common/Cache/MemcachedCache.php
@@ -118,7 +118,7 @@ class MemcachedCache extends CacheProvider
             Cache::STATS_MISSES => $stats['get_misses'],
             Cache::STATS_UPTIME => $stats['uptime'],
             Cache::STATS_MEMORY_USAGE       => $stats['bytes'],
-            Cache::STATS_MEMORY_AVAILIABLE  => $stats['limit_maxbytes'],
+            Cache::STATS_MEMORY_AVAILABLE  => $stats['limit_maxbytes'],
         );
     }
 }

--- a/lib/Doctrine/Common/Cache/RedisCache.php
+++ b/lib/Doctrine/Common/Cache/RedisCache.php
@@ -81,7 +81,7 @@ class RedisCache extends CacheProvider
     {
         $result = $this->redis->set($id, $data);
         if ($lifeTime > 0) {
-            $this->redis->expire($id, $lifeTime);        
+            $this->redis->expire($id, $lifeTime);
         }
         return $result;
     }
@@ -113,7 +113,7 @@ class RedisCache extends CacheProvider
             Cache::STATS_MISSES => false,
             Cache::STATS_UPTIME => $info['uptime_in_seconds'],
             Cache::STATS_MEMORY_USAGE       => $info['used_memory'],
-            Cache::STATS_MEMORY_AVAILIABLE  => false
+            Cache::STATS_MEMORY_AVAILABLE  => false
         );
     }
 }

--- a/lib/Doctrine/Common/Cache/WinCacheCache.php
+++ b/lib/Doctrine/Common/Cache/WinCacheCache.php
@@ -87,7 +87,7 @@ class WinCacheCache extends CacheProvider
             Cache::STATS_MISSES            => $info['total_miss_count'],
             Cache::STATS_UPTIME            => $info['total_cache_uptime'],
             Cache::STATS_MEMORY_USAGE      => $meminfo['memory_total'],
-            Cache::STATS_MEMORY_AVAILIABLE => $meminfo['memory_free'],
+            Cache::STATS_MEMORY_AVAILABLE => $meminfo['memory_free'],
         );
     }
 }

--- a/lib/Doctrine/Common/Cache/XcacheCache.php
+++ b/lib/Doctrine/Common/Cache/XcacheCache.php
@@ -104,7 +104,7 @@ class XcacheCache extends CacheProvider
             Cache::STATS_MISSES => $info['misses'],
             Cache::STATS_UPTIME => null,
             Cache::STATS_MEMORY_USAGE       => $info['size'],
-            Cache::STATS_MEMORY_AVAILIABLE  => $info['avail'],
+            Cache::STATS_MEMORY_AVAILABLE  => $info['avail'],
         );
     }
 }

--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -81,7 +81,7 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertArrayHasKey(Cache::STATS_MISSES, $stats);
         $this->assertArrayHasKey(Cache::STATS_UPTIME, $stats);
         $this->assertArrayHasKey(Cache::STATS_MEMORY_USAGE, $stats);
-        $this->assertArrayHasKey(Cache::STATS_MEMORY_AVAILIABLE, $stats);
+        $this->assertArrayHasKey(Cache::STATS_MEMORY_AVAILABLE, $stats);
     }
 
     /**


### PR DESCRIPTION
fixed typo on constant name (STATS_MEMORY_AVAILIABLE => STATS_MEMORY_AVAILABLE)
