### PR TITLE
make Base LifecycleEventArgs usable in orm and odm

### DIFF
--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -59,7 +59,7 @@ class LifecycleEventArgs extends EventArgs
      * Retrieve associated entity.
      * @deprecated
      *
-     * @return entity
+     * @return object
      */
     public function getEntity()
     {


### PR DESCRIPTION
Pull requests are to come for both orm and odm to make use of this.

The main goal is to make more abstract listeners, compatible with both orm and odm.
