### PR TITLE
Use preg_quote() to escape text before inserting into regexp

### DIFF
--- a/lib/Doctrine/Common/Annotations/PhpParser.php
+++ b/lib/Doctrine/Common/Annotations/PhpParser.php
@@ -51,7 +51,7 @@ final class PhpParser
             return array();
         }
 
-        $namespace = str_replace('\\', '\\\\', $class->getNamespaceName());
+        $namespace = preg_quote($class->getNamespaceName());
         $content = preg_replace('/^.*?(\bnamespace\s+' . $namespace . '\s*[;{].*)$/s', '\\1', $content);
         $tokenizer = new TokenParser('<?php ' . $content);
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -184,7 +184,7 @@ abstract class AnnotationDriver implements MappingDriver
                     new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 ),
-                '/^.+' . str_replace('.', '\.', $this->fileExtension) . '$/i',
+                '/^.+' . preg_quote($this->fileExtension) . '$/i',
                 \RecursiveRegexIterator::GET_MATCH
             );
 


### PR DESCRIPTION
PHP has build-in function `preg_quote()` in order to escape strings witch are dynamically inserted into regular expression.
