### PR TITLE
Replace file_exists() calls with is_file() where it is needed

### DIFF
--- a/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
+++ b/lib/Doctrine/Common/Annotations/AnnotationRegistry.php
@@ -120,7 +120,7 @@ final class AnnotationRegistry
                     }
                 } else {
                     foreach((array)$dirs AS $dir) {
-                        if (file_exists($dir . DIRECTORY_SEPARATOR . $file)) {
+                        if (is_file($dir . DIRECTORY_SEPARATOR . $file)) {
                             require $dir . DIRECTORY_SEPARATOR . $file;
                             return true;
                         }

--- a/lib/Doctrine/Common/Annotations/FileCacheReader.php
+++ b/lib/Doctrine/Common/Annotations/FileCacheReader.php
@@ -91,7 +91,7 @@ class FileCacheReader implements Reader
         }
 
         $path = $this->dir.'/'.strtr($key, '\\', '-').'.cache.php';
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
             $annot = $this->reader->getClassAnnotations($class);
             $this->saveCacheFile($path, $annot);
             return $this->loadedAnnotations[$key] = $annot;
@@ -129,7 +129,7 @@ class FileCacheReader implements Reader
         }
 
         $path = $this->dir.'/'.strtr($key, '\\', '-').'.cache.php';
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
             $annot = $this->reader->getPropertyAnnotations($property);
             $this->saveCacheFile($path, $annot);
             return $this->loadedAnnotations[$key] = $annot;
@@ -167,7 +167,7 @@ class FileCacheReader implements Reader
         }
 
         $path = $this->dir.'/'.strtr($key, '\\', '-').'.cache.php';
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
             $annot = $this->reader->getMethodAnnotations($method);
             $this->saveCacheFile($path, $annot);
             return $this->loadedAnnotations[$key] = $annot;

--- a/lib/Doctrine/Common/Annotations/PhpParser.php
+++ b/lib/Doctrine/Common/Annotations/PhpParser.php
@@ -46,7 +46,7 @@ final class PhpParser
         }
 
         $content = $this->getFileContent($filename, $class->getStartLine());
-        
+
         if (null === $content) {
             return array();
         }
@@ -69,7 +69,7 @@ final class PhpParser
      */
     private function getFileContent($filename, $lineNumber)
     {
-        if ( ! file_exists($filename)) {
+        if ( ! is_file($filename)) {
             return null;
         }
 

--- a/lib/Doctrine/Common/Cache/FilesystemCache.php
+++ b/lib/Doctrine/Common/Cache/FilesystemCache.php
@@ -44,7 +44,7 @@ class FilesystemCache extends FileCache
         $lifetime = -1;
         $filename = $this->getFilename($id);
 
-        if ( ! file_exists($filename)) {
+        if ( ! is_file($filename)) {
             return false;
         }
 
@@ -77,7 +77,7 @@ class FilesystemCache extends FileCache
         $lifetime = -1;
         $filename = $this->getFilename($id);
 
-        if ( ! file_exists($filename)) {
+        if ( ! is_file($filename)) {
             return false;
         }
 

--- a/lib/Doctrine/Common/Cache/PhpFileCache.php
+++ b/lib/Doctrine/Common/Cache/PhpFileCache.php
@@ -42,7 +42,7 @@ class PhpFileCache extends FileCache
     {
         $filename = $this->getFilename($id);
 
-        if ( ! file_exists($filename)) {
+        if ( ! is_file($filename)) {
             return false;
         }
 
@@ -62,7 +62,7 @@ class PhpFileCache extends FileCache
     {
         $filename = $this->getFilename($id);
 
-        if ( ! file_exists($filename)) {
+        if ( ! is_file($filename)) {
             return false;
         }
 

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -181,7 +181,7 @@ class ClassLoader
         $file = str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className) . $this->fileExtension;
 
         if ($this->includePath !== null) {
-            return file_exists($this->includePath . DIRECTORY_SEPARATOR . $file);
+            return is_file($this->includePath . DIRECTORY_SEPARATOR . $file);
         }
 
         return (false !== stream_resolve_include_path($file));

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -109,7 +109,7 @@ class DefaultFileLocator implements FileLocator
 
         // Check whether file exists
         foreach ($this->paths as $path) {
-            if (file_exists($path . DIRECTORY_SEPARATOR . $fileName)) {
+            if (is_file($path . DIRECTORY_SEPARATOR . $fileName)) {
                 return $path . DIRECTORY_SEPARATOR . $fileName;
             }
         }
@@ -160,7 +160,7 @@ class DefaultFileLocator implements FileLocator
 
         // Check whether file exists
         foreach ((array) $this->paths as $path) {
-            if (file_exists($path . DIRECTORY_SEPARATOR . $fileName)) {
+            if (is_file($path . DIRECTORY_SEPARATOR . $fileName)) {
                 return true;
             }
         }

--- a/lib/Doctrine/Common/Reflection/Psr0FindFile.php
+++ b/lib/Doctrine/Common/Reflection/Psr0FindFile.php
@@ -73,7 +73,7 @@ class Psr0FindFile implements ClassFinderInterface
         foreach ($this->prefixes as $prefix => $dirs) {
             if (0 === strpos($class, $prefix)) {
                 foreach ($dirs as $dir) {
-                    if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
+                    if (is_file($dir . DIRECTORY_SEPARATOR . $classPath)) {
                         return $dir . DIRECTORY_SEPARATOR . $classPath;
                     }
                 }

--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -11,14 +11,14 @@ spl_autoload_register(function($class)
 {
     if (0 === strpos($class, 'Doctrine\Tests\\')) {
         $path = __DIR__.'/../../'.strtr($class, '\\', '/').'.php';
-        if (file_exists($path) && is_readable($path)) {
+        if (is_file($path) && is_readable($path)) {
             require_once $path;
 
             return true;
         }
     } else if (0 === strpos($class, 'Doctrine\Common\\')) {
         $path = __DIR__.'/../../../lib/'.($class = strtr($class, '\\', '/')).'.php';
-        if (file_exists($path) && is_readable($path)) {
+        if (is_file($path) && is_readable($path)) {
             require_once $path;
 
             return true;

--- a/tests/NativePhpunitTask.php
+++ b/tests/NativePhpunitTask.php
@@ -124,7 +124,7 @@ class NativePhpunitTask extends Task
                 "failures (".$result->skippedCount()." skipped, ".$result->notImplementedCount()." not implemented)");
 
             // Hudson for example doesn't like the backslash in class names
-            if (file_exists($this->coverageClover)) {
+            if (is_file($this->coverageClover)) {
                 $this->log("Generated Clover Coverage XML to: ".$this->coverageClover);
                 $content = file_get_contents($this->coverageClover);
                 $content = str_replace("\\", ".", $content);


### PR DESCRIPTION
The function `file_exists()` checks whether file or directory exists. And `is_file()` checks only files for the existence. All places, where `file_exists()` is replaced with `is_file()` needs only to check for file existence.
