### PR TITLE
Criteria filtering doesn't work with DateTime instance

### DIFF
--- a/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
+++ b/lib/Doctrine/Common/Collections/Expr/ClosureExpressionVisitor.php
@@ -92,6 +92,10 @@ class ClosureExpressionVisitor extends ExpressionVisitor
 
         switch ($comparison->getOperator()) {
             case Comparison::EQ:
+                return function ($object) use ($field, $value) {
+                    return ClosureExpressionVisitor::getObjectFieldValue($object, $field) == $value;
+                };
+
             case Comparison::IS:
                 return function ($object) use ($field, $value) {
                     return ClosureExpressionVisitor::getObjectFieldValue($object, $field) === $value;


### PR DESCRIPTION
Filtering associations doesn't work with DateTime instance as a comparison value because filtering uses === operator. It works with SQL backed filtering, but not on PHP collection level.

``` php
$criteria = Criteria::create()
    ->where(Criteria::expr()->eq("birthday", new \DateTime("1982-02-17")))
    ->orderBy(array("username" => "ASC"))
    ->setFirstResult(0)
    ->setMaxResults(20)
;
```
