### PR TITLE
Improve performance of if key exists in the array

### DIFF
--- a/lib/Doctrine/Common/Collections/ArrayCollection.php
+++ b/lib/Doctrine/Common/Collections/ArrayCollection.php
@@ -120,7 +120,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function remove($key)
     {
-        if (array_key_exists($key, $this->_elements)) {
+        if (isset($this->_elements[$key]) || array_key_exists($key, $this->_elements)) {
             $removed = $this->_elements[$key];
             unset($this->_elements[$key]);
 
@@ -214,7 +214,7 @@ class ArrayCollection implements Collection, Selectable
      */
     public function containsKey($key)
     {
-        return array_key_exists($key, $this->_elements);
+        return isset($this->_elements[$key]) || array_key_exists($key, $this->_elements);
     }
 
     /**


### PR DESCRIPTION
So, here are few indications:
http://php.net/manual/en/function.array-key-exists.php#107786
http://php.net/manual/en/function.array-key-exists.php#104474
