### PR TITLE
Adding Support for Couchbase as Caching Infrastructure.

### DIFF
--- a/lib/Doctrine/Common/Cache/CouchbaseCache.php
+++ b/lib/Doctrine/Common/Cache/CouchbaseCache.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Cache;
+
+use \Couchbase;
+
+/**
+ * Couchbase cache provider.
+ *
+ * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link    www.doctrine-project.org
+ * @since   2.4
+ * @author  Michael Nitschinger <michael@nitschinger.at>
+ */
+class CouchbaseCache extends CacheProvider
+{
+
+    /**
+     * @var Couchbase
+     */
+    private $couchbase;
+
+    /**
+     * Sets the Couchbase instance to use.
+     *
+     * @param Couchbase $couchbase
+     */
+    public function setCouchbase(Couchbase $couchbase)
+    {
+        $this->couchbase = $couchbase;
+    }
+
+    /**
+     * Gets the Couchbase instance used by the cache.
+     *
+     * @return Couchbase
+     */
+    public function getCouchbase()
+    {
+        return $this->couchbase;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        return $this->couchbase->get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        return (null !== $this->couchbase->get($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = 0)
+    {
+        if ($lifeTime > 30 * 24 * 3600) {
+            $lifeTime = time() + $lifeTime;
+        }
+        return $this->couchbase->set($id, $data, (int) $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        return $this->couchbase->delete($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        return $this->couchbase->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        $stats   = $this->couchbase->getStats();
+        $servers = $this->couchbase->getServers();
+        $server  = explode(":", $servers[0]);
+        $key     = $server[0] . ":" . "11210";
+        $stats   = $stats[$key];
+        return array(
+            Cache::STATS_HITS   => $stats['get_hits'],
+            Cache::STATS_MISSES => $stats['get_misses'],
+            Cache::STATS_UPTIME => $stats['uptime'],
+            Cache::STATS_MEMORY_USAGE       => $stats['bytes'],
+            Cache::STATS_MEMORY_AVAILIABLE  => $stats['limit_maxbytes'],
+        );
+    }
+
+}

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\Tests\Common\Cache;
+
+use Couchbase;
+use Doctrine\Common\Cache\CouchbaseCache;
+
+class CouchbaseCacheTest extends CacheTest
+{
+    private $couchbase;
+
+    public function setUp()
+    {
+        if (extension_loaded('couchbase')) {
+            try {
+                $this->couchbase = new Couchbase('127.0.0.1', 'Administrator', 'password', 'default');
+            } catch(Exception $ex) {
+                 $this->markTestSkipped('Could not instantiate the Couchbase cache because of: ' . $ex);   
+            }
+        } else {
+            $this->markTestSkipped('The ' . __CLASS__ .' requires the use of the couchbase extension');
+        }
+    }
+
+    public function testNoExpire() 
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('noexpire', 'value', 0);
+        sleep(1);
+        $this->assertTrue($cache->contains('noexpire'), 'Couchbase provider should support no-expire');
+    }
+
+    public function testLongLifetime()
+    {
+        $cache = $this->_getCacheDriver();
+        $cache->save('key', 'value', 30 * 24 * 3600 + 1);
+
+        $this->assertTrue($cache->contains('key'), 'Couchbase provider should support TTL > 30 days');
+    }
+
+    protected function _getCacheDriver()
+    {
+        $driver = new CouchbaseCache();
+        $driver->setCouchbase($this->couchbase);
+        return $driver;
+    }
+}


### PR DESCRIPTION
This changeset brings in support for Couchbase Server 2.0 as
the caching layer. The interface is identical to the memcached
one, but using ext/couchbase allows to take advantage of the
automatic cluster discovery and failover functionality provided.
