### PR TITLE
[Cache/CouchbaseCache] Return false instead of null for compat.

### DIFF
--- a/tests/Doctrine/Tests/Common/Cache/CacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CacheTest.php
@@ -85,6 +85,18 @@ abstract class CacheTest extends \Doctrine\Tests\DoctrineTestCase
     }
 
     /**
+     * Make sure that all supported caches return "false" instead of "null" to be compatible
+     * with ORM integration.
+     */
+    public function testFalseOnFailedFetch()
+    {
+        $cache = $this->_getCacheDriver();
+        $result = $cache->fetch('nonexistent_key');
+        $this->assertFalse($result);
+        $this->assertNotNull($result);
+    }
+
+    /**
      * @return \Doctrine\Common\Cache\CacheProvider
      */
     abstract protected function _getCacheDriver();

--- a/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
+++ b/tests/Doctrine/Tests/Common/Cache/CouchbaseCacheTest.php
@@ -38,13 +38,6 @@ class CouchbaseCacheTest extends CacheTest
         $this->assertTrue($cache->contains('key'), 'Couchbase provider should support TTL > 30 days');
     }
 
-    public function testFalseOnFailedFetch() {
-        $cache = $this->_getCacheDriver();
-        $result = $cache->fetch('nonexistent_key');
-        $this->assertFalse($result);
-        $this->assertNotNull($result);
-    }
-
     protected function _getCacheDriver()
     {
         $driver = new CouchbaseCache();


### PR DESCRIPTION
This changeset fixes and verifies that instead of null, false is returned
from the fetch method. This fixes a bug which causes CouchbaseCache not
to work in combination with the ORM library. Test added.
