### PR TITLE
return parameter for debug method

### DIFF
--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -63,12 +63,14 @@ final class Debug
         ob_end_clean();
 
         $dumpText =  ($stripTags ? strip_tags(html_entity_decode($dump)) : $dump);
-        if($return){
-            ini_set('html_errors', 'Off');
+        ini_set('html_errors', 'Off');
+        
+        if ($return) {
+            
             return $dumpText;
         }
+        
         echo $dumpText;
-        ini_set('html_errors', 'Off');
     }
 
     /**


### PR DESCRIPTION
Added $return as 4th parameter to specify whether to return the debug text or print it. It works similar to print_r function
