### PR TITLE
Documentation fixes

### DIFF
--- a/bin/travis-setup.php
+++ b/bin/travis-setup.php
@@ -13,7 +13,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
+ * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
 

--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
            <lead user="guilhermeblanco" name="Guilherme Blanco" email="guilhermeblanco@gmail.com" />
            <lead user="romanb" name="Roman Borschel" email="roman@code-factory.org" />
            <lead user="beberlei" name="Benjamin Eberlei" email="kontakt@beberlei.de" />
-           <license>LGPL</license>
+           <license>MIT</license>
            <version release="${pear.version}" api="${pear.version}" />
            <stability release="${pear.stability}" api="${pear.stability}" />
            <notes>-</notes>

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -34,22 +34,30 @@ namespace Doctrine\Common;
 class ClassLoader
 {
     /**
-     * @var string PHP file extension
+     * PHP file extension.
+     *
+     * @var string
      */
     protected $fileExtension = '.php';
 
     /**
-     * @var string Current namespace
+     * Current namespace.
+     *
+     * @var string|null
      */
     protected $namespace;
 
     /**
-     * @var string Current include path
+     * Current include path.
+     *
+     * @var string|null
      */
     protected $includePath;
 
     /**
-     * @var string PHP namespace separator
+     * PHP namespace separator.
+     *
+     * @var string
      */
     protected $namespaceSeparator = '\\';
 
@@ -61,8 +69,8 @@ class ClassLoader
      * If neither a namespace nor an include path is given, the ClassLoader will
      * be responsible for loading all classes, thereby relying on the PHP include_path.
      *
-     * @param string $ns The namespace of the classes to load.
-     * @param string $includePath The base include path to use.
+     * @param string|null $ns          The namespace of the classes to load.
+     * @param string|null $includePath The base include path to use.
      */
     public function __construct($ns = null, $includePath = null)
     {
@@ -74,6 +82,8 @@ class ClassLoader
      * Sets the namespace separator used by classes in the namespace of this ClassLoader.
      *
      * @param string $sep The separator to use.
+     *
+     * @return void
      */
     public function setNamespaceSeparator($sep)
     {
@@ -93,7 +103,9 @@ class ClassLoader
     /**
      * Sets the base include path for all class files in the namespace of this ClassLoader.
      *
-     * @param string $includePath
+     * @param string|null $includePath
+     *
+     * @return void
      */
     public function setIncludePath($includePath)
     {
@@ -103,7 +115,7 @@ class ClassLoader
     /**
      * Gets the base include path for all class files in the namespace of this ClassLoader.
      *
-     * @return string
+     * @return string|null
      */
     public function getIncludePath()
     {
@@ -114,6 +126,8 @@ class ClassLoader
      * Sets the file extension of class files in the namespace of this ClassLoader.
      *
      * @param string $fileExtension
+     *
+     * @return void
      */
     public function setFileExtension($fileExtension)
     {
@@ -132,6 +146,8 @@ class ClassLoader
 
     /**
      * Registers this ClassLoader on the SPL autoload stack.
+     *
+     * @return void
      */
     public function register()
     {
@@ -140,6 +156,8 @@ class ClassLoader
 
     /**
      * Removes this ClassLoader from the SPL autoload stack.
+     *
+     * @return void
      */
     public function unregister()
     {
@@ -150,6 +168,7 @@ class ClassLoader
      * Loads the given class or interface.
      *
      * @param string $className The name of the class to load.
+     *
      * @return boolean TRUE if the class has been successfully loaded, FALSE otherwise.
      */
     public function loadClass($className)
@@ -170,6 +189,7 @@ class ClassLoader
      * the given name.
      *
      * @param string $className The fully-qualified name of the class.
+     *
      * @return boolean TRUE if this ClassLoader can load the class, FALSE otherwise.
      */
     public function canLoadClass($className)
@@ -206,6 +226,7 @@ class ClassLoader
      * these responsibilities.
      *
      * @param string $className The fully-qualified name of the class.
+     *
      * @return boolean TRUE if the class exists as per the definition given above, FALSE otherwise.
      */
     public static function classExists($className)
@@ -248,6 +269,7 @@ class ClassLoader
      * for (and is able to load) the class with the given name.
      *
      * @param string $className The name of the class.
+     *
      * @return ClassLoader The <tt>ClassLoader</tt> for the class or NULL if no such <tt>ClassLoader</tt> exists.
      */
     public static function getClassLoader($className)

--- a/lib/Doctrine/Common/CommonException.php
+++ b/lib/Doctrine/Common/CommonException.php
@@ -20,9 +20,10 @@
 namespace Doctrine\Common;
 
 /**
- * Base exception class for package Doctrine\Common
- * @author heinrich
+ * Base exception class for package Doctrine\Common.
  *
+ * @author heinrich
  */
-class CommonException extends \Exception {
+class CommonException extends \Exception
+{
 }

--- a/lib/Doctrine/Common/Comparable.php
+++ b/lib/Doctrine/Common/Comparable.php
@@ -17,22 +17,20 @@
  * <http://www.doctrine-project.org>.
  */
 
-
 namespace Doctrine\Common;
 
 /**
  * Comparable interface that allows to compare two value objects to each other for similarity.
  *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.com
- * @since       2.2
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
- * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  */
 interface Comparable
 {
     /**
-     * Compare the current object to the passed $other.
+     * Compares the current object to the passed $other.
      *
      * Returns 0 if they are semantically equal, 1 if the other object
      * is less than the current one, or -1 if its more than the current one.
@@ -46,4 +44,3 @@ interface Comparable
      */
     public function compareTo($other);
 }
-

--- a/lib/Doctrine/Common/EventArgs.php
+++ b/lib/Doctrine/Common/EventArgs.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28,18 +26,18 @@ namespace Doctrine\Common;
  * information to an event handler when an event is raised. The single empty EventArgs
  * instance can be obtained through {@link getEmptyInstance}.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision: 3938 $
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 class EventArgs
 {
     /**
-     * @var EventArgs Single instance of EventArgs
+     * Single instance of EventArgs.
+     *
+     * @var EventArgs
      */
     private static $_emptyEventArgsInstance;
 
@@ -50,10 +48,12 @@ class EventArgs
      * like this: EventManager::dispatchEvent('eventname');
      *
      * The benefit from this is that only one empty instance is instantiated and shared
-     * (otherwise there would be instances for every dispatched in the abovementioned form)
+     * (otherwise there would be instances for every dispatched in the abovementioned form).
      *
      * @see EventManager::dispatchEvent
+     *
      * @link http://msdn.microsoft.com/en-us/library/system.eventargs.aspx
+     *
      * @return EventArgs
      */
     public static function getEmptyInstance()

--- a/lib/Doctrine/Common/EventManager.php
+++ b/lib/Doctrine/Common/EventManager.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -26,13 +24,11 @@ namespace Doctrine\Common;
  * Listeners are registered on the manager and events are dispatched through the
  * manager.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision: 3938 $
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 class EventManager
 {
@@ -47,10 +43,11 @@ class EventManager
     /**
      * Dispatches an event to all registered listeners.
      *
-     * @param string $eventName The name of the event to dispatch. The name of the event is
-     *                          the name of the method that is invoked on listeners.
-     * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
-     *                             If not supplied, the single empty EventArgs instance is used.
+     * @param string    $eventName      The name of the event to dispatch. The name of the event is
+     *                                  the name of the method that is invoked on listeners.
+     * @param EventArgs|null $eventArgs The event arguments to pass to the event handlers/listeners.
+     *                                  If not supplied, the single empty EventArgs instance is used.
+     *
      * @return boolean
      */
     public function dispatchEvent($eventName, EventArgs $eventArgs = null)
@@ -67,7 +64,8 @@ class EventManager
     /**
      * Gets the listeners of a specific event or all listeners.
      *
-     * @param string $event The name of the event.
+     * @param string|null $event The name of the event.
+     *
      * @return array The event listeners for the specified event, or all event listeners.
      */
     public function getListeners($event = null)
@@ -79,6 +77,7 @@ class EventManager
      * Checks whether an event has any registered listeners.
      *
      * @param string $event
+     *
      * @return boolean TRUE if the specified event has any listeners, FALSE otherwise.
      */
     public function hasListeners($event)
@@ -89,8 +88,10 @@ class EventManager
     /**
      * Adds an event listener that listens on the specified events.
      *
-     * @param string|array $events The event(s) to listen on.
-     * @param object $listener The listener object.
+     * @param string|array $events   The event(s) to listen on.
+     * @param object       $listener The listener object.
+     *
+     * @return void
      */
     public function addEventListener($events, $listener)
     {
@@ -108,7 +109,9 @@ class EventManager
      * Removes an event listener from the specified events.
      *
      * @param string|array $events
-     * @param object $listener
+     * @param object       $listener
+     *
+     * @return void
      */
     public function removeEventListener($events, $listener)
     {
@@ -128,6 +131,8 @@ class EventManager
      * interested in and added as a listener for these events.
      *
      * @param \Doctrine\Common\EventSubscriber $subscriber The subscriber.
+     *
+     * @return void
      */
     public function addEventSubscriber(EventSubscriber $subscriber)
     {
@@ -139,6 +144,8 @@ class EventManager
      * interested in and removed as a listener for these events.
      *
      * @param \Doctrine\Common\EventSubscriber $subscriber The subscriber.
+     *
+     * @return void
      */
     public function removeEventSubscriber(EventSubscriber $subscriber)
     {

--- a/lib/Doctrine/Common/EventSubscriber.php
+++ b/lib/Doctrine/Common/EventSubscriber.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id: EventListener.php 4653 2008-07-10 17:17:58Z romanb $
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -27,12 +25,11 @@ namespace Doctrine\Common;
  * {@link getSubscribedEvents} and registers the subscriber as a listener for all
  * returned events.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 interface EventSubscriber
 {

--- a/lib/Doctrine/Common/Lexer.php
+++ b/lib/Doctrine/Common/Lexer.php
@@ -27,10 +27,10 @@ use Doctrine\Common\Lexer\AbstractLexer;
  * Lexer moved into its own Component Doctrine\Common\Lexer. This class
  * only stays for being BC.
  *
- * @since   2.0
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 abstract class Lexer extends AbstractLexer
 {

--- a/lib/Doctrine/Common/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Common/NotifyPropertyChanged.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -25,13 +23,11 @@ namespace Doctrine\Common;
  * Contract for classes that provide the service of notifying listeners of
  * changes to their properties.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision: 3938 $
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 interface NotifyPropertyChanged
 {
@@ -39,6 +35,8 @@ interface NotifyPropertyChanged
      * Adds a listener that wants to be notified about property changes.
      *
      * @param PropertyChangedListener $listener
+     *
+     * @return void
      */
     public function addPropertyChangedListener(PropertyChangedListener $listener);
 }

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -25,12 +24,11 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 /**
  * Abstract implementation of the ManagerRegistry contract.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.2
- * @author  Fabien Potencier <fabien@symfony.com>
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 abstract class AbstractManagerRegistry implements ManagerRegistry
 {
@@ -65,11 +63,11 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     private $proxyInterfaceName;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param string $name
-     * @param array $connections
-     * @param array $managers
+     * @param array  $connections
+     * @param array  $managers
      * @param string $defaultConnection
      * @param string $defaultManager
      * @param string $proxyInterfaceName
@@ -85,27 +83,29 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     }
 
     /**
-     * Fetches/creates the given services
+     * Fetches/creates the given services.
      *
-     * A service in this context is connection or a manager instance
+     * A service in this context is connection or a manager instance.
      *
-     * @param string $name name of the service
-     * @return object instance of the given service
+     * @param string $name The name of the service.
+     *
+     * @return object The instance of the given service.
      */
     abstract protected function getService($name);
 
     /**
-     * Resets the given services
+     * Resets the given services.
      *
-     * A service in this context is connection or a manager instance
+     * A service in this context is connection or a manager instance.
      *
-     * @param string $name name of the service
+     * @param string $name The name of the service.
+     *
      * @return void
      */
     abstract protected function resetService($name);
 
     /**
-     * Get the name of the registry
+     * Gets the name of the registry.
      *
      * @return string
      */

--- a/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
@@ -22,42 +22,41 @@ namespace Doctrine\Common\Persistence;
 /**
  * Contract covering connection for a Doctrine persistence layer ManagerRegistry class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.2
- * @author  Fabien Potencier <fabien@symfony.com>
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 interface ConnectionRegistry
 {
     /**
      * Gets the default connection name.
      *
-     * @return string The default connection name
+     * @return string The default connection name.
      */
     public function getDefaultConnectionName();
 
     /**
      * Gets the named connection.
      *
-     * @param string $name The connection name (null for the default one)
+     * @param string $name The connection name (null for the default one).
      *
      * @return object
      */
     public function getConnection($name = null);
 
     /**
-     * Gets an array of all registered connections
+     * Gets an array of all registered connections.
      *
-     * @return array An array of Connection instances
+     * @return array An array of Connection instances.
      */
     public function getConnections();
 
     /**
      * Gets all connection names.
      *
-     * @return array An array of connection names
+     * @return array An array of connection names.
      */
     public function getConnectionNames();
 }

--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -15,7 +15,7 @@
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
-*/
+ */
 
 namespace Doctrine\Common\Persistence\Event;
 
@@ -44,9 +44,9 @@ class LifecycleEventArgs extends EventArgs
     private $object;
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param object $object
+     * @param object        $object
      * @param ObjectManager $objectManager
      */
     public function __construct($object, ObjectManager $objectManager)
@@ -56,7 +56,8 @@ class LifecycleEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve associated entity.
+     * Retrieves the associated entity.
+     *
      * @deprecated
      *
      * @return object
@@ -67,7 +68,7 @@ class LifecycleEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve associated object.
+     * Retrieves the associated object.
      *
      * @return object
      */
@@ -77,7 +78,7 @@ class LifecycleEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve associated ObjectManager.
+     * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
      */

--- a/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -54,7 +54,7 @@ class LoadClassMetadataEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve associated ClassMetadata.
+     * Retrieves the associated ClassMetadata.
      *
      * @return ClassMetadata
      */
@@ -64,7 +64,7 @@ class LoadClassMetadataEventArgs extends EventArgs
     }
 
     /**
-     * Retrieve associated ObjectManager.
+     * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
      */
@@ -73,4 +73,3 @@ class LoadClassMetadataEventArgs extends EventArgs
         return $this->objectManager;
     }
 }
-

--- a/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
@@ -15,22 +15,22 @@
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
-*/
+ */
 
 namespace Doctrine\Common\Persistence\Event;
 
+use Doctrine\Common\EventArgs;
 use Doctrine\Common\Persistence\ObjectManager;
 
 /**
  * Provides event arguments for the preFlush event.
  *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.2
- * @author      Roman Borschel <roman@code-factory.de>
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Roman Borschel <roman@code-factory.de>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class ManagerEventArgs extends \Doctrine\Common\EventArgs
+class ManagerEventArgs extends EventArgs
 {
     /**
      * @var ObjectManager
@@ -48,7 +48,7 @@ class ManagerEventArgs extends \Doctrine\Common\EventArgs
     }
 
     /**
-     * Retrieve associated ObjectManager.
+     * Retrieves the associated ObjectManager.
      *
      * @return ObjectManager
      */

--- a/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
@@ -19,16 +19,18 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+
 /**
  * Provides event arguments for the onClear event.
  *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.2
- * @author      Roman Borschel <roman@code-factory.de>
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Roman Borschel <roman@code-factory.de>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class OnClearEventArgs extends \Doctrine\Common\EventArgs
+class OnClearEventArgs extends EventArgs
 {
     /**
      * @var \Doctrine\Common\Persistence\ObjectManager
@@ -36,15 +38,15 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     private $objectManager;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $entityClass;
 
     /**
      * Constructor.
      *
-     * @param \Doctrine\Common\Persistence\ObjectManager $objectManager
-     * @param string $entityClass Optional entity class
+     * @param ObjectManager $objectManager The object manager.
+     * @param string|null   $entityClass   The optional entity class.
      */
     public function __construct($objectManager, $entityClass = null)
     {
@@ -53,7 +55,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     }
 
     /**
-     * Retrieve associated ObjectManager.
+     * Retrieves the associated ObjectManager.
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
@@ -63,9 +65,9 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     }
 
     /**
-     * Name of the entity class that is cleared, or empty if all are cleared.
+     * Returns the name of the entity class that is cleared, or null if all are cleared.
      *
-     * @return string
+     * @return string|null
      */
     public function getEntityClass()
     {
@@ -73,7 +75,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     }
 
     /**
-     * Check if event clears all entities.
+     * Returns whether this event clears all entities.
      *
      * @return bool
      */

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -19,8 +19,8 @@
 
 namespace Doctrine\Common\Persistence\Event;
 
-use Doctrine\Common\EventArgs,
-    Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
 
 /**
  * Class that holds event arguments for a preUpdate event.
@@ -40,9 +40,9 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     /**
      * Constructor.
      *
-     * @param object $entity
+     * @param object        $entity
      * @param ObjectManager $objectManager
-     * @param array $changeSet
+     * @param array         $changeSet
      */
     public function __construct($entity, ObjectManager $objectManager, array &$changeSet)
     {
@@ -52,7 +52,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Retrieve entity changeset.
+     * Retrieves the entity changeset.
      *
      * @return array
      */
@@ -62,7 +62,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Check if field has a changeset.
+     * Checks if field has a changeset.
      *
      * @param string $field
      *
@@ -74,9 +74,10 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Get the old value of the changeset of the changed field.
+     * Gets the old value of the changeset of the changed field.
      *
-     * @param  string $field
+     * @param string $field
+     *
      * @return mixed
      */
     public function getOldValue($field)
@@ -87,9 +88,10 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Get the new value of the changeset of the changed field.
+     * Gets the new value of the changeset of the changed field.
      *
-     * @param  string $field
+     * @param string $field
+     *
      * @return mixed
      */
     public function getNewValue($field)
@@ -100,10 +102,12 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Set the new value of this field.
+     * Sets the new value of this field.
      *
      * @param string $field
-     * @param mixed $value
+     * @param mixed  $value
+     *
+     * @return void
      */
     public function setNewValue($field, $value)
     {
@@ -113,9 +117,11 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
-     * Assert the field exists in changeset.
+     * Asserts the field exists in changeset.
      *
      * @param string $field
+     *
+     * @return void
      *
      * @throws \InvalidArgumentException
      */
@@ -130,4 +136,3 @@ class PreUpdateEventArgs extends LifecycleEventArgs
         }
     }
 }
-

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -22,33 +22,32 @@ namespace Doctrine\Common\Persistence;
 /**
  * Contract covering object managers for a Doctrine persistence layer ManagerRegistry class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.2
- * @author  Fabien Potencier <fabien@symfony.com>
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 interface ManagerRegistry extends ConnectionRegistry
 {
     /**
      * Gets the default object manager name.
      *
-     * @return string The default object manager name
+     * @return string The default object manager name.
      */
     public function getDefaultManagerName();
 
     /**
      * Gets a named object manager.
      *
-     * @param string $name The object manager name (null for the default one)
+     * @param string $name The object manager name (null for the default one).
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
     public function getManager($name = null);
 
     /**
-     * Gets an array of all registered object managers
+     * Gets an array of all registered object managers.
      *
      * @return \Doctrine\Common\Persistence\ObjectManager[] An array of ObjectManager instances
      */
@@ -67,7 +66,7 @@ interface ManagerRegistry extends ConnectionRegistry
      * hold an obsolete reference. You can inject the registry instead
      * to avoid this problem.
      *
-     * @param string $name The object manager name (null for the default one)
+     * @param string|null $name The object manager name (null for the default one).
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
@@ -78,24 +77,24 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * This method looks for the alias in all registered object managers.
      *
-     * @param string $alias The alias
+     * @param string $alias The alias.
      *
-     * @return string The full namespace
+     * @return string The full namespace.
      */
     public function getAliasNamespace($alias);
 
     /**
      * Gets all connection names.
      *
-     * @return array An array of connection names
+     * @return array An array of connection names.
      */
     public function getManagerNames();
 
     /**
      * Gets the ObjectRepository for an persistent object.
      *
-     * @param string $persistentObject        The name of the persistent object.
-     * @param string $persistentManagerName The object manager name (null for the default one)
+     * @param string $persistentObject      The name of the persistent object.
+     * @param string $persistentManagerName The object manager name (null for the default one).
      *
      * @return \Doctrine\Common\Persistence\ObjectRepository
      */
@@ -104,7 +103,7 @@ interface ManagerRegistry extends ConnectionRegistry
     /**
      * Gets the object manager associated with a given class.
      *
-     * @param string $class A persistent object class name
+     * @param string $class A persistent object class name.
      *
      * @return \Doctrine\Common\Persistence\ObjectManager|null
      */

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -19,21 +19,21 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use Doctrine\Common\Cache\Cache,
-    Doctrine\Common\Util\ClassUtils;
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
  * metadata mapping informations of a class which describes how a class should be mapped
  * to a relational database.
  *
- * This class was abstracted from the ORM ClassMetadataFactory
+ * This class was abstracted from the ORM ClassMetadataFactory.
  *
- * @since   2.2
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @since  2.2
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 {
@@ -42,10 +42,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @var string
      */
-    protected $cacheSalt = "\$CLASSMETADATA";
+    protected $cacheSalt = '$CLASSMETADATA';
 
     /**
-     * @var \Doctrine\Common\Cache\Cache
+     * @var \Doctrine\Common\Cache\Cache|null
      */
     private $cacheDriver;
 
@@ -60,14 +60,16 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     protected $initialized = false;
 
     /**
-     * @var ReflectionService
+     * @var ReflectionService|null
      */
-    private $reflectionService;
+    private $reflectionService = null;
 
     /**
      * Sets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @param Doctrine\Common\Cache\Cache $cacheDriver
+     * @param \Doctrine\Common\Cache\Cache $cacheDriver
+     *
+     * @return void
      */
     public function setCacheDriver(Cache $cacheDriver = null)
     {
@@ -77,7 +79,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Gets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @return Doctrine\Common\Cache\Cache
+     * @return \Doctrine\Common\Cache\Cache|null
      */
     public function getCacheDriver()
     {
@@ -85,7 +87,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * Return an array of all the loaded metadata currently in memory.
+     * Returns an array of all the loaded metadata currently in memory.
      *
      * @return array
      */
@@ -124,35 +126,38 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     abstract protected function initialize();
 
     /**
-     * Get the fully qualified class-name from the namespace alias.
+     * Gets the fully qualified class-name from the namespace alias.
      *
      * @param string $namespaceAlias
      * @param string $simpleClassName
+     *
      * @return string
      */
     abstract protected function getFqcnFromAlias($namespaceAlias, $simpleClassName);
 
     /**
-     * Return the mapping driver implementation.
+     * Returns the mapping driver implementation.
      *
      * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
      */
     abstract protected function getDriver();
 
     /**
-     * Wakeup reflection after ClassMetadata gets unserialized from cache.
+     * Wakes up reflection after ClassMetadata gets unserialized from cache.
      *
-     * @param ClassMetadata $class
+     * @param ClassMetadata     $class
      * @param ReflectionService $reflService
+     *
      * @return void
      */
     abstract protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService);
 
     /**
-     * Initialize Reflection after ClassMetadata was constructed.
+     * Initializes Reflection after ClassMetadata was constructed.
      *
-     * @param ClassMetadata $class
+     * @param ClassMetadata     $class
      * @param ReflectionService $reflService
+     *
      * @return void
      */
     abstract protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService);
@@ -160,10 +165,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Checks whether the class metadata is an entity.
      *
-     * This method should false for mapped superclasses or
-     * embedded classes.
+     * This method should return false for mapped superclasses or embedded classes.
      *
      * @param ClassMetadata $class
+     *
      * @return boolean
      */
     abstract protected function isEntity(ClassMetadata $class);
@@ -172,6 +177,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
+     *
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
      */
     public function getMetadataFor($className)
@@ -224,6 +230,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Checks whether the factory has the metadata for a class loaded already.
      *
      * @param string $className
+     *
      * @return boolean TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
     public function hasMetadataFor($className)
@@ -236,8 +243,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * NOTE: This is only useful in very special cases, like when generating proxy classes.
      *
-     * @param string $className
+     * @param string        $className
      * @param ClassMetadata $class
+     *
+     * @return void
      */
     public function setMetadataFor($className, $class)
     {
@@ -245,10 +254,11 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * Get array of parent classes for the given entity class
+     * Gets an array of parent classes for the given entity class.
      *
      * @param string $name
-     * @return array $parentClasses
+     *
+     * @return array
      */
     protected function getParentClasses($name)
     {
@@ -325,12 +335,14 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * Actually load the metadata from the underlying metadata
+     * Actually loads the metadata from the underlying metadata.
      *
-     * @param ClassMetadata $class
+     * @param ClassMetadata      $class
      * @param ClassMetadata|null $parent
-     * @param bool $rootEntityFound
-     * @param array $nonSuperclassParents classnames all parent classes that are not marked as mapped superclasses
+     * @param bool               $rootEntityFound
+     * @param array              $nonSuperclassParents All parent class names
+     *                                                 that are not marked as mapped superclasses.
+     *
      * @return void
      */
     abstract protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents);
@@ -339,15 +351,13 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * Creates a new ClassMetadata instance for the given class name.
      *
      * @param string $className
+     *
      * @return ClassMetadata
      */
     abstract protected function newClassMetadataInstance($className);
 
     /**
-     * Check if this class is mapped by this Object Manager + ClassMetadata configuration
-     *
-     * @param $class
-     * @return bool
+     * {@inheritDoc}
      */
     public function isTransient($class)
     {
@@ -365,9 +375,11 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * Set reflectionService.
+     * Sets the reflectionService.
      *
      * @param ReflectionService $reflectionService
+     *
+     * @return void
      */
     public function setReflectionService(ReflectionService $reflectionService)
     {
@@ -375,7 +387,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
-     * Get the reflection service associated with this metadata factory.
+     * Gets the reflection service associated with this metadata factory.
      *
      * @return ReflectionService
      */

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -22,16 +22,15 @@ namespace Doctrine\Common\Persistence\Mapping;
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.1
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Jonathan Wage <jonwage@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.1
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Jonathan Wage <jonwage@gmail.com>
  */
 interface ClassMetadata
 {
     /**
-     * Get fully-qualified class name of this persistent class.
+     * Gets the fully-qualified class name of this persistent class.
      *
      * @return string
      */
@@ -57,6 +56,7 @@ interface ClassMetadata
      * Checks if the given field name is a mapped identifier for this class.
      *
      * @param string $fieldName
+     *
      * @return boolean
      */
     public function isIdentifier($fieldName);
@@ -65,6 +65,7 @@ interface ClassMetadata
      * Checks if the given field is a mapped property for this class.
      *
      * @param string $fieldName
+     *
      * @return boolean
      */
     public function hasField($fieldName);
@@ -73,6 +74,7 @@ interface ClassMetadata
      * Checks if the given field is a mapped association for this class.
      *
      * @param string $fieldName
+     *
      * @return boolean
      */
     public function hasAssociation($fieldName);
@@ -81,6 +83,7 @@ interface ClassMetadata
      * Checks if the given field is a mapped single valued association for this class.
      *
      * @param string $fieldName
+     *
      * @return boolean
      */
     public function isSingleValuedAssociation($fieldName);
@@ -89,6 +92,7 @@ interface ClassMetadata
      * Checks if the given field is a mapped collection valued association for this class.
      *
      * @param string $fieldName
+     *
      * @return boolean
      */
     public function isCollectionValuedAssociation($fieldName);
@@ -110,7 +114,7 @@ interface ClassMetadata
     public function getIdentifierFieldNames();
 
     /**
-     * A numerically indexed list of association names of this persistent class.
+     * Returns a numerically indexed list of association names of this persistent class.
      *
      * This array includes identifier associations if present on this class.
      *
@@ -125,6 +129,7 @@ interface ClassMetadata
      * integer, string, boolean, float/double, datetime.
      *
      * @param string $fieldName
+     *
      * @return string
      */
     public function getTypeOfField($fieldName);
@@ -133,32 +138,36 @@ interface ClassMetadata
      * Returns the target class name of the given association.
      *
      * @param string $assocName
+     *
      * @return string
      */
     public function getAssociationTargetClass($assocName);
 
     /**
-     * Checks if the association is the inverse side of a bidirectional association
+     * Checks if the association is the inverse side of a bidirectional association.
      *
      * @param string $assocName
+     *
      * @return boolean
      */
     public function isAssociationInverseSide($assocName);
 
     /**
-     * Returns the target field of the owning side of the association
+     * Returns the target field of the owning side of the association.
      *
      * @param string $assocName
+     *
      * @return string
      */
     public function getAssociationMappedByTargetField($assocName);
 
     /**
-     * Return the identifier of this object as an array with field name as key.
+     * Returns the identifier of this object as an array with field name as key.
      *
      * Has to return an empty array if no identifier isset.
      *
      * @param object $object
+     *
      * @return array
      */
     public function getIdentifierValues($object);

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -22,11 +22,10 @@ namespace Doctrine\Common\Persistence\Mapping;
 /**
  * Contract for a Doctrine persistence layer ClassMetadata class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.1
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Jonathan Wage <jonwage@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.1
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Jonathan Wage <jonwage@gmail.com>
  */
 interface ClassMetadataFactory
 {
@@ -42,6 +41,7 @@ interface ClassMetadataFactory
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
+     *
      * @return ClassMetadata
      */
     public function getMetadataFor($className);
@@ -50,6 +50,7 @@ interface ClassMetadataFactory
      * Checks whether the factory has the metadata for a class loaded already.
      *
      * @param string $className
+     *
      * @return boolean TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
     public function hasMetadataFor($className);
@@ -58,16 +59,17 @@ interface ClassMetadataFactory
      * Sets the metadata descriptor for a specific class.
      *
      * @param string $className
+     *
      * @param ClassMetadata $class
      */
     public function setMetadataFor($className, $class);
 
     /**
-     * Whether the class with the specified name should have its metadata loaded.
-     * This is only the case if it is either mapped directly or as a
-     * MappedSuperclass.
+     * Returns whether the class with the specified name should have its metadata loaded.
+     * This is only the case if it is either mapped directly or as a MappedSuperclass.
      *
      * @param string $className
+     *
      * @return boolean
      */
     public function isTransient($className);

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -19,15 +19,14 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use Doctrine\Common\Cache\ArrayCache,
-    Doctrine\Common\Annotations\AnnotationReader,
-    Doctrine\Common\Annotations\AnnotationRegistry,
-    Doctrine\Common\Persistence\Mapping\MappingException;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.
  *
- * @since 2.2
+ * @since  2.2
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Jonathan H. Wage <jonwage@gmail.com>
@@ -57,14 +56,14 @@ abstract class AnnotationDriver implements MappingDriver
     protected $fileExtension = '.php';
 
     /**
-     * Cache for AnnotationDriver#getAllClassNames()
+     * Cache for AnnotationDriver#getAllClassNames().
      *
-     * @var array
+     * @var array|null
      */
     protected $classNames;
 
     /**
-     * Name of the entity annotations as keys
+     * Name of the entity annotations as keys.
      *
      * @var array
      */
@@ -74,8 +73,8 @@ abstract class AnnotationDriver implements MappingDriver
      * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
      * docblock annotations.
      *
-     * @param AnnotationReader $reader The AnnotationReader to use, duck-typed.
-     * @param string|array $paths One or multiple paths where mapping classes can be found.
+     * @param AnnotationReader  $reader The AnnotationReader to use, duck-typed.
+     * @param string|array|null $paths  One or multiple paths where mapping classes can be found.
      */
     public function __construct($reader, $paths = null)
     {
@@ -86,9 +85,11 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Append lookup paths to metadata driver.
+     * Appends lookup paths to metadata driver.
      *
      * @param array $paths
+     *
+     * @return void
      */
     public function addPaths(array $paths)
     {
@@ -96,7 +97,7 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Retrieve the defined metadata lookup paths.
+     * Retrieves the defined metadata lookup paths.
      *
      * @return array
      */
@@ -106,7 +107,7 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Retrieve the current annotation reader
+     * Retrieves the current annotation reader.
      *
      * @return AnnotationReader
      */
@@ -116,7 +117,7 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Get the file extension used to look for mapping files under
+     * Gets the file extension used to look for mapping files under.
      *
      * @return string
      */
@@ -126,9 +127,10 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Set the file extension used to look for mapping files under
+     * Sets the file extension used to look for mapping files under.
      *
-     * @param string $fileExtension The file extension to set
+     * @param string $fileExtension The file extension to set.
+     *
      * @return void
      */
     public function setFileExtension($fileExtension)
@@ -137,13 +139,14 @@ abstract class AnnotationDriver implements MappingDriver
     }
 
     /**
-     * Whether the class with the specified name is transient. Only non-transient
+     * Returns whether the class with the specified name is transient. Only non-transient
      * classes, that is entities and mapped superclasses, should have their metadata loaded.
      *
      * A class is non-transient if it is annotated with an annotation
      * from the {@see AnnotationDriver::entityAnnotationClasses}.
      *
      * @param string $className
+     *
      * @return boolean
      */
     public function isTransient($className)

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -15,14 +15,14 @@
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
-*/
+ */
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
- * Locate the file that contains the metadata information for a given class name.
+ * Locates the file that contains the metadata information for a given class name.
  *
  * This behavior is independent of the actual content of the file. It just detects
  * the file which is responsible for the given class name.
@@ -42,7 +42,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * The file extension of mapping documents.
      *
-     * @var string
+     * @var string|null
      */
     protected $fileExtension;
 
@@ -50,8 +50,8 @@ class DefaultFileLocator implements FileLocator
      * Initializes a new FileDriver that looks in the given path(s) for mapping
      * documents and operates in the specified operating mode.
      *
-     * @param string|array $paths One or multiple paths where mapping documents can be found.
-     * @param string|null $fileExtension
+     * @param string|array $paths         One or multiple paths where mapping documents can be found.
+     * @param string|null  $fileExtension The file extension of mapping documents.
      */
     public function __construct($paths, $fileExtension = null)
     {
@@ -60,9 +60,11 @@ class DefaultFileLocator implements FileLocator
     }
 
     /**
-     * Append lookup paths to metadata driver.
+     * Appends lookup paths to metadata driver.
      *
      * @param array $paths
+     *
+     * @return void
      */
     public function addPaths(array $paths)
     {
@@ -70,7 +72,7 @@ class DefaultFileLocator implements FileLocator
     }
 
     /**
-     * Retrieve the defined metadata lookup paths.
+     * Retrieves the defined metadata lookup paths.
      *
      * @return array
      */
@@ -80,9 +82,9 @@ class DefaultFileLocator implements FileLocator
     }
 
     /**
-     * Get the file extension used to look for mapping files under
+     * Gets the file extension used to look for mapping files under.
      *
-     * @return string
+     * @return string|null
      */
     public function getFileExtension()
     {
@@ -90,9 +92,10 @@ class DefaultFileLocator implements FileLocator
     }
 
     /**
-     * Set the file extension used to look for mapping files under
+     * Sets the file extension used to look for mapping files under.
      *
-     * @param string $fileExtension The file extension to set
+     * @param string|null $fileExtension The file extension to set.
+     *
      * @return void
      */
     public function setFileExtension($fileExtension)

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -29,13 +29,12 @@ use Doctrine\Common\Persistence\Mapping\MappingException;
  * file per class and the file names of the mapping files must correspond to the full
  * class name, including namespace, with the namespace delimiters '\', replaced by dots '.'.
  *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.com
- * @since       2.2
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
- * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author      Jonathan H. Wage <jonwage@gmail.com>
- * @author      Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 abstract class FileDriver implements MappingDriver
 {
@@ -45,12 +44,12 @@ abstract class FileDriver implements MappingDriver
     protected $locator;
 
     /**
-     * @var array
+     * @var array|null
      */
     protected $classCache;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $globalBasename;
 
@@ -58,8 +57,9 @@ abstract class FileDriver implements MappingDriver
      * Initializes a new FileDriver that looks in the given path(s) for mapping
      * documents and operates in the specified operating mode.
      *
-     * @param string|array|FileLocator $locator A FileLocator or one/multiple paths where mapping documents can be found.
-     * @param string $fileExtension
+     * @param string|array|FileLocator $locator       A FileLocator or one/multiple paths
+     *                                                where mapping documents can be found.
+     * @param string|null              $fileExtension
      */
     public function __construct($locator, $fileExtension = null)
     {
@@ -71,9 +71,11 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Set global basename
+     * Sets the global basename.
      *
      * @param string $file
+     *
+     * @return void
      */
     public function setGlobalBasename($file)
     {
@@ -81,9 +83,9 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Retrieve global basename
+     * Retrieves the global basename.
      *
-     * @return string
+     * @return string|null
      */
     public function getGlobalBasename()
     {
@@ -91,13 +93,14 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Get the element of schema meta data for the class from the mapping file.
-     * This will lazily load the mapping file if it is not loaded yet
+     * Gets the element of schema meta data for the class from the mapping file.
+     * This will lazily load the mapping file if it is not loaded yet.
      *
      * @param string $className
      *
+     * @return array The element of schema meta data.
+     *
      * @throws MappingException
-     * @return array The element of schema meta data
      */
     public function getElement($className)
     {
@@ -118,12 +121,7 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Whether the class with the specified name should have its metadata loaded.
-     * This is only the case if it is either mapped as an Entity or a
-     * MappedSuperclass.
-     *
-     * @param string $className
-     * @return boolean
+     * {@inheritDoc}
      */
     public function isTransient($className)
     {
@@ -139,9 +137,7 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Gets the names of all mapped classes known to this driver.
-     *
-     * @return array The names of all mapped classes known to this driver.
+     * {@inheritDoc}
      */
     public function getAllClassNames()
     {
@@ -161,12 +157,13 @@ abstract class FileDriver implements MappingDriver
      * from class/entity names to their corresponding file driver elements.
      *
      * @param string $file The mapping file to load.
+     *
      * @return array
      */
     abstract protected function loadMappingFile($file);
 
     /**
-     * Initialize the class cache from all the global files.
+     * Initializes the class cache from all the global files.
      *
      * Using this feature adds a substantial performance hit to file drivers as
      * more metadata has to be loaded into memory than might actually be
@@ -193,7 +190,7 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Retrieve the locator used to discover mapping files by className
+     * Retrieves the locator used to discover mapping files by className.
      *
      * @return FileLocator
      */
@@ -203,7 +200,7 @@ abstract class FileDriver implements MappingDriver
     }
 
     /**
-     * Set the locator used to discover mapping files by className
+     * Sets the locator used to discover mapping files by className.
      *
      * @param FileLocator $locator
      */

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
@@ -15,12 +15,12 @@
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
-*/
+ */
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 /**
- * Locate the file that contains the metadata information for a given class name.
+ * Locates the file that contains the metadata information for a given class name.
  *
  * This behavior is independent of the actual content of the file. It just detects
  * the file which is responsible for the given class name.
@@ -31,23 +31,25 @@ namespace Doctrine\Common\Persistence\Mapping\Driver;
 interface FileLocator
 {
     /**
-     * Locate mapping file for the given class name.
+     * Locates mapping file for the given class name.
      *
      * @param string $className
+     *
      * @return string
      */
     public function findMappingFile($className);
 
     /**
-     * Get all class names that are found with this file locator.
+     * Gets all class names that are found with this file locator.
      *
-     * @param string $globalBasename Passed to allow excluding the basename
+     * @param string $globalBasename Passed to allow excluding the basename.
+     *
      * @return array
      */
     public function getAllClassNames($globalBasename);
 
     /**
-     * Check if a file can be found for this class name.
+     * Checks if a file can be found for this class name.
      *
      * @param string $className
      *
@@ -56,14 +58,14 @@ interface FileLocator
     public function fileExists($className);
 
     /**
-     * Get all the paths that this file locator looks for mapping files.
+     * Gets all the paths that this file locator looks for mapping files.
      *
      * @return array
      */
     public function getPaths();
 
     /**
-     * Get the file extension that mapping files are suffixed with.
+     * Gets the file extension that mapping files are suffixed with.
      *
      * @return string
      */

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 /**
  * Contract for metadata drivers.
  *
- * @since 2.2
+ * @since  2.2
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
 interface MappingDriver
@@ -32,8 +32,10 @@ interface MappingDriver
     /**
      * Loads the metadata for the specified class into the provided container.
      *
-     * @param string $className
+     * @param string        $className
      * @param ClassMetadata $metadata
+     *
+     * @return void
      */
     public function loadMetadataForClass($className, ClassMetadata $metadata);
 
@@ -45,11 +47,11 @@ interface MappingDriver
     public function getAllClassNames();
 
     /**
-     * Whether the class with the specified name should have its metadata loaded.
-     * This is only the case if it is either mapped as an Entity or a
-     * MappedSuperclass.
+     * Returns whether the class with the specified name should have its metadata loaded.
+     * This is only the case if it is either mapped as an Entity or a MappedSuperclass.
      *
      * @param string $className
+     *
      * @return boolean
      */
     public function isTransient($className);

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -19,13 +19,13 @@
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver,
-    Doctrine\Common\Persistence\Mapping\ClassMetadata,
-    Doctrine\Common\Persistence\Mapping\MappingException;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
  * The DriverChain allows you to add multiple other mapping drivers for
- * certain namespaces
+ * certain namespaces.
  *
  * @since  2.2
  * @author Benjamin Eberlei <kontakt@beberlei.de>
@@ -36,11 +36,11 @@ use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver,
 class MappingDriverChain implements MappingDriver
 {
     /**
-     * The default driver
+     * The default driver.
      *
-     * @var MappingDriver
+     * @var MappingDriver|null
      */
-    private $defaultDriver;
+    private $defaultDriver = null;
 
     /**
      * @var array
@@ -48,7 +48,7 @@ class MappingDriverChain implements MappingDriver
     private $drivers = array();
 
     /**
-     * Get the default driver.
+     * Gets the default driver.
      *
      * @return MappingDriver|null
      */
@@ -61,6 +61,8 @@ class MappingDriverChain implements MappingDriver
      * Set the default driver.
      *
      * @param MappingDriver $driver
+     *
+     * @return void
      */
     public function setDefaultDriver(MappingDriver $driver)
     {
@@ -68,10 +70,12 @@ class MappingDriverChain implements MappingDriver
     }
 
     /**
-     * Add a nested driver.
+     * Adds a nested driver.
      *
      * @param MappingDriver $nestedDriver
-     * @param string $namespace
+     * @param string        $namespace
+     *
+     * @return void
      */
     public function addDriver(MappingDriver $nestedDriver, $namespace)
     {
@@ -79,7 +83,7 @@ class MappingDriverChain implements MappingDriver
     }
 
     /**
-     * Get the array of nested drivers.
+     * Gets the array of nested drivers.
      *
      * @return array $drivers
      */
@@ -89,12 +93,7 @@ class MappingDriverChain implements MappingDriver
     }
 
     /**
-     * Loads the metadata for the specified class into the provided container.
-     *
-     * @param string $className
-     * @param ClassMetadata $metadata
-     *
-     * @throws MappingException
+     * {@inheritDoc}
      */
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {
@@ -115,9 +114,7 @@ class MappingDriverChain implements MappingDriver
     }
 
     /**
-     * Gets the names of all mapped classes known to this driver.
-     *
-     * @return array The names of all mapped classes known to this driver.
+     * {@inheritDoc}
      */
     public function getAllClassNames()
     {
@@ -149,12 +146,7 @@ class MappingDriverChain implements MappingDriver
     }
 
     /**
-     * Whether the class with the specified name should have its metadata loaded.
-     *
-     * This is only the case for non-transient classes either mapped as an Entity or MappedSuperclass.
-     *
-     * @param string $className
-     * @return boolean
+     * {@inheritDoc}
      */
     public function isTransient($className)
     {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -23,21 +23,19 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 /**
  * The PHPDriver includes php files which just populate ClassMetadataInfo
- * instances with plain php code
+ * instances with plain PHP code.
  *
- * @license 	http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    	www.doctrine-project.org
- * @since   	2.0
- * @version     $Revision$
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
- * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author      Jonathan H. Wage <jonwage@gmail.com>
- * @author      Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 class PHPDriver extends FileDriver
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected $metadata;
 
@@ -51,7 +49,7 @@ class PHPDriver extends FileDriver
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {
@@ -60,7 +58,7 @@ class PHPDriver extends FileDriver
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function loadMappingFile($file)
     {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -26,13 +26,12 @@ use Doctrine\Common\Persistence\Mapping\MappingException;
  * The StaticPHPDriver calls a static loadMetadata() method on your entity
  * classes where you can manually populate the ClassMetadata instance.
  *
- * @license 	http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    	www.doctrine-project.org
- * @since   	2.2
- * @author      Benjamin Eberlei <kontakt@beberlei.de>
- * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author      Jonathan H. Wage <jonwage@gmail.com>
- * @author      Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.2
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 class StaticPHPDriver implements MappingDriver
 {
@@ -51,7 +50,7 @@ class StaticPHPDriver implements MappingDriver
     private $classNames;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param array|string $paths
      */
@@ -61,9 +60,11 @@ class StaticPHPDriver implements MappingDriver
     }
 
     /**
-     * Add paths
+     * Adds paths.
      *
      * @param array $paths
+     *
+     * @return void
      */
     public function addPaths(array $paths)
     {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -15,7 +15,7 @@
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
-*/
+ */
 
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
@@ -26,8 +26,8 @@ use Doctrine\Common\Persistence\Mapping\MappingException;
  * to the DefaultFileLocator. By assuming paths only contain entities of a certain
  * namespace the mapping files consists of the short classname only.
  *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author  Fabien Potencier <fabien@symfony.com>
+ * @author  Benjamin Eberlei <kontakt@beberlei.de>
  * @license MIT
  */
 class SymfonyFileLocator implements FileLocator
@@ -49,14 +49,14 @@ class SymfonyFileLocator implements FileLocator
     /**
      * File extension that is searched for.
      *
-     * @var string
+     * @var string|null
      */
     protected $fileExtension;
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param array $prefixes
+     * @param array       $prefixes
      * @param string|null $fileExtension
      */
     public function __construct(array $prefixes, $fileExtension = null)
@@ -66,9 +66,11 @@ class SymfonyFileLocator implements FileLocator
     }
 
     /**
-     * Add Namespace Prefixes
+     * Adds Namespace Prefixes.
      *
      * @param array $prefixes
+     *
+     * @return void
      */
     public function addNamespacePrefixes(array $prefixes)
     {
@@ -77,7 +79,7 @@ class SymfonyFileLocator implements FileLocator
     }
 
     /**
-     * Get Namespace Prefixes
+     * Gets Namespace Prefixes.
      *
      * @return array
      */
@@ -103,9 +105,10 @@ class SymfonyFileLocator implements FileLocator
     }
 
     /**
-     * Set the file extension used to look for mapping files under
+     * Sets the file extension used to look for mapping files under.
      *
-     * @param string $fileExtension The file extension to set
+     * @param string $fileExtension The file extension to set.
+     *
      * @return void
      */
     public function setFileExtension($fileExtension)

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -14,7 +14,7 @@
  *
  * This software consists of voluntary contributions made by many individuals
  * and is licensed under the MIT license. For more information, see
- * <http://www.phpdoctrine.org>.
+ * <http://www.doctrine-project.org>.
  */
 
 namespace Doctrine\Common\Persistence\Mapping;
@@ -27,9 +27,8 @@ namespace Doctrine\Common\Persistence\Mapping;
 class MappingException extends \Exception
 {
     /**
-     *
      * @param string $className
-     * @param array $namespaces
+     * @param array  $namespaces
      *
      * @return MappingException
      */
@@ -50,6 +49,7 @@ class MappingException extends \Exception
 
     /**
      * @param string|null $path
+     *
      * @return MappingException
      */
     public static function fileMappingDriversRequireConfiguredDirectoryPath($path = null)
@@ -67,6 +67,7 @@ class MappingException extends \Exception
     /**
      * @param string $entityName
      * @param string $fileName
+     *
      * @return MappingException
      */
     public static function mappingFileNotFound($entityName, $fileName)
@@ -77,6 +78,7 @@ class MappingException extends \Exception
     /**
      * @param string $entityName
      * @param string $fileName
+     *
      * @return MappingException
      */
     public static function invalidMappingFile($entityName, $fileName)

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -30,7 +30,7 @@ namespace Doctrine\Common\Persistence\Mapping;
 interface ReflectionService
 {
     /**
-     * Return an array of the parent classes (not interfaces) for the given class.
+     * Returns an array of the parent classes (not interfaces) for the given class.
      *
      * @param string $class
      *
@@ -41,43 +41,47 @@ interface ReflectionService
     public function getParentClasses($class);
 
     /**
-     * Return the shortname of a class.
+     * Returns the shortname of a class.
      *
      * @param string $class
+     *
      * @return string
      */
     public function getClassShortName($class);
 
     /**
      * @param string $class
+     *
      * @return string
      */
     public function getClassNamespace($class);
 
     /**
-     * Return a reflection class instance or null
+     * Returns a reflection class instance or null.
      *
      * @param string $class
+     *
      * @return \ReflectionClass|null
      */
     public function getClass($class);
 
     /**
-     * Return an accessible property (setAccessible(true)) or null.
+     * Returns an accessible property (setAccessible(true)) or null.
      *
      * @param string $class
      * @param string $property
+     *
      * @return \ReflectionProperty|null
      */
     public function getAccessibleProperty($class, $property);
 
     /**
-     * Check if the class have a public method with the given name.
+     * Checks if the class have a public method with the given name.
      *
      * @param mixed $class
      * @param mixed $method
+     *
      * @return bool
      */
     public function hasPublicMethod($class, $method);
 }
-

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -25,7 +25,7 @@ use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
- * PHP Runtime Reflection Service
+ * PHP Runtime Reflection Service.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
@@ -95,4 +95,3 @@ class RuntimeReflectionService implements ReflectionService
         return method_exists($class, $method) && is_callable(array($class, $method));
     }
 }
-

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -19,21 +19,15 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
-use ReflectionClass;
-use ReflectionProperty;
-
 /**
- * PHP Runtime Reflection Service
+ * PHP Runtime Reflection Service.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 class StaticReflectionService implements ReflectionService
 {
     /**
-     * Return an array of the parent classes (not interfaces) for the given class.
-     *
-     * @param string $class
-     * @return array
+     * {@inheritDoc}
      */
     public function getParentClasses($class)
     {
@@ -41,10 +35,7 @@ class StaticReflectionService implements ReflectionService
     }
 
     /**
-     * Return the shortname of a class.
-     *
-     * @param string $className
-     * @return string
+     * {@inheritDoc}
      */
     public function getClassShortName($className)
     {
@@ -55,10 +46,7 @@ class StaticReflectionService implements ReflectionService
     }
 
     /**
-     * Return the namespace of a class.
-     *
-     * @param string $className
-     * @return string
+     * {@inheritDoc}
      */
     public function getClassNamespace($className)
     {
@@ -70,10 +58,7 @@ class StaticReflectionService implements ReflectionService
     }
 
     /**
-     * Return a reflection class instance or null
-     *
-     * @param string $class
-     * @return ReflectionClass|null
+     * {@inheritDoc}
      */
     public function getClass($class)
     {
@@ -81,11 +66,7 @@ class StaticReflectionService implements ReflectionService
     }
 
     /**
-     * Return an accessible property (setAccessible(true)) or null.
-     *
-     * @param string $class
-     * @param string $property
-     * @return ReflectionProperty|null
+     * {@inheritDoc}
      */
     public function getAccessibleProperty($class, $property)
     {
@@ -93,15 +74,10 @@ class StaticReflectionService implements ReflectionService
     }
 
     /**
-     * Check if the class have a public method with the given name.
-     *
-     * @param mixed $class
-     * @param mixed $method
-     * @return bool
+     * {@inheritDoc}
      */
     public function hasPublicMethod($class, $method)
     {
         return method_exists($class, $method) && is_callable(array($class, $method));
     }
 }
-

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -22,11 +22,10 @@ namespace Doctrine\Common\Persistence;
 /**
  * Contract for a Doctrine persistence layer ObjectManager class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.1
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Jonathan Wage <jonwage@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.1
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Jonathan Wage <jonwage@gmail.com>
  */
 interface ObjectManager
 {
@@ -35,9 +34,10 @@ interface ObjectManager
      *
      * This is just a convenient shortcut for getRepository($className)->find($id).
      *
-     * @param string
-     * @param mixed
-     * @return object
+     * @param string $className The class name of the object to find.
+     * @param mixed  $id        The identity of the object to find.
+     *
+     * @return object The found object.
      */
     public function find($className, $id);
 
@@ -50,6 +50,8 @@ interface ObjectManager
      * this ObjectManager as NEW. Do not pass detached objects to the persist operation.
      *
      * @param object $object The instance to make managed and persistent.
+     *
+     * @return void
      */
     public function persist($object);
 
@@ -59,6 +61,8 @@ interface ObjectManager
      * A removed object will be removed from the database as a result of the flush operation.
      *
      * @param object $object The object instance to remove.
+     *
+     * @return void
      */
     public function remove($object);
 
@@ -68,6 +72,7 @@ interface ObjectManager
      * The object passed to merge will not become associated/managed with this ObjectManager.
      *
      * @param object $object
+     *
      * @return object
      */
     public function merge($object);
@@ -76,7 +81,9 @@ interface ObjectManager
      * Clears the ObjectManager. All objects that are currently managed
      * by this ObjectManager become detached.
      *
-     * @param string $objectName if given, only objects of this type will get detached
+     * @param string|null $objectName if given, only objects of this type will get detached.
+     *
+     * @return void
      */
     public function clear($objectName = null);
 
@@ -88,6 +95,8 @@ interface ObjectManager
      * reference it.
      *
      * @param object $object The object to detach.
+     *
+     * @return void
      */
     public function detach($object);
 
@@ -96,6 +105,8 @@ interface ObjectManager
      * overriding any local changes that have not yet been persisted.
      *
      * @param object $object The object to refresh.
+     *
+     * @return void
      */
     public function refresh($object);
 
@@ -103,6 +114,8 @@ interface ObjectManager
      * Flushes all changes to objects that have been queued up to now to the database.
      * This effectively synchronizes the in-memory state of managed objects with the
      * database.
+     *
+     * @return void
      */
     public function flush();
 
@@ -110,6 +123,7 @@ interface ObjectManager
      * Gets the repository for a class.
      *
      * @param string $className
+     *
      * @return \Doctrine\Common\Persistence\ObjectRepository
      */
     public function getRepository($className);
@@ -121,6 +135,7 @@ interface ObjectManager
      * (as it is returned by get_class($obj)).
      *
      * @param string $className
+     *
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
      */
     public function getClassMetadata($className);
@@ -138,14 +153,16 @@ interface ObjectManager
      * This method is a no-op for other objects.
      *
      * @param object $obj
+     *
+     * @return void
      */
     public function initializeObject($obj);
 
     /**
-     * Check if the object is part of the current UnitOfWork and therefore
-     * managed.
+     * Checks if the object is part of the current UnitOfWork and therefore managed.
      *
      * @param object $object
+     *
      * @return bool
      */
     public function contains($object);

--- a/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
@@ -44,6 +44,8 @@ interface ObjectManagerAware
      *
      * @param ObjectManager $objectManager
      * @param ClassMetadata $classMetadata
+     *
+     * @return void
      */
     public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata);
 }

--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -22,18 +22,18 @@ namespace Doctrine\Common\Persistence;
 /**
  * Contract for a Doctrine persistence layer ObjectRepository class to implement.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.1
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Jonathan Wage <jonwage@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.1
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Jonathan Wage <jonwage@gmail.com>
  */
 interface ObjectRepository
 {
     /**
      * Finds an object by its primary key / identifier.
      *
-     * @param int $id The identifier.
+     * @param mixed $id The identifier.
+     *
      * @return object The object.
      */
     public function find($id);
@@ -41,7 +41,7 @@ interface ObjectRepository
     /**
      * Finds all objects in the repository.
      *
-     * @return mixed The objects.
+     * @return array The objects.
      */
     public function findAll();
 
@@ -52,25 +52,28 @@ interface ObjectRepository
      * an UnexpectedValueException if certain values of the sorting or limiting details are
      * not supported.
      *
-     * @throws \UnexpectedValueException
-     * @param array $criteria
+     * @param array      $criteria
      * @param array|null $orderBy
-     * @param int|null $limit
-     * @param int|null $offset
-     * @return mixed The objects.
+     * @param int|null   $limit
+     * @param int|null   $offset
+     *
+     * @return array The objects.
+     *
+     * @throws \UnexpectedValueException
      */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null);
 
     /**
      * Finds a single object by a set of criteria.
      *
-     * @param array $criteria
+     * @param array $criteria The criteria.
+     *
      * @return object The object.
      */
     public function findOneBy(array $criteria);
 
     /**
-     * Returns the class name of the object managed by the repository
+     * Returns the class name of the object managed by the repository.
      *
      * @return string
      */

--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -29,7 +29,6 @@ use Doctrine\Common\Collections\Collection;
  *
  * This class is a forward compatible implementation of the PersistentObject trait.
  *
- *
  * Limitations:
  *
  * 1. All persistent objects have to be associated with a single ObjectManager, multiple
@@ -58,19 +57,21 @@ use Doctrine\Common\Collections\Collection;
 abstract class PersistentObject implements ObjectManagerAware
 {
     /**
-     * @var ObjectManager
+     * @var ObjectManager|null
      */
-    private static $objectManager;
+    private static $objectManager = null;
 
     /**
-     * @var ClassMetadata
+     * @var ClassMetadata|null
      */
-    private $cm;
+    private $cm = null;
 
     /**
-     * Set the object manager responsible for all persistent object base classes.
+     * Sets the object manager responsible for all persistent object base classes.
      *
-     * @param ObjectManager $objectManager
+     * @param ObjectManager|null $objectManager
+     *
+     * @return void
      */
     static public function setObjectManager(ObjectManager $objectManager = null)
     {
@@ -78,7 +79,7 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * @return ObjectManager
+     * @return ObjectManager|null
      */
     static public function getObjectManager()
     {
@@ -86,10 +87,12 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * Inject Doctrine Object Manager
+     * Injects the Doctrine Object Manager.
      *
      * @param ObjectManager $objectManager
      * @param ClassMetadata $classMetadata
+     *
+     * @return void
      *
      * @throws \RuntimeException
      */
@@ -107,11 +110,12 @@ abstract class PersistentObject implements ObjectManagerAware
      * Sets a persistent fields value.
      *
      * @param string $field
-     * @param array $args
+     * @param array  $args
      *
-     * @throws \BadMethodCallException - When no persistent field exists by that name.
-     * @throws \InvalidArgumentException - When the wrong target object type is passed to an association
      * @return void
+     *
+     * @throws \BadMethodCallException   When no persistent field exists by that name.
+     * @throws \InvalidArgumentException When the wrong target object type is passed to an association.
      */
     private function set($field, $args)
     {
@@ -132,13 +136,13 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * Get persistent field value.
-     *
+     * Gets a persistent field value.
      *
      * @param string $field
      *
-     * @throws \BadMethodCallException - When no persistent field exists by that name.
      * @return mixed
+     *
+     * @throws \BadMethodCallException When no persistent field exists by that name.
      */
     private function get($field)
     {
@@ -152,11 +156,13 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * If this is an inverse side association complete the owning side.
+     * If this is an inverse side association, completes the owning side.
      *
-     * @param string $field
+     * @param string        $field
      * @param ClassMetadata $targetClass
-     * @param object $targetObject
+     * @param object        $targetObject
+     *
+     * @return void
      */
     private function completeOwningSide($field, $targetClass, $targetObject)
     {
@@ -172,10 +178,12 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * Add an object to a collection
+     * Adds an object to a collection.
      *
      * @param string $field
-     * @param array $args
+     * @param array  $args
+     *
+     * @return void
      *
      * @throws \BadMethodCallException
      * @throws \InvalidArgumentException
@@ -200,10 +208,11 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * Initialize Doctrine Metadata for this class.
+     * Initializes Doctrine Metadata for this class.
+     *
+     * @return void
      *
      * @throws \RuntimeException
-     * @return void
      */
     private function initializeDoctrine()
     {
@@ -219,13 +228,14 @@ abstract class PersistentObject implements ObjectManagerAware
     }
 
     /**
-     * Magic method that implements
+     * Magic methods.
      *
      * @param string $method
-     * @param array $args
+     * @param array  $args
+     *
+     * @return mixed
      *
      * @throws \BadMethodCallException
-     * @return mixed
      */
     public function __call($method, $args)
     {

--- a/lib/Doctrine/Common/Persistence/Proxy.php
+++ b/lib/Doctrine/Common/Persistence/Proxy.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -24,7 +23,7 @@ namespace Doctrine\Common\Persistence;
  * Interface for proxy classes.
  *
  * @author Roman Borschel <roman@code-factory.org>
- * @since 2.2
+ * @since  2.2
  */
 interface Proxy
 {
@@ -36,14 +35,14 @@ interface Proxy
     const MARKER = '__CG__';
 
     /**
-     * Length of the proxy marker
+     * Length of the proxy marker.
      *
      * @var integer
      */
     const MARKER_LENGTH = 6;
 
     /**
-     * Initialize this proxy if its not yet initialized.
+     * Initializes this proxy if its not yet initialized.
      *
      * Acts as a no-op if already initialized.
      *
@@ -52,7 +51,7 @@ interface Proxy
     public function __load();
 
     /**
-     * Is this proxy initialized or not.
+     * Returns whether this proxy is initialized or not.
      *
      * @return bool
      */

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -25,24 +23,23 @@ namespace Doctrine\Common;
  * Contract for classes that are potential listeners of a <tt>NotifyPropertyChanged</tt>
  * implementor.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision: 3938 $
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 interface PropertyChangedListener
 {
     /**
      * Notifies the listener of a property change.
      *
-     * @param object $sender The object on which the property changed.
+     * @param object $sender       The object on which the property changed.
      * @param string $propertyName The name of the property that changed.
-     * @param mixed $oldValue The old value of the property that changed.
-     * @param mixed $newValue The new value of the property that changed.
+     * @param mixed  $oldValue     The old value of the property that changed.
+     * @param mixed  $newValue     The new value of the property that changed.
+     *
+     * @return void
      */
     function propertyChanged($sender, $propertyName, $oldValue, $newValue);
 }
-

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -31,13 +31,13 @@ class Autoloader
     /**
      * Resolves proxy class name to a filename based on the following pattern.
      *
-     * 1. Remove Proxy namespace from class name
+     * 1. Remove Proxy namespace from class name.
      * 2. Remove namespace separators from remaining class name.
      * 3. Return PHP filename from proxy-dir with the result from 2.
      *
-     * @param  string $proxyDir
-     * @param  string $proxyNamespace
-     * @param  string $className
+     * @param string $proxyDir
+     * @param string $proxyNamespace
+     * @param string $className
      *
      * @return string
      *
@@ -55,12 +55,11 @@ class Autoloader
     }
 
     /**
-     * Register and return autoloader callback for the given proxy dir and
-     * namespace.
+     * Registers and returns autoloader callback for the given proxy dir and namespace.
      *
-     * @param  string  $proxyDir
-     * @param  string  $proxyNamespace
-     * @param  callable $notFoundCallback Invoked when the proxy file is not found.
+     * @param string        $proxyDir
+     * @param string        $proxyNamespace
+     * @param callable|null $notFoundCallback Invoked when the proxy file is not found.
      *
      * @return \Closure
      *

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -23,11 +23,11 @@ use Doctrine\Common\Persistence\Proxy;
 use InvalidArgumentException as BaseInvalidArgumentException;
 
 /**
- * Proxy Invalid Argument Exception
+ * Proxy Invalid Argument Exception.
  *
- * @link        www.doctrine-project.com
- * @since       2.4
- * @author      Marco Pivetta <ocramius@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.4
+ * @author Marco Pivetta <ocramius@gmail.com>
  */
 class InvalidArgumentException extends BaseInvalidArgumentException implements ProxyException
 {
@@ -40,8 +40,8 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
     }
 
     /**
-     * @param  string $className
-     * @param  string $proxyNamespace
+     * @param string $className
+     * @param string $proxyNamespace
      *
      * @return self
      */
@@ -51,7 +51,7 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
     }
 
     /**
-     * @param  string $name
+     * @param string $name
      *
      * @return self
      */
@@ -77,7 +77,7 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
     }
 
     /**
-     * @param  mixed $callback
+     * @param mixed $callback
      *
      * @return self
      */

--- a/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
@@ -20,11 +20,11 @@
 namespace Doctrine\Common\Proxy\Exception;
 
 /**
- * Base exception interface for proxy exceptions
+ * Base exception interface for proxy exceptions.
  *
- * @link        www.doctrine-project.com
- * @since       2.4
- * @author      Marco Pivetta <ocramius@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.4
+ * @author Marco Pivetta <ocramius@gmail.com>
  */
 interface ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -22,11 +22,11 @@ namespace Doctrine\Common\Proxy\Exception;
 use UnexpectedValueException as BaseUnexpectedValueException;
 
 /**
- * Proxy Unexpected Value Exception
+ * Proxy Unexpected Value Exception.
  *
- * @link        www.doctrine-project.com
- * @since       2.4
- * @author      Marco Pivetta <ocramius@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.4
+ * @author Marco Pivetta <ocramius@gmail.com>
  */
 class UnexpectedValueException extends BaseUnexpectedValueException implements ProxyException
 {
@@ -39,9 +39,10 @@ class UnexpectedValueException extends BaseUnexpectedValueException implements P
     }
 
     /**
-     * @param string $className
-     * @param string $methodName
-     * @param string $parameterName
+     * @param string     $className
+     * @param string     $methodName
+     * @param string     $parameterName
+     * @param \Exception $previous
      *
      * @return self
      */

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -36,21 +35,26 @@ interface Proxy extends BaseProxy
      * Marks the proxy as initialized or not.
      *
      * @param boolean $initialized
+     *
+     * @return void
      */
     public function __setInitialized($initialized);
 
     /**
-     * Set the initializer callback to be used when initializing the proxy. That
+     * Sets the initializer callback to be used when initializing the proxy. That
      * initializer should accept 3 parameters: $proxy, $method and $params. Those
      * are respectively the proxy object that is being initialized, the method name
-     * that triggered initialization and the parameters passed to that method
+     * that triggered initialization and the parameters passed to that method.
      *
-     * @param Closure $initializer
+     * @param Closure|null $initializer
+     *
+     * @return void
      */
     public function __setInitializer(Closure $initializer = null);
 
     /**
      * Retrieves the initializer callback used to initialize the proxy.
+     *
      * @see __setInitializer
      *
      * @return Closure|null
@@ -58,15 +62,18 @@ interface Proxy extends BaseProxy
     public function __getInitializer();
 
     /**
-     * Set the callback to be used when cloning the proxy. That initializer should accept
-     * a single parameter, which is the cloned proxy instance itself
+     * Sets the callback to be used when cloning the proxy. That initializer should accept
+     * a single parameter, which is the cloned proxy instance itself.
      *
-     * @param Closure $cloner
+     * @param Closure|null $cloner
+     *
+     * @return void
      */
     public function __setCloner(Closure $cloner = null);
 
     /**
      * Retrieves the callback to be used when cloning the proxy.
+     *
      * @see __setCloner
      *
      * @return Closure|null
@@ -76,8 +83,8 @@ interface Proxy extends BaseProxy
     /**
      * Retrieves the list of lazy loaded properties for a given proxy
      *
-     * @return array with keys being the property names, and values being the default values
-     *               for those properties
+     * @return array Keys are the property names, and values are the default values
+     *               for those properties.
      */
     public function __getLazyProperties();
 }

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -25,11 +25,11 @@ use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 
 /**
- * This factory is used to generate proxy classes. It builds proxies from given parameters, a template and class
- * metadata.
+ * This factory is used to generate proxy classes.
+ * It builds proxies from given parameters, a template and class metadata.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
- * @since 2.4
+ * @since  2.4
  */
 class ProxyGenerator
 {
@@ -40,17 +40,23 @@ class ProxyGenerator
     const PATTERN_MATCH_ID_METHOD = '((public\s)?(function\s{1,}%s\s?\(\)\s{1,})\s{0,}{\s{0,}return\s{0,}\$this->%s;\s{0,}})i';
 
     /**
-     * @var string The namespace that contains all proxy classes.
+     * The namespace that contains all proxy classes.
+     *
+     * @var string
      */
     private $proxyNamespace;
 
     /**
-     * @var string The directory that contains all proxy classes.
+     * The directory that contains all proxy classes.
+     *
+     * @var string
      */
     private $proxyDirectory;
 
     /**
-     * @var string[]|callable[] map of callables used to fill in placeholders set in the template
+     * Map of callables used to fill in placeholders set in the template.
+     *
+     * @var string[]|callable[]
      */
     protected $placeholders = array(
         'baseProxyInterface'   => 'Doctrine\Common\Proxy\Proxy',
@@ -58,7 +64,9 @@ class ProxyGenerator
     );
 
     /**
-     * @var string template used as a blueprint to generate proxies
+     * Template used as a blueprint to generate proxies.
+     *
+     * @var string
      */
     protected $proxyClassTemplate = '<?php
 
@@ -196,8 +204,8 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * Initializes a new instance of the <tt>ProxyFactory</tt> class that is
      * connected to the given <tt>EntityManager</tt>.
      *
-     * @param  string $proxyDirectory The directory to use for the proxy classes. It must exist.
-     * @param  string $proxyNamespace The namespace to use for the proxy classes.
+     * @param string $proxyDirectory The directory to use for the proxy classes. It must exist.
+     * @param string $proxyNamespace The namespace to use for the proxy classes.
      *
      * @throws InvalidArgumentException
      */
@@ -216,10 +224,10 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Set a placeholder to be replaced in the template
+     * Sets a placeholder to be replaced in the template.
      *
-     * @param  string          $name
-     * @param  string|callable $placeholder
+     * @param string          $name
+     * @param string|callable $placeholder
      *
      * @throws InvalidArgumentException
      */
@@ -233,7 +241,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Set the base template used to create proxy classes
+     * Sets the base template used to create proxy classes.
      *
      * @param string $proxyClassTemplate
      */
@@ -245,8 +253,8 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates a proxy class file.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata  $class    Metadata for the original class
-     * @param  string         $fileName Filename (full path) for the generated class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class    Metadata for the original class.
+     * @param string                                             $fileName Filename (full path) for the generated class.
      *
      * @throws UnexpectedValueException
      */
@@ -288,9 +296,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the proxy short class name to be used in the template
+     * Generates the proxy short class name to be used in the template.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -303,9 +311,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the proxy namespace
+     * Generates the proxy namespace.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -318,9 +326,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the original class name
+     * Generates the original class name.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -330,9 +338,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the array representation of lazy loaded public properties and their default values
+     * Generates the array representation of lazy loaded public properties and their default values.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -349,9 +357,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the constructor code (un-setting public lazy loaded properties, setting identifier field values)
+     * Generates the constructor code (un-setting public lazy loaded properties, setting identifier field values).
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -384,9 +392,9 @@ EOT;
     }
 
     /**
-     * Generates the magic getter invoked when lazy loaded public properties are requested
+     * Generates the magic getter invoked when lazy loaded public properties are requested.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -453,9 +461,9 @@ EOT;
     }
 
     /**
-     * Generates the magic setter (currently unused)
+     * Generates the magic setter (currently unused).
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -510,9 +518,9 @@ EOT;
     }
 
     /**
-     * Generates the magic issetter invoked when lazy loaded public properties are checked against isset()
+     * Generates the magic issetter invoked when lazy loaded public properties are checked against isset().
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -566,7 +574,7 @@ EOT;
     /**
      * Generates implementation for the `__sleep` method of proxies.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -631,7 +639,7 @@ EOT;
     /**
      * Generates implementation for the `__wakeup` method of proxies.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -686,7 +694,7 @@ EOT;
     /**
      * Generates implementation for the `__clone` method of proxies.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -708,9 +716,9 @@ EOT;
     }
 
     /**
-     * Generates decorated methods by picking those available in the parent class
+     * Generates decorated methods by picking those available in the parent class.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -824,12 +832,12 @@ EOT;
     }
 
     /**
-     * Generate the Proxy file name
+     * Generates the Proxy file name.
      *
      * @param string $className
-     * @param string $baseDirectory   Optional base directory for proxy file name generation.
-     *                        If not specified, the directory configured on the Configuration of the
-     *                        EntityManager will be used by this factory.
+     * @param string $baseDirectory Optional base directory for proxy file name generation.
+     *                              If not specified, the directory configured on the Configuration of the
+     *                              EntityManager will be used by this factory.
      *
      * @return string
      */
@@ -842,7 +850,7 @@ EOT;
     }
 
     /**
-     * Check if the method is a short identifier getter.
+     * Checks if the method is a short identifier getter.
      *
      * What does this mean? For proxy objects the identifier is already known,
      * however accessing the getter for this identifier usually triggers the
@@ -850,8 +858,8 @@ EOT;
      * ID is interesting for the userland code (for example in views that
      * generate links to the entity, but do not display anything else).
      *
-     * @param  \ReflectionMethod                                  $method
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \ReflectionMethod                                  $method
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return boolean
      */
@@ -883,9 +891,9 @@ EOT;
     }
 
     /**
-     * Generates the list of public properties to be lazy loaded, with their default values
+     * Generates the list of public properties to be lazy loaded, with their default values.
      *
-     * @param  \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
      * @return mixed[]
      */
@@ -905,3 +913,4 @@ EOT;
         return $properties;
     }
 }
+

--- a/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
@@ -31,8 +31,7 @@ interface ClassFinderInterface
      *
      * @param string $class The name of the class.
      *
-     * @return
-     *     The name of the class or NULL if not found.
+     * @return string|null The name of the class or NULL if not found.
      */
     public function findFile($class);
 }

--- a/lib/Doctrine/Common/Reflection/Psr0FindFile.php
+++ b/lib/Doctrine/Common/Reflection/Psr0FindFile.php
@@ -29,14 +29,13 @@ class Psr0FindFile implements ClassFinderInterface
     /**
      * The PSR-0 prefixes.
      *
-     * @var string
+     * @var array
      */
     protected $prefixes;
 
     /**
-     * @param string $prefixes
-     *     An array of prefixes. Each key is a PHP namespace and each value is
-     *     a list of directories.
+     * @param array $prefixes An array of prefixes. Each key is a PHP namespace and each value is
+     *                        a list of directories.
      */
     public function __construct($prefixes)
     {
@@ -44,12 +43,7 @@ class Psr0FindFile implements ClassFinderInterface
     }
 
     /**
-     * Finds a class.
-     *
-     * @param string $class The name of the class.
-     *
-     * @return
-     *     The name of the class or NULL if not found.
+     * {@inheritDoc}
      */
     public function findFile($class)
     {
@@ -79,5 +73,7 @@ class Psr0FindFile implements ClassFinderInterface
                 }
             }
         }
+
+        return null;
     }
 }

--- a/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -23,23 +22,27 @@ namespace Doctrine\Common\Reflection;
 interface ReflectionProviderInterface
 {
     /**
-     * Get the ReflectionClass equivalent for this class.
+     * Gets the ReflectionClass equivalent for this class.
      *
-     * @return ReflectionClass
+     * @return \ReflectionClass
      */
     public function getReflectionClass();
 
     /**
-     * Get the ReflectionClass equivalent for this class.
+     * Gets the ReflectionMethod equivalent for this class.
      *
-     * @return ReflectionMethod
+     * @param string $name
+     *
+     * @return \ReflectionMethod
      */
     public function getReflectionMethod($name);
 
     /**
-     * Get the ReflectionClass equivalent for this class.
+     * Gets the ReflectionProperty equivalent for this class.
      *
-     * @return ReflectionMethod
+     * @param string $name
+     *
+     * @return \ReflectionProperty
      */
     public function getReflectionProperty($name);
 }

--- a/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
@@ -23,7 +23,7 @@ use ReflectionProperty;
 use Doctrine\Common\Proxy\Proxy;
 
 /**
- * PHP Runtime Reflection Public Property - special overrides for public properties
+ * PHP Runtime Reflection Public Property - special overrides for public properties.
  *
  * @author Marco Pivetta <ocramius@gmail.com>
  * @since  2.4

--- a/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
@@ -31,82 +31,403 @@ class StaticReflectionClass extends ReflectionClass
      */
     private $staticReflectionParser;
 
+    /**
+     * @param StaticReflectionParser $staticReflectionParser
+     */
     public function __construct(StaticReflectionParser $staticReflectionParser)
     {
         $this->staticReflectionParser = $staticReflectionParser;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getName()
     {
         return $this->staticReflectionParser->getClassName();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getDocComment()
     {
         return $this->staticReflectionParser->getDocComment();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getNamespaceName()
     {
         return $this->staticReflectionParser->getNamespaceName();
     }
 
+    /**
+     * @return array
+     */
     public function getUseStatements()
     {
         return $this->staticReflectionParser->getUseStatements();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getMethod($name)
     {
         return $this->staticReflectionParser->getReflectionMethod($name);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getProperty($name)
     {
         return $this->staticReflectionParser->getReflectionProperty($name);
     }
 
-    public static function export($argument, $return = false) { throw new ReflectionException('Method not implemented'); }
-    public function getConstant($name) { throw new ReflectionException('Method not implemented'); }
-    public function getConstants() { throw new ReflectionException('Method not implemented'); }
-    public function getConstructor() { throw new ReflectionException('Method not implemented'); }
-    public function getDefaultProperties() { throw new ReflectionException('Method not implemented'); }
-    public function getEndLine() { throw new ReflectionException('Method not implemented'); }
-    public function getExtension() { throw new ReflectionException('Method not implemented'); }
-    public function getExtensionName() { throw new ReflectionException('Method not implemented'); }
-    public function getFileName() { throw new ReflectionException('Method not implemented'); }
-    public function getInterfaceNames() { throw new ReflectionException('Method not implemented'); }
-    public function getInterfaces() { throw new ReflectionException('Method not implemented'); }
-    public function getMethods($filter = NULL) { throw new ReflectionException('Method not implemented'); }
-    public function getModifiers() { throw new ReflectionException('Method not implemented'); }
-    public function getParentClass() { throw new ReflectionException('Method not implemented'); }
-    public function getProperties($filter = NULL) { throw new ReflectionException('Method not implemented'); }
-    public function getShortName() { throw new ReflectionException('Method not implemented'); }
-    public function getStartLine() { throw new ReflectionException('Method not implemented'); }
-    public function getStaticProperties() { throw new ReflectionException('Method not implemented'); }
-    public function getStaticPropertyValue($name, $default = '') { throw new ReflectionException('Method not implemented'); }
-    public function getTraitAliases() { throw new ReflectionException('Method not implemented'); }
-    public function getTraitNames() { throw new ReflectionException('Method not implemented'); }
-    public function getTraits() { throw new ReflectionException('Method not implemented'); }
-    public function hasConstant($name) { throw new ReflectionException('Method not implemented'); }
-    public function hasMethod($name) { throw new ReflectionException('Method not implemented'); }
-    public function hasProperty($name) { throw new ReflectionException('Method not implemented'); }
-    public function implementsInterface($interface) { throw new ReflectionException('Method not implemented'); }
-    public function inNamespace() { throw new ReflectionException('Method not implemented'); }
-    public function isAbstract() { throw new ReflectionException('Method not implemented'); }
-    public function isCloneable() { throw new ReflectionException('Method not implemented'); }
-    public function isFinal() { throw new ReflectionException('Method not implemented'); }
-    public function isInstance($object) { throw new ReflectionException('Method not implemented'); }
-    public function isInstantiable() { throw new ReflectionException('Method not implemented'); }
-    public function isInterface() { throw new ReflectionException('Method not implemented'); }
-    public function isInternal() { throw new ReflectionException('Method not implemented'); }
-    public function isIterateable() { throw new ReflectionException('Method not implemented'); }
-    public function isSubclassOf($class) { throw new ReflectionException('Method not implemented'); }
-    public function isTrait() { throw new ReflectionException('Method not implemented'); }
-    public function isUserDefined() { throw new ReflectionException('Method not implemented'); }
-    public function newInstance($args) { throw new ReflectionException('Method not implemented'); }
-    public function newInstanceArgs(array $args = array()) { throw new ReflectionException('Method not implemented'); }
-    public function newInstanceWithoutConstructor() { throw new ReflectionException('Method not implemented'); }
-    public function setStaticPropertyValue($name, $value) { throw new ReflectionException('Method not implemented'); }
-    public function __toString() { throw new ReflectionException('Method not implemented'); }
+    /**
+     * {@inheritDoc}
+     */
+    public static function export($argument, $return = false)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConstant($name)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConstants()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConstructor()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultProperties()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEndLine()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtension()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtensionName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFileName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInterfaceNames()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInterfaces()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMethods($filter = null)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getModifiers()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParentClass()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getProperties($filter = null)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getShortName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStartLine()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStaticProperties()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStaticPropertyValue($name, $default = '')
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTraitAliases()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTraitNames()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTraits()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasConstant($name)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasMethod($name)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasProperty($name)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function implementsInterface($interface)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function inNamespace()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAbstract()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCloneable()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFinal()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInstance($object)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInstantiable()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInterface()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInternal()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIterateable()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSubclassOf($class)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isTrait()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isUserDefined()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function newInstance($args)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function newInstanceArgs(array $args = array())
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function newInstanceWithoutConstructor()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setStaticPropertyValue($name, $value)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
 }

--- a/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
@@ -38,66 +38,325 @@ class StaticReflectionMethod extends ReflectionMethod
      */
     protected $methodName;
 
+    /**
+     * @param StaticReflectionParser $staticReflectionParser
+     * @param string                 $methodName
+     */
     public function __construct(StaticReflectionParser $staticReflectionParser, $methodName)
     {
         $this->staticReflectionParser = $staticReflectionParser;
         $this->methodName = $methodName;
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getName()
     {
         return $this->methodName;
     }
+
+    /**
+     * @return StaticReflectionParser
+     */
     protected function getStaticReflectionParser()
     {
         return $this->staticReflectionParser->getStaticReflectionParserForDeclaringClass('method', $this->methodName);
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDeclaringClass()
     {
         return $this->getStaticReflectionParser()->getReflectionClass();
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getNamespaceName()
     {
         return $this->getStaticReflectionParser()->getNamespaceName();
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDocComment()
     {
         return $this->getStaticReflectionParser()->getDocComment('method', $this->methodName);
     }
+
+    /**
+     * @return array
+     */
     public function getUseStatements()
     {
         return $this->getStaticReflectionParser()->getUseStatements();
     }
-    public static function export($class, $name, $return = false) { throw new ReflectionException('Method not implemented'); }
-    public function getClosure($object) { throw new ReflectionException('Method not implemented'); }
-    public function getModifiers() { throw new ReflectionException('Method not implemented'); }
-    public function getPrototype() { throw new ReflectionException('Method not implemented'); }
-    public function invoke($object, $parameter = NULL) { throw new ReflectionException('Method not implemented'); }
-    public function invokeArgs($object, array $args) { throw new ReflectionException('Method not implemented'); }
-    public function isAbstract() { throw new ReflectionException('Method not implemented'); }
-    public function isConstructor() { throw new ReflectionException('Method not implemented'); }
-    public function isDestructor() { throw new ReflectionException('Method not implemented'); }
-    public function isFinal() { throw new ReflectionException('Method not implemented'); }
-    public function isPrivate() { throw new ReflectionException('Method not implemented'); }
-    public function isProtected() { throw new ReflectionException('Method not implemented'); }
-    public function isPublic() { throw new ReflectionException('Method not implemented'); }
-    public function isStatic() { throw new ReflectionException('Method not implemented'); }
-    public function setAccessible($accessible) { throw new ReflectionException('Method not implemented'); }
-    public function __toString() { throw new ReflectionException('Method not implemented'); }
-    public function getClosureThis() { throw new ReflectionException('Method not implemented'); }
-    public function getEndLine() { throw new ReflectionException('Method not implemented'); }
-    public function getExtension() { throw new ReflectionException('Method not implemented'); }
-    public function getExtensionName() { throw new ReflectionException('Method not implemented'); }
-    public function getFileName() { throw new ReflectionException('Method not implemented'); }
-    public function getNumberOfParameters() { throw new ReflectionException('Method not implemented'); }
-    public function getNumberOfRequiredParameters() { throw new ReflectionException('Method not implemented'); }
-    public function getParameters() { throw new ReflectionException('Method not implemented'); }
-    public function getShortName() { throw new ReflectionException('Method not implemented'); }
-    public function getStartLine() { throw new ReflectionException('Method not implemented'); }
-    public function getStaticVariables() { throw new ReflectionException('Method not implemented'); }
-    public function inNamespace() { throw new ReflectionException('Method not implemented'); }
-    public function isClosure() { throw new ReflectionException('Method not implemented'); }
-    public function isDeprecated() { throw new ReflectionException('Method not implemented'); }
-    public function isInternal() { throw new ReflectionException('Method not implemented'); }
-    public function isUserDefined() { throw new ReflectionException('Method not implemented'); }
-    public function returnsReference() { throw new ReflectionException('Method not implemented'); }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function export($class, $name, $return = false)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getClosure($object)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getModifiers()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPrototype()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function invoke($object, $parameter = null)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function invokeArgs($object, array $args)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAbstract()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isConstructor()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isDestructor()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isFinal()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPrivate()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isProtected()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPublic()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isStatic()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAccessible($accessible)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getClosureThis()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEndLine()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtension()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtensionName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFileName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNumberOfParameters()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNumberOfRequiredParameters()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParameters()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getShortName()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStartLine()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getStaticVariables()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function inNamespace()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isClosure()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isDeprecated()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInternal()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isUserDefined()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function returnsReference()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
 }

--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -29,7 +29,6 @@ use Doctrine\Common\Annotations\TokenParser;
  */
 class StaticReflectionParser implements ReflectionProviderInterface
 {
-
     /**
      * The fully qualified class name.
      *
@@ -45,28 +44,28 @@ class StaticReflectionParser implements ReflectionProviderInterface
     protected $shortClassName;
 
     /**
-     * TRUE if the caller only wants class annotations.
+     * Whether the caller only wants class annotations.
      *
      * @var boolean.
      */
     protected $classAnnotationOptimize;
 
     /**
-     * TRUE when the parser has ran.
+     * Whether the parser has run.
      *
      * @var boolean
      */
     protected $parsed = false;
 
     /**
-     * The namespace of the class
+     * The namespace of the class.
      *
      * @var string
      */
     protected $namespace = '';
 
     /**
-     * The use statements of this class.
+     * The use statements of the class.
      *
      * @var array
      */
@@ -80,7 +79,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     protected $docComment = array(
         'class' => '',
         'property' => array(),
-        'method' => array(),
+        'method' => array()
     );
 
     /**
@@ -93,20 +92,17 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * The parent PSR-0 Parser.
      *
-     * @var \Doctrine\Common\Annotations\StaticReflectionParser
+     * @var \Doctrine\Common\Reflection\StaticReflectionParser
      */
     protected $parentStaticReflectionParser;
 
     /**
      * Parses a class residing in a PSR-0 hierarchy.
      *
-     * @param string $class
-     *     The full, namespaced class name.
-     * @param ClassFinder $finder
-     *     A ClassFinder object which finds the class.
-     * @param boolean $classAnnotationOptimize
-     *     Only retrieve the class docComment. Presumes there is only one
-     *     statement per line.
+     * @param string               $className               The full, namespaced class name.
+     * @param ClassFinderInterface $finder                  A ClassFinder object which finds the class.
+     * @param boolean              $classAnnotationOptimize Only retrieve the class docComment.
+     *                                                      Presumes there is only one statement per line.
      */
     public function __construct($className, $finder, $classAnnotationOptimize = false)
     {
@@ -124,6 +120,9 @@ class StaticReflectionParser implements ReflectionProviderInterface
         $this->classAnnotationOptimize = $classAnnotationOptimize;
     }
 
+    /**
+     * @return void
+     */
     protected function parse()
     {
         if ($this->parsed || !$fileName = $this->finder->findFile($this->className)) {
@@ -205,6 +204,9 @@ class StaticReflectionParser implements ReflectionProviderInterface
         }
     }
 
+    /**
+     * @return StaticReflectionParser
+     */
     protected function getParentStaticReflectionParser()
     {
         if (empty($this->parentStaticReflectionParser)) {
@@ -214,18 +216,24 @@ class StaticReflectionParser implements ReflectionProviderInterface
         return $this->parentStaticReflectionParser;
     }
 
+    /**
+     * @return string
+     */
     public function getClassName()
     {
         return $this->className;
     }
 
+    /**
+     * @return string
+     */
     public function getNamespaceName()
     {
         return $this->namespace;
     }
 
     /**
-     * Get the ReflectionClass equivalent for this file / class.
+     * {@inheritDoc}
      */
     public function getReflectionClass()
     {
@@ -233,7 +241,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     }
 
     /**
-     * Get the ReflectionMethod equivalent for the method of this file / class.
+     * {@inheritDoc}
      */
     public function getReflectionMethod($methodName)
     {
@@ -241,7 +249,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     }
 
     /**
-     * Get the ReflectionProperty equivalent for the method of this file / class.
+     * {@inheritDoc}
      */
     public function getReflectionProperty($propertyName)
     {
@@ -249,7 +257,9 @@ class StaticReflectionParser implements ReflectionProviderInterface
     }
 
     /**
-     * Get the use statements from this file.
+     * Gets the use statements from this file.
+     *
+     * @return array
      */
     public function getUseStatements()
     {
@@ -259,12 +269,12 @@ class StaticReflectionParser implements ReflectionProviderInterface
     }
 
     /**
-     * Get docComment.
+     * Gets the doc comment.
      *
-     * @param string $type class, property or method.
-     * @param string $name Name of the property or method, not needed for class.
+     * @param string $type The type: 'class', 'property' or 'method'.
+     * @param string $name The name of the property or method, not needed for 'class'.
      *
-     * @return string the doc comment or empty string if none.
+     * @return string The doc comment, empty string if none.
      */
     public function getDocComment($type = 'class', $name = '')
     {
@@ -274,12 +284,14 @@ class StaticReflectionParser implements ReflectionProviderInterface
     }
 
     /**
-     * Get the PSR-0 parser for the declaring class.
+     * Gets the PSR-0 parser for the declaring class.
      *
-     * @param string $type property or method.
-     * @param string $name Name of the property or method.
+     * @param string $type The type: 'property' or 'method'.
+     * @param string $name The name of the property or method.
      *
      * @return StaticReflectionParser A static reflection parser for the declaring class.
+     *
+     * @throws ReflectionException
      */
     public function getStaticReflectionParserForDeclaringClass($type, $name)
     {

--- a/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
@@ -34,44 +34,145 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * The name of the property.
      *
-     * @var string
+     * @var string|null
      */
     protected $propertyName;
 
+    /**
+     * @param StaticReflectionParser $staticReflectionParser
+     * @param string|null            $propertyName
+     */
     public function __construct(StaticReflectionParser $staticReflectionParser, $propertyName)
     {
         $this->staticReflectionParser = $staticReflectionParser;
         $this->propertyName = $propertyName;
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getName()
     {
         return $this->propertyName;
     }
+
+    /**
+     * @return StaticReflectionParser
+     */
     protected function getStaticReflectionParser()
     {
         return $this->staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', $this->propertyName);
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDeclaringClass()
     {
         return $this->getStaticReflectionParser()->getReflectionClass();
     }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getDocComment()
     {
         return $this->getStaticReflectionParser()->getDocComment('property', $this->propertyName);
     }
+
+    /**
+     * @return array
+     */
     public function getUseStatements()
     {
         return $this->getStaticReflectionParser()->getUseStatements();
     }
-    public static function export ($class, $name, $return = false) { throw new ReflectionException('Method not implemented'); }
-    public function getModifiers() { throw new ReflectionException('Method not implemented'); }
-    public function getValue($object = NULL) { throw new ReflectionException('Method not implemented'); }
-    public function isDefault() { throw new ReflectionException('Method not implemented'); }
-    public function isPrivate() { throw new ReflectionException('Method not implemented'); }
-    public function isProtected() { throw new ReflectionException('Method not implemented'); }
-    public function isPublic() { throw new ReflectionException('Method not implemented'); }
-    public function isStatic() { throw new ReflectionException('Method not implemented'); }
-    public function setAccessible ($accessible) { throw new ReflectionException('Method not implemented'); }
-    public function setValue ($object, $value = NULL) { throw new ReflectionException('Method not implemented'); }
-    public function __toString() { throw new ReflectionException('Method not implemented'); }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function export ($class, $name, $return = false)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getModifiers()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getValue($object = null)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isDefault()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPrivate()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isProtected()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPublic()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isStatic()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setAccessible ($accessible)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setValue ($object, $value = null)
+    {
+        throw new ReflectionException('Method not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString()
+    {
+        throw new ReflectionException('Method not implemented');
+    }
 }

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -31,9 +31,10 @@ use Doctrine\Common\Persistence\Proxy;
 class ClassUtils
 {
     /**
-     * Get the real class name of a class name that could be a proxy.
+     * Gets the real class name of a class name that could be a proxy.
      *
-     * @param string
+     * @param string $class
+     *
      * @return string
      */
     public static function getRealClass($class)
@@ -46,9 +47,10 @@ class ClassUtils
     }
 
     /**
-     * Get the real class name of an object (even if its a proxy)
+     * Gets the real class name of an object (even if its a proxy).
      *
-     * @param object
+     * @param object $object
+     *
      * @return string
      */
     public static function getClass($object)
@@ -57,9 +59,10 @@ class ClassUtils
     }
 
     /**
-     * Get the real parent class name of a class or object
+     * Gets the real parent class name of a class or object.
      *
-     * @param string
+     * @param string $className
+     *
      * @return string
      */
     public static function getParentClass($className)
@@ -68,9 +71,10 @@ class ClassUtils
     }
 
     /**
-     * Create a new reflection class
+     * Creates a new reflection class.
      *
-     * @param string
+     * @param string $class
+     *
      * @return \ReflectionClass
      */
     public static function newReflectionClass($class)
@@ -79,9 +83,10 @@ class ClassUtils
     }
 
     /**
-     * Create a new reflection object
+     * Creates a new reflection object.
      *
-     * @param object
+     * @param object $object
+     *
      * @return \ReflectionObject
      */
     public static function newReflectionObject($object)
@@ -90,10 +95,11 @@ class ClassUtils
     }
 
     /**
-     * Given a class name and a proxy namespace return the proxy name.
+     * Given a class name and a proxy namespace returns the proxy name.
      *
      * @param string $className
      * @param string $proxyNamespace
+     *
      * @return string
      */
     public static function generateProxyClassName($className, $proxyNamespace)

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -19,32 +19,35 @@
 
 namespace Doctrine\Common\Util;
 
+use Doctrine\Common\Persistence\Proxy;
+
 /**
  * Static class containing most used debug methods.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
- * @author  Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
+ * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
  */
 final class Debug
 {
     /**
-     * Private constructor (prevents from instantiation)
-     *
+     * Private constructor (prevents instantiation).
      */
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * Prints a dump of the public, protected and private properties of $var.
      *
      * @link http://xdebug.org/
-     * @param mixed $var
-     * @param integer $maxDepth Maximum nesting level for object properties
-     * @param boolean $stripTags Flag that indicate if output should strip HTML tags
+     *
+     * @param mixed   $var       The variable to dump.
+     * @param integer $maxDepth  The maximum nesting level for object properties.
+     * @param boolean $stripTags Whether output should strip HTML tags.
      */
     public static function dump($var, $maxDepth = 2, $stripTags = true)
     {
@@ -67,10 +70,9 @@ final class Debug
     }
 
     /**
-     * Export
-     *
      * @param mixed $var
-     * @param int $maxDepth
+     * @param int   $maxDepth
+     *
      * @return mixed
      */
     public static function export($var, $maxDepth)
@@ -99,7 +101,7 @@ final class Debug
                     $reflClass = ClassUtils::newReflectionObject($var);
                     $return->__CLASS__ = ClassUtils::getClass($var);
 
-                    if ($var instanceof \Doctrine\Common\Persistence\Proxy) {
+                    if ($var instanceof Proxy) {
                         $return->__IS_PROXY__ = true;
                         $return->__PROXY_INITIALIZED__ = $var->__isInitialized();
                     }
@@ -127,9 +129,10 @@ final class Debug
     }
 
     /**
-     * Convert to string
+     * Returns a string representation of an object.
      *
      * @param object $obj
+     *
      * @return string
      */
     public static function toString($obj)

--- a/lib/Doctrine/Common/Util/Inflector.php
+++ b/lib/Doctrine/Common/Util/Inflector.php
@@ -22,10 +22,9 @@ namespace Doctrine\Common\Util;
 use Doctrine\Common\Inflector\Inflector as BaseInflector;
 
 /**
- * Doctrine inflector has static methods for inflecting text
+ * Doctrine inflector has static methods for inflecting text.
  *
- * Kept for backwards compatibility reasons, was moved to its
- * own component.
+ * Kept for backwards compatibility reasons, was moved to its own component.
  */
 class Inflector extends BaseInflector
 {

--- a/lib/Doctrine/Common/Version.php
+++ b/lib/Doctrine/Common/Version.php
@@ -20,21 +20,19 @@
 namespace Doctrine\Common;
 
 /**
- * Class to store and retrieve the version of Doctrine
+ * Class to store and retrieve the version of Doctrine.
  *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision$
- * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
- * @author  Jonathan Wage <jonwage@gmail.com>
- * @author  Roman Borschel <roman@code-factory.org>
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author Jonathan Wage <jonwage@gmail.com>
+ * @author Roman Borschel <roman@code-factory.org>
  */
 class Version
 {
     /**
-     * Current Doctrine Version
+     * Current Doctrine Version.
      */
     const VERSION = '2.4.1';
 
@@ -42,8 +40,8 @@ class Version
      * Compares a Doctrine version with the current one.
      *
      * @param string $version Doctrine version to compare.
-     * @return int Returns -1 if older, 0 if it is the same, 1 if version
-     *             passed as argument is newer.
+     *
+     * @return int -1 if older, 0 if it is the same, 1 if version passed as argument is newer.
      */
     public static function compare($version)
     {

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -13,7 +13,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
+ * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
@@ -13,7 +13,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
+ * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
 

--- a/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
@@ -13,7 +13,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
+ * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
 


### PR DESCRIPTION
Documentation fixes, continuing the work done on [ORM](https://github.com/doctrine/doctrine2/pull/528) and [DBAL](https://github.com/doctrine/dbal/pull/243).
- Missing docblocks
- Missing / incorrect `@param` / `@return` / `@throws` annotations
- Missing newlines between annotations
- Incorrect vertical alignment of `@param` annotations
- Incorrect doctrine-project.org links
- SVN leftovers cleanup
- Licensing (LGPL => MIT)
