### PR TITLE
[DCOM-96] Refactor ProxyGenerator, introduce AbstractProxyFactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.3.3
   - 5.3
   - 5.4
+  - 5.5
 
 before_script:
     - composer --prefer-source --dev install

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -19,9 +19,9 @@
 
 namespace Doctrine\Common\Proxy;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Util\ClassUtils;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 /**
@@ -32,9 +32,9 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 abstract class AbstractProxyFactory
 {
     /**
-     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory
      */
-    private $objectManager;
+    private $metadataFactory;
 
     /**
      * @var \Doctrine\Common\Proxy\ProxyGenerator the proxy generator responsible for creating the proxy classes/files.
@@ -47,19 +47,20 @@ abstract class AbstractProxyFactory
     private $autoGenerate;
 
     /**
-     * @var array
+     * @var \Doctrine\Common\Proxy\ProxyDefinition[]
      */
     private $definitions = array();
 
     /**
-     * @param ProxyGenerator $proxyGenerator
-     * @param ObjectManager $objectManager
+     * @param \Doctrine\Common\Proxy\ProxyGenerator                     $proxyGenerator
+     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory $metadataFactory
+     * @param bool                                                      $autoGenerate
      */
-    public function __construct(ProxyGenerator $proxyGenerator, ObjectManager $objectManager, $autoGenerate)
+    public function __construct(ProxyGenerator $proxyGenerator, ClassMetadataFactory $metadataFactory, $autoGenerate)
     {
-        $this->proxyGenerator = $proxyGenerator;
-        $this->objectManager  = $objectManager;
-        $this->autoGenerate   = $autoGenerate;
+        $this->proxyGenerator  = $proxyGenerator;
+        $this->metadataFactory = $metadataFactory;
+        $this->autoGenerate    = $autoGenerate;
     }
 
     /**
@@ -67,13 +68,15 @@ abstract class AbstractProxyFactory
      * the given identifier.
      *
      * @param  string $className
-     * @param  mixed  $identifier
+     * @param  array  $identifier
      *
      * @return \Doctrine\Common\Proxy\Proxy
      */
-    public function getProxy($className, $identifier)
+    public function getProxy($className, array $identifier)
     {
-        $definition = $this->getProxyDefinition($className);
+        $definition = isset($this->definitions[$className])
+            ? $this->definitions[$className]
+            : $this->getProxyDefinition($className);
         $fqcn       = $definition->proxyClassName;
         $proxy      = new $fqcn($definition->initializer, $definition->cloner);
 
@@ -99,7 +102,6 @@ abstract class AbstractProxyFactory
         $generated = 0;
 
         foreach ($classes as $class) {
-            /* @var $class \Doctrine\Common\Persistence\Mapping\ClassMetadata */
             if ($this->skipClass($class)) {
                 continue;
             }
@@ -126,11 +128,13 @@ abstract class AbstractProxyFactory
     public function resetUninitializedProxy(Proxy $proxy)
     {
         if ($proxy->__isInitialized()) {
-            throw InvalidArgumentException::unitializedProxyExpected();
+            throw InvalidArgumentException::unitializedProxyExpected($proxy);
         }
 
         $className  = ClassUtils::getClass($proxy);
-        $definition = $this->getProxyDefinition($className);
+        $definition = isset($this->definitions[$className])
+            ? $this->definitions[$className]
+            : $this->getProxyDefinition($className);
 
         $proxy->__setInitializer($definition->initializer);
         $proxy->__setCloner($definition->cloner);
@@ -145,23 +149,20 @@ abstract class AbstractProxyFactory
      */
     private function getProxyDefinition($className)
     {
-        if ( ! isset($this->definitions[$className])) {
-            $classMetadata = $this->objectManager->getClassMetadata($className);
-            $className     = $classMetadata->getName(); // make sure case-sensitivy is correct
+        $classMetadata = $this->metadataFactory->getMetadataFor($className);
+        $className     = $classMetadata->getName(); // aliases and case sensitivity
 
-            $this->definitions[$className] = $this->createProxyDefinition($className);
+        $this->definitions[$className] = $this->createProxyDefinition($className);
+        $proxyClassName                = $this->definitions[$className]->proxyClassName;
 
-            $proxyClassName = $this->definitions[$className]->proxyClassName;
+        if ( ! class_exists($proxyClassName, false)) {
+            $fileName  = $this->proxyGenerator->getProxyFileName($className);
 
-            if ( ! class_exists($proxyClassName, false)) {
-                $fileName  = $this->proxyGenerator->getProxyFileName($className);
-
-                if ($this->autoGenerate) {
-                    $this->proxyGenerator->generateProxyClass($classMetadata);
-                }
-
-                require $fileName;
+            if ($this->autoGenerate) {
+                $this->proxyGenerator->generateProxyClass($classMetadata);
             }
+
+            require $fileName;
         }
 
         return $this->definitions[$className];

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Common\Proxy\Exception;
 
+use Doctrine\Common\Persistence\Proxy;
 use InvalidArgumentException as BaseInvalidArgumentException;
 
 /**
@@ -67,9 +68,12 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
         return new self('You must configure a proxy namespace');
     }
 
-    public static function unitializedProxyExpected()
+    /**
+     * @return self
+     */
+    public static function unitializedProxyExpected(Proxy $proxy)
     {
-        return new self('Provided proxy must not be initialized.');
+        return new self(sprintf('Provided proxy of type "%s" must not be initialized.', get_class($proxy)));
     }
 
     /**

--- a/lib/Doctrine/Common/Proxy/ProxyDefinition.php
+++ b/lib/Doctrine/Common/Proxy/ProxyDefinition.php
@@ -30,27 +30,31 @@ class ProxyDefinition
      * @var string
      */
     public $proxyClassName;
+
     /**
      * @var array
      */
     public $identifierFields;
+
     /**
-     * @var array
+     * @var \ReflectionProperty[]
      */
     public $reflectionFields;
+
     /**
      * @var callable
      */
     public $initializer;
+
     /**
      * @var callable
      */
     public $cloner;
 
     /**
-     * @param string $proxyClassName
-     * @param array $identifierFields
-     * @param array $reflectionFields
+     * @param string   $proxyClassName
+     * @param array    $identifierFields
+     * @param array    $reflectionFields
      * @param callable $initializer
      * @param callable $cloner
      */

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -260,20 +260,17 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         foreach ($placeholderMatches as $placeholder => $name) {
             $placeholders[$placeholder] = isset($this->placeholders[$name])
                 ? $this->placeholders[$name]
-                : array($this, "generate" . $name);
+                : array($this, 'generate' . $name);
         }
 
-        $placeholders = array_map(function ($value) use ($class) {
-            if (is_callable($value)) {
-                return call_user_func($value, $class);
+        foreach ($placeholders as & $placeholder) {
+            if (is_callable($placeholder)) {
+                $placeholder = call_user_func($placeholder, $class);
             }
+        }
 
-            return $value;
-        }, $placeholders);
-
-        $fileName  = $fileName ?: $this->getProxyFileName($class->getName());
-        $proxyCode = strtr($this->proxyClassTemplate, $placeholders);
-
+        $proxyCode       = strtr($this->proxyClassTemplate, $placeholders);
+        $fileName        = $fileName ?: $this->getProxyFileName($class->getName());
         $parentDirectory = dirname($fileName);
 
         if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0775, true))) {

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -9,45 +9,54 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 {
     public function testGenerateProxyClasses()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-
+        $metadata       = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $proxyGenerator = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $proxyGenerator->expects($this->once())->method('getProxyFileName');
-        $proxyGenerator->expects($this->once())->method('generateProxyClass');
 
-        $manager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('getProxyFileName');
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('generateProxyClass');
 
-        $proxyFactory = $this->getMock(
+        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $proxyFactory    = $this->getMockForAbstractClass(
             'Doctrine\Common\Proxy\AbstractProxyFactory',
-            array('skipClass', 'createProxyDefinition'),
-            array($proxyGenerator, $manager, true)
+            array($proxyGenerator, $metadataFactory, true)
         );
 
-        $proxyFactory->expects($this->any())->method('skipClass')->will($this->returnValue(false));
+        $proxyFactory
+            ->expects($this->any())
+            ->method('skipClass')
+            ->will($this->returnValue(false));
 
         $generated = $proxyFactory->generateProxyClasses(array($metadata), sys_get_temp_dir());
 
-        $this->assertEquals(1, $generated, "One proxy was generated.");
+        $this->assertEquals(1, $generated, 'One proxy was generated');
     }
 
     public function testGetProxy()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
+        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
+        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
 
-        $proxy = $this->getMock('Doctrine\Common\Proxy\Proxy');
-        $definition = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->will($this->returnValue($metadata));
 
-        $proxyGenerator = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $manager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
-        $manager->expects($this->once())->method('getClassMetadata')->will($this->returnValue($metadata));
-
-        $proxyFactory = $this->getMock(
+        $proxyFactory = $this->getMockForAbstractClass(
             'Doctrine\Common\Proxy\AbstractProxyFactory',
-            array('skipClass', 'createProxyDefinition'),
-            array($proxyGenerator, $manager, true)
+            array($proxyGenerator, $metadataFactory, true)
         );
 
-        $proxyFactory->expects($this->any())->method('createProxyDefinition')->will($this->returnValue($definition));
+        $proxyFactory
+            ->expects($this->any())
+            ->method('createProxyDefinition')
+            ->will($this->returnValue($definition));
 
         $generatedProxy = $proxyFactory->getProxy('Class', array('id' => 1));
 
@@ -56,25 +65,52 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
     public function testResetUnitializedProxy()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $proxy = $this->getMock('Doctrine\Common\Proxy\Proxy');
-        $definition = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
+        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
+        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
+        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
 
-        $proxyGenerator = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $manager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
-        $manager->expects($this->once())->method('getClassMetadata')->will($this->returnValue($metadata));
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->will($this->returnValue($metadata));
 
-        $proxyFactory = $this->getMock(
+        $proxyFactory = $this->getMockForAbstractClass(
             'Doctrine\Common\Proxy\AbstractProxyFactory',
-            array('skipClass', 'createProxyDefinition'),
-            array($proxyGenerator, $manager, true)
+            array($proxyGenerator, $metadataFactory, true)
         );
 
-        $proxyFactory->expects($this->any())->method('createProxyDefinition')->will($this->returnValue($definition));
+        $proxyFactory
+            ->expects($this->any())
+            ->method('createProxyDefinition')
+            ->will($this->returnValue($definition));
 
-        $proxy->expects($this->once())->method('__isInitialized')->will($this->returnValue(false));
-        $proxy->expects($this->once())->method('__setInitializer');
-        $proxy->expects($this->once())->method('__setCloner');
+        $proxy
+            ->expects($this->once())
+            ->method('__isInitialized')
+            ->will($this->returnValue(false));
+        $proxy
+            ->expects($this->once())
+            ->method('__setInitializer');
+        $proxy
+            ->expects($this->once())
+            ->method('__setCloner');
+
+        $proxyFactory->resetUninitializedProxy($proxy);
+    }
+
+    public function testDisallowsResettingInitializedProxy()
+    {
+        $proxyFactory = $this->getMockForAbstractClass('Doctrine\Common\Proxy\AbstractProxyFactory',  array(), '', false);
+        $proxy        = $this->getMock('Doctrine\Common\Proxy\Proxy');
+
+        $proxy
+            ->expects($this->any())
+            ->method('__isInitialized')
+            ->will($this->returnValue(true));
+
+        $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');
 
         $proxyFactory->resetUninitializedProxy($proxy);
     }


### PR DESCRIPTION
This PR does two things:
- ProxyGenerator is refactored to use lazy templating.
- AbstractProxyFactory is introduced to move more logic into Common
