### PR TITLE
Refactored AnnotationDriver to handle only required classes

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -173,6 +173,7 @@ abstract class AnnotationDriver implements MappingDriver
 
         $classes = array();
         $includedFiles = array();
+        $beforeDeclaration = get_declared_classes();
 
         foreach ($this->paths as $path) {
             if ( ! is_dir($path)) {
@@ -197,12 +198,13 @@ abstract class AnnotationDriver implements MappingDriver
             }
         }
 
-        $declared = get_declared_classes();
+        $afterDeclaration = get_declared_classes();
+        $declared = array_diff($afterDeclaration, $beforeDeclaration);
 
         foreach ($declared as $className) {
             $rc = new \ReflectionClass($className);
             $sourceFile = $rc->getFileName();
-            if (in_array($sourceFile, $includedFiles) && ! $this->isTransient($className)) {
+            if (in_array($sourceFile, $includedFiles) && !$this->isTransient($className)) {
                 $classes[] = $className;
             }
         }


### PR DESCRIPTION
Whilst debugging an issue I was having I found that the AnnotationDriver uses get_declared_classes() and iterates over the result to identify classes that should be handled.

This seems like a ridiculous overhead especially as it then instantiated a ReflectionClass for each declared class. As an example my current project was iterating over 522 items when it needed to only handle 6.

I've kept the alterations to a minimum but it now takes a snapshot of the declared classes before and after the require for the files and then uses array_diff to get only the classes we are targeting.
