### PR TITLE
Add a new method to use a filter before extracting the metadata

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -116,6 +116,29 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     }
 
     /**
+     * Forces the factory to load the metadata of all classes known to the underlying
+     * mapping driver and where the name looks like one of the pattern given.
+     *
+     * @param array $filter
+     * @return array The ClassMetadat instances of all mapped classes.
+     */
+    function getAllFilteredMetadata(array $filter)
+    {
+        if ( ! $this->initialized) {
+            $this->initialize();
+        }
+
+        $driver = $this->getDriver();
+        $metadata = array();
+        foreach ($driver->getFilteredClassNames($filter) as $className) {
+            $metadata[] = $this->getMetadataFor($className);
+        }
+
+        return $metadata;
+    }
+
+
+    /**
      * Lazy initialization of this stuff, especially the metadata driver,
      * since these are not needed at all when a metadata cache is active.
      *


### PR DESCRIPTION
Hi

I have notice that, when you use the doctrine:mapping:convert and doctrine:mapping:import command in symfony, the filter is added after all the metadata are extracting from the database.
In this case, when you have a table with no primary key for example, you cannot extract the mapping for only one entity.

I have also made a pull-request into the doctrineBundle and doctrine2 to fix this issue.
https://github.com/doctrine/DoctrineBundle/pull/161
https://github.com/doctrine/doctrine2/pull/603

What are your thought about my issue?
