### PR TITLE
Allow empty arrays in annotations

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -929,6 +929,10 @@ final class DocParser
         $array = $values = array();
 
         $this->match(DocLexer::T_OPEN_CURLY_BRACES);
+        if ($this->lexer->isNextToken(DocLexer::T_CLOSE_CURLY_BRACES)) {
+            $this->match(DocLexer::T_CLOSE_CURLY_BRACES);
+            return $array;
+        }
         $values[] = $this->ArrayEntry();
 
         while ($this->lexer->isNextToken(DocLexer::T_COMMA)) {


### PR DESCRIPTION
an empty array so far is impossible as it either results in a parse error if you just do the obvious {} or if you try {""} it will create an empty entry which in turn will cause errors depending on the annotation.
