### PR TITLE
RuntimeReflectionService - throw exception instead of php warning

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -83,4 +83,14 @@ class MappingException extends \Exception
     {
         return new self("Invalid mapping file '$fileName' for class '$entityName'.");
     }
+
+    /**
+     * @param string $className
+     *
+     * @return \Doctrine\Common\Persistence\Mapping\MappingException
+     */
+    public static function nonExistingClass($className)
+    {
+        return new self("Class '$className' does not exists");
+    }
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -33,6 +33,9 @@ interface ReflectionService
      * Return an array of the parent classes (not interfaces) for the given class.
      *
      * @param string $class
+     *
+     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     *
      * @return array
      */
     function getParentClasses($class);

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -22,6 +22,7 @@ namespace Doctrine\Common\Persistence\Mapping;
 use ReflectionClass;
 use ReflectionProperty;
 use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
  * PHP Runtime Reflection Service
@@ -35,6 +36,10 @@ class RuntimeReflectionService implements ReflectionService
      */
     public function getParentClasses($class)
     {
+        if ( ! class_exists($class)) {
+            throw MappingException::nonExistingClass($class);
+        }
+
         return class_parents($class);
     }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -39,6 +39,12 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertTrue($this->cmf->hasMetadataFor('stdClass'));
     }
 
+    public function testGetMetadataForAbsentClass()
+    {
+        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->cmf->getMetadataFor(__NAMESPACE__ . '\AbsentClass');
+    }
+
     public function testGetParentMetadata()
     {
         $metadata = $this->cmf->getMetadataFor(__NAMESPACE__ . '\ChildEntity');

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -54,6 +54,12 @@ class RuntimeReflectionServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(count($classes) >= 1, "The test class ".__CLASS__." should have at least one parent.");
     }
 
+    public function testGetParentClassesForAbsentClass()
+    {
+        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->reflectionService->getParentClasses(__NAMESPACE__ . '\AbsentClass');
+    }
+
     public function testGetReflectionClass()
     {
         $class = $this->reflectionService->getClass(__CLASS__);


### PR DESCRIPTION
At RuntimeReflectionService throw exception getting parents class instead of php warning

Related to https://github.com/doctrine/common/pull/274
