### PR TITLE
graceful classloader

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -158,11 +158,16 @@ class ClassLoader
             return false;
         }
 
-        require ($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
+        $path = ($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
                . str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className)
                . $this->fileExtension;
 
-        return true;
+        if (file_exists($path)) {
+            require $path;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Right now if the Doctrine class loader is asked to load a class that it is actually not responsible for (because my class loader is later in the list) it fails with a fatal error. This patch only requires a file if it exists. Other class loaders in the list can still try to load the class.
