### PR TITLE
[DCOM-194] Fixed proxying magic getter with reference

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -400,12 +400,25 @@ EOT;
         }
 
         $inheritDoc = $hasParentGet ? '{@inheritDoc}' : '';
+
+
         $magicGet = <<<EOT
     /**
      * $inheritDoc
      * @param string \$name
      */
-    public function __get(\$name)
+    public function
+EOT;
+
+        $magicGet .= ' ';
+
+
+        if ($hasParentGet && $class->getReflectionClass()->getMethod('__get')->returnsReference()) {
+            $magicGet .= '&';
+        }
+
+$magicGet .= <<<EOT
+__get(\$name)
     {
 
 EOT;

--- a/tests/Doctrine/Tests/Common/Proxy/MagicGetByRefClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicGetByRefClass.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class MagicGetByRefClass
+{
+    public $valueField;
+
+    /**
+     * @param $name
+     *
+     * @return string
+     * @throws \BadMethodCallException
+     */
+    public function &__get($name)
+    {
+        if ($name === 'value') {
+            return $this->valueField;
+        }
+
+        return 'not defined';
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -94,6 +94,29 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
         $this->assertSame(3, $counter);
     }
 
+    public function testInheritedMagicGetByRef()
+    {
+        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicGetByRefClass');
+        $proxy          = new $proxyClassName();
+
+        $proxy->valueField = 123;
+
+        $this->assertSame(123, $proxy->valueField);
+        $this->assertSame(123, $proxy->value);
+
+        $proxy->valueField = array(1, 2);
+
+        $this->assertSame(1, $proxy->value[0]);
+        $this->assertSame(2, $proxy->value[1]);
+
+        $proxy->value[0] = 3;
+        $proxy->value[2] = 1;
+
+        $this->assertSame(3, $proxy->value[0]);
+        $this->assertSame(2, $proxy->value[1]);
+        $this->assertSame(1, $proxy->value[2]);
+    }
+
     public function testInheritedMagicSet()
     {
         $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicSetClass');


### PR DESCRIPTION
This is a proposal for a fix for [DCOM-194](http://doctrine-project.org/jira/browse/DCOM-194) (and GH issue #276). This issue is important for us to be solved before 2.4.0 is out, since the base object class of Nette Framework, Nette\Object, uses this behavior, see https://github.com/nette/nette/blob/04e4e4b3ee36551fe99e63f91d9a839f7edc72ee/Nette/common/Object.php#L124-133.

(By the way, your Travis environment seems to be broken.)
