### PR TITLE
Fixed html_errors overwriting

### DIFF
--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -51,7 +51,11 @@ final class Debug
      */
     public static function dump($var, $maxDepth = 2, $stripTags = true)
     {
-        ini_set('html_errors', 'On');
+        $html = ini_get('html_errors');
+
+        if ($html !== true) {
+            ini_set('html_errors', true);
+        }
 
         if (extension_loaded('xdebug')) {
             ini_set('xdebug.var_display_max_depth', $maxDepth);
@@ -66,7 +70,7 @@ final class Debug
 
         echo ($stripTags ? strip_tags(html_entity_decode($dump)) : $dump);
 
-        ini_set('html_errors', 'Off');
+        ini_set('html_errors', $html);
     }
 
     /**


### PR DESCRIPTION
html_errors configuration option is being overwritten instead of  switched on temporarily.
Especially annoying when using xdebug extension which relies on html_errors

> By default Xdebug overloads var_dump() with its own improved version for displaying variables when the html_errors php.ini setting is set to 1.
