### PR TITLE
Patch to support entity's static property.

### DIFF
--- a/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
@@ -44,13 +44,17 @@ class RuntimePublicReflectionProperty extends ReflectionProperty
         if ($object instanceof Proxy && ! $object->__isInitialized()) {
             $originalInitializer = $object->__getInitializer();
             $object->__setInitializer(null);
-            $val = isset($object->$name) ? $object->$name : null;
+            $val = null;
+            if(property_exists($object, $name)) {
+                $rftp = new \ReflectionProperty($object, $name);
+                $val = $rftp->getValue();
+            }
             $object->__setInitializer($originalInitializer);
 
             return $val;
         }
 
-        return isset($object->$name) ? parent::getValue($object) : null;
+        return property_exists($object, $name) ? parent::getValue($object) : null;
     }
 
     /**


### PR DESCRIPTION
Entity contains association mapping have trouble to debug with dumping object (entity) because association field will invoke proxy entity, in additional the association field can make as static and static can solve in this case. This patch make to support static member of the fields.

This pull to review.
