### PR TITLE
Silence E_NOTICE warning: "Undefined index".

### DIFF
--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -21,6 +21,7 @@ namespace Doctrine\Common\Proxy;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
@@ -108,6 +109,8 @@ abstract class AbstractProxyFactory
      * @param  array  $identifier
      *
      * @return \Doctrine\Common\Proxy\Proxy
+     *
+     * @throws \Doctrine\Common\Proxy\Exception\OutOfBoundsException
      */
     public function getProxy($className, array $identifier)
     {
@@ -118,6 +121,10 @@ abstract class AbstractProxyFactory
         $proxy      = new $fqcn($definition->initializer, $definition->cloner);
 
         foreach ($definition->identifierFields as $idField) {
+            if (! isset($identifier[$idField])) {
+                throw OutOfBoundsException::missingPrimaryKeyValue($className, $idField);
+            }
+
             $definition->reflectionFields[$idField]->setValue($proxy, $identifier[$idField]);
         }
 

--- a/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Proxy\Exception;
+
+use Doctrine\Common\Persistence\Proxy;
+use OutOfBoundsException as BaseOutOfBoundsException;
+
+/**
+ * Proxy Invalid Argument Exception.
+ *
+ * @link   www.doctrine-project.org
+ * @author Fredrik Wendel <fredrik_w@users.sourceforge.net>
+ */
+class OutOfBoundsException extends BaseOutOfBoundsException implements ProxyException
+{
+    /**
+     * @param string $className
+     * @param string $idField
+     *
+     * @return self
+     */
+    public static function missingPrimaryKeyValue($className, $idField)
+    {
+        return new self(sprintf("Missing value for primary key %s on %s", $idField, $className));
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -114,5 +114,33 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
         $proxyFactory->resetUninitializedProxy($proxy);
     }
+
+    public function testMissingPrimaryKeyValue()
+    {
+        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $definition      = new ProxyDefinition(get_class($proxy), array('missingKey'), array(), null, null);
+        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
+        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->will($this->returnValue($metadata));
+
+        $proxyFactory = $this->getMockForAbstractClass(
+            'Doctrine\Common\Proxy\AbstractProxyFactory',
+            array($proxyGenerator, $metadataFactory, true)
+        );
+
+        $proxyFactory
+            ->expects($this->any())
+            ->method('createProxyDefinition')
+            ->will($this->returnValue($definition));
+
+        $this->setExpectedException('\OutOfBoundsException');
+
+        $generatedProxy = $proxyFactory->getProxy('Class', array());
+    }
 }
 


### PR DESCRIPTION
Running PHP with error reporting on for E_NOTICE this bit me. Fix is simple and straightforward, check if key is defined and use that value if so, otherwise use null.
