### PR TITLE
Allow root namespaces for Entities

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -99,7 +99,7 @@ class MappingDriverChain implements MappingDriver
     {
         /* @var $driver MappingDriver */
         foreach ($this->drivers as $namespace => $driver) {
-            if (strpos($className, $namespace) === 0) {
+            if (strpos($className, $namespace) === 0 || $namespace === "\\") {
                 $driver->loadMetadataForClass($className, $metadata);
                 return;
             }


### PR DESCRIPTION
Allow root namespaces for entities to be "valid" since a prefix in symfony2 cannot be empty.
