### PR TITLE
fix hasPublicMethod implementations for abstract functions in ReflectionService

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -92,6 +92,12 @@ class RuntimeReflectionService implements ReflectionService
      */
     public function hasPublicMethod($class, $method)
     {
-        return method_exists($class, $method) && is_callable(array($class, $method));
+        $reflectionClass = new ReflectionClass($class);
+
+        if ( ! $reflectionClass->hasMethod($method)) {
+            return false;
+        }
+
+        return $reflectionClass->getMethod($method)->isPublic();
     }
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
+use ReflectionClass;
+
 /**
  * PHP Runtime Reflection Service.
  *
@@ -78,6 +80,12 @@ class StaticReflectionService implements ReflectionService
      */
     public function hasPublicMethod($class, $method)
     {
-        return method_exists($class, $method) && is_callable(array($class, $method));
+        $reflectionClass = new ReflectionClass($class);
+
+        if ( ! $reflectionClass->hasMethod($method)) {
+            return false;
+        }
+
+        return $reflectionClass->getMethod($method)->isPublic();
     }
 }


### PR DESCRIPTION
Since php >=5.4.8 the method is_callable returns false for
abstract functions. As the documentation for the
hasPublicMethod method states that it is sufficient
for the class to have a public method with that name it’s
not necessary to check whether the method is abstract or not.

The mentioned method is currently used in the doctrine2-orm
project where it helps with the validation of lifecycle callbacks.
As lifecycle callbacks must be callable but considering the fact
that abstract functions can only be used in abstract classes it
should be OK to rely on php for the assumption that the method
is in fact not abstract when it is called because php would be
unable to instantiate abstract classes.

this fixes DDC-2708.

there are currently no tests in this pull request. i’d volunteer for writing one or two (one for common, one for orm) but i would like to talk to someone first :).
