### PR TITLE
fix the optimize regex and adapt the tests to actually test classAnnotat...

### DIFF
--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -131,8 +131,8 @@ class StaticReflectionParser implements ReflectionProviderInterface
         $this->parsed = true;
         $contents = file_get_contents($fileName);
         if ($this->classAnnotationOptimize) {
-            if (preg_match("/(\A.*)^\s+(abstract|final)?\s+class\s+{$this->shortClassName}\s+{/sm", $contents, $matches)) {
-                $contents = $matches[1];
+            if (preg_match("/\A.*^\s*((abstract|final)\s+)?class\s+{$this->shortClassName}\s+/sm", $contents, $matches)) {
+                $contents = $matches[0];
             }
         }
         $tokenParser = new TokenParser($contents);

--- a/tests/Doctrine/Tests/Common/Reflection/DeeperNamespaceParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/DeeperNamespaceParent.php
@@ -2,6 +2,6 @@
 
 namespace Doctrine\Tests\Common\Reflection;
 
-class SameNamespaceParent extends Dummies\NoParent
+class DeeperNamespaceParent extends Dummies\NoParent
 {
 }

--- a/tests/Doctrine/Tests/Common/Reflection/ExampleAnnotationClass.php
+++ b/tests/Doctrine/Tests/Common/Reflection/ExampleAnnotationClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Common\Reflection;
+
+use Doctrine\Common\Annotations\Annotation;
+
+/**
+ * @Annotation(
+ *   key = "value"
+ * )
+ */
+class ExampleAnnotationClass {
+
+} 

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -9,45 +9,75 @@ use Doctrine\Common\Reflection\Psr0FindFile;
 class StaticReflectionParserTest extends DoctrineTestCase
 {
     /**
-     * @dataProvider classAnnotationOptimize
+     * @dataProvider parentClassData
      *
      * @param bool $classAnnotationOptimize
+     * @param string $parsedClassName
+     * @param string $expectedClassName
      *
      * @return void
      */
-    public function testParentClass($classAnnotationOptimize)
+    public function testParentClass($classAnnotationOptimize, $parsedClassName, $expectedClassName)
     {
+        // If classed annotation optimization is enabled the properties tested
+        // below cannot be found.
+        if ($classAnnotationOptimize) {
+            $this->setExpectedException('ReflectionException');
+        }
+
         $testsRoot = substr(__DIR__, 0, -strlen(__NAMESPACE__) - 1);
         $paths = array(
             'Doctrine\\Tests' => array($testsRoot),
         );
+        $staticReflectionParser = new StaticReflectionParser($parsedClassName, new Psr0FindFile($paths), $classAnnotationOptimize);
+        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
+        $this->assertEquals($expectedClassName, $declaringClassName);
+
+    }
+
+    /**
+     * @return array
+     */
+    public function parentClassData()
+    {
+        $data = array();
         $noParentClassName = 'Doctrine\\Tests\\Common\\Reflection\\NoParent';
-        $staticReflectionParser = new StaticReflectionParser($noParentClassName, new Psr0FindFile($paths), $classAnnotationOptimize);
-        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
-        $this->assertEquals($noParentClassName, $declaringClassName);
-
-        $className = 'Doctrine\\Tests\\Common\\Reflection\\FullyClassifiedParent';
-        $staticReflectionParser = new StaticReflectionParser($className, new Psr0FindFile($paths), $classAnnotationOptimize);
-        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
-        $this->assertEquals($noParentClassName, $declaringClassName);
-
-        $className = 'Doctrine\\Tests\\Common\\Reflection\\SameNamespaceParent';
-        $staticReflectionParser = new StaticReflectionParser($className, new Psr0FindFile($paths), $classAnnotationOptimize);
-        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
-        $this->assertEquals($noParentClassName, $declaringClassName);
-
         $dummyParentClassName = 'Doctrine\\Tests\\Common\\Reflection\\Dummies\\NoParent';
+        foreach (array(false, true) as $classAnnotationOptimize) {
+            $data[] = array(
+              $classAnnotationOptimize, $noParentClassName, $noParentClassName,
+            );
+            $data[] = array(
+              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\FullyClassifiedParent', $noParentClassName,
+            );
+            $data[] = array(
+              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\SameNamespaceParent', $noParentClassName,
+            );
+            $data[] = array(
+              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\DeeperNamespaceParent', $dummyParentClassName,
+            );
+            $data[] = array(
+              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\UseParent', $dummyParentClassName,
+            );
+        }
+        return $data;
+    }
 
-        $className = 'Doctrine\\Tests\\Common\\Reflection\\DeeperNamespaceParent';
-        $staticReflectionParser = new StaticReflectionParser($className, new Psr0FindFile($paths), $classAnnotationOptimize);
-        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
-        $this->assertEquals($dummyParentClassName, $declaringClassName);
-
-        $className = 'Doctrine\\Tests\\Common\\Reflection\\UseParent';
-        $staticReflectionParser = new StaticReflectionParser($className, new Psr0FindFile($paths), $classAnnotationOptimize);
-        $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
-        $this->assertEquals($dummyParentClassName, $declaringClassName);
-
+    /**
+     * @dataProvider classAnnotationOptimize
+     */
+    public function testClassAnnotationOptimizedParsing($classAnnotationOptimize) {
+        $testsRoot = substr(__DIR__, 0, -strlen(__NAMESPACE__) - 1);
+        $paths = array(
+          'Doctrine\\Tests' => array($testsRoot),
+        );
+        $staticReflectionParser = new StaticReflectionParser('Doctrine\\Tests\\Common\\Reflection\\ExampleAnnotationClass', new Psr0FindFile($paths), $classAnnotationOptimize);
+        $expectedDocComment = '/**
+ * @Annotation(
+ *   key = "value"
+ * )
+ */';
+        $this->assertEquals($expectedDocComment, $staticReflectionParser->getDocComment('class'));
     }
 
     /**


### PR DESCRIPTION
There has been several problems
- Even we enabled classAnnotationOptimized we expected a different behavior: You cannot parse properties any longer (fixed that by expecting an exception). Therefore moved the test data into a provider so you can check the exception on each of them.
- Once done I realized that DeeperNamespaceParent had the wrong className
- Additional I added a test to check that the regex matched.
#307
