### PR TITLE
Improve UnexpectedValueException error message, add testcase.

### DIFF
--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -33,9 +33,9 @@ class UnexpectedValueException extends BaseUnexpectedValueException implements P
     /**
      * @return self
      */
-    public static function proxyDirectoryNotWritable()
+    public static function proxyDirectoryNotWritable($proxyDirectory)
     {
-        return new self('Your proxy directory must be writable');
+        return new self(sprintf('Your proxy directory: %s must be writable', $proxyDirectory));
     }
 
     /**

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -292,11 +292,11 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         $parentDirectory = dirname($fileName);
 
         if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0775, true))) {
-            throw UnexpectedValueException::proxyDirectoryNotWritable();
+            throw UnexpectedValueException::proxyDirectoryNotWritable($this->proxyDirectory);
         }
 
         if ( ! is_writable($parentDirectory)) {
-            throw UnexpectedValueException::proxyDirectoryNotWritable();
+            throw UnexpectedValueException::proxyDirectoryNotWritable($this->proxyDirectory);
         }
 
         $tmpFileName = $fileName . '.' . uniqid('', true);

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -183,6 +183,23 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         new ProxyGenerator(null, null);
     }
 
+    public function testProxyDirNotWritableThrowsException()
+    {
+        $className = 'Doctrine\Tests\Common\Proxy\StaticPropertyClass';
+        $metadata = $this->createClassMetadata($className, array('id'));
+        $this->setExpectedException('Doctrine\Common\Proxy\Exception\UnexpectedValueException', 'must be writable');
+        $readOnlyDir = __DIR__ . '/readonly';
+        mkdir($readOnlyDir, 0555, true);
+        try {
+          $proxyGenerator = new ProxyGenerator($readOnlyDir, true);
+          $this->generateAndRequire($proxyGenerator, $metadata);
+        } catch(UnexpectedValueException $e){
+          chmod($readOnlyDir, 0777);
+          rmdir($readOnlyDir);
+          throw($e);
+        }
+    }
+
     public function testNoNamespaceThrowsException()
     {
         $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');


### PR DESCRIPTION
UnexpectedValueException::proxyDirectoryNotWritable() provides
information as to which directory was unwritable.

A TestCase is provided for the proxyDirectoryNotWritable() function.
