### PR TITLE
Improve UnexpectedValueException error message

### DIFF
--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -33,9 +33,9 @@ class UnexpectedValueException extends BaseUnexpectedValueException implements P
     /**
      * @return self
      */
-    public static function proxyDirectoryNotWritable()
+    public static function proxyDirectoryNotWritable($proxyDirectory)
     {
-        return new self('Your proxy directory must be writable');
+        return new self(sprintf('Your proxy directory "%s" must be writable', $proxyDirectory));
     }
 
     /**

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -292,11 +292,11 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         $parentDirectory = dirname($fileName);
 
         if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0775, true))) {
-            throw UnexpectedValueException::proxyDirectoryNotWritable();
+            throw UnexpectedValueException::proxyDirectoryNotWritable($this->proxyDirectory);
         }
 
         if ( ! is_writable($parentDirectory)) {
-            throw UnexpectedValueException::proxyDirectoryNotWritable();
+            throw UnexpectedValueException::proxyDirectoryNotWritable($this->proxyDirectory);
         }
 
         $tmpFileName = $fileName . '.' . uniqid('', true);


### PR DESCRIPTION
UnexpectedValueException::proxyDirectoryNotWritable() provides
information as to which directory was unwritable.
