### PR TITLE
Implemented the suggested fix of DCOM-204

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -192,7 +192,10 @@ abstract class AnnotationDriver implements MappingDriver
             );
 
             foreach ($iterator as $file) {
-                $sourceFile = realpath($file[0]);
+                $sourceFile = str_replace('\\', '/', $file[0]);
+                if (!preg_match('#^phar://#i', $sourceFile)) {
+                    $sourceFile = realpath($sourceFile);
+                }
 
                 require_once $sourceFile;
 


### PR DESCRIPTION
Johan Groth has reported "AnnotationDriver cannot find classes inside Phar files" (http://www.doctrine-project.org/jira/browse/DCOM-204) and suggested this fix. 
