### PR TITLE
2.4 do not serialize static properties

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -619,6 +619,10 @@ EOT;
 
         /* @var $prop \ReflectionProperty */
         foreach ($class->getReflectionClass()->getProperties() as $prop) {
+            if ($prop->isStatic()) {
+                continue;
+            }
+
             $allProperties[] = $prop->isPrivate()
                 ? "\0" . $prop->getDeclaringClass()->getName() . "\0" . $prop->getName()
                 : $prop->getName();


### PR DESCRIPTION
The master branch does not serialize static properties, 2.4 does.

When we upgraded to Doctrine ORM 2.4 the proxy generation was moved to Doctrine Common (I think) and subsequently all the proxy entities which has static properties caused errors on __sleep
