### PR TITLE
Create proxy cache dir with 777

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -291,7 +291,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
 
         $parentDirectory = dirname($fileName);
 
-        if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0775, true))) {
+        if ( ! is_dir($parentDirectory) && (false === @mkdir($parentDirectory, 0777, true))) {
             throw UnexpectedValueException::proxyDirectoryNotWritable($this->proxyDirectory);
         }
 


### PR DESCRIPTION
All other directories in Doctrine use 777 but this one. This causes access problems when clearing the cache when the first request was done via a webbrowser and the files are owned by apache/www-data. Now a console / deployment user can not clear the cache any longer. The problem also works the other way around.
