### PR TITLE
0.25 second wait for file caching

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -302,6 +302,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         $tmpFileName = $fileName . '.' . uniqid('', true);
 
         file_put_contents($tmpFileName, $proxyCode);
+        usleep(250000);
         rename($tmpFileName, $fileName);
     }
 


### PR DESCRIPTION
To deal with the issue of windows caching files when you wirte to them then close the handle I have added a 0.25 second pause between closing and moving the file. This is so that windows finishes handling writting to the file before trying to move it
