### PR TITLE
Change tracking interface for object values

### DIFF
--- a/lib/Doctrine/Common/ObjectChangeTracking.php
+++ b/lib/Doctrine/Common/ObjectChangeTracking.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common;
+
+/**
+ * Implement to allow the UnitOfWork to track changes for object values.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.0
+ * @author Andrei Liutec <andrei@liutec.ro>
+ */
+interface ObjectChangeTracking
+{
+    /**
+     * Set the dirty state.
+     *
+     * @param bool $dirty The object's new dirty state.
+     * @return $this
+     */
+    function setDirty($dirty = true);
+
+    /**
+     * Get the dirty state.
+     *
+     * @return bool $dirty The object's dirty state.
+     */
+    function isDirty();
+}


### PR DESCRIPTION
Currently, aside from the "NOTIFY" change tracking policy which takes long to implement on pre-existing entities, there is no atomic mechanism to allow tracking changes that take place inside de-serialized values of the DBAL\ObjectType once the entity has been loaded.

The UnitOfWork uses PHP's identity comparison operator (===) to compute the changed sets which yelds no change result when comparing pointers to the same object instance.

By implementing this interface, a serialized object may manage it's own dirty state and ensure the new values are persisted without affecting the entity's current change tracking policy.

The corresponding pull request on doctrine2 changes the following in Doctrine\ORM\UnitOfWork.php:
// skip if value haven't changed
if ($orgValue === $actualValue) {
    continue;
}

into:

// skip if value haven't changed
if (($orgValue === $actualValue) && ( ! ($actualValue instanceof ObjectChangeTracking) || ( ! $actualValue->isDirty()))) {
    continue;
}
