### PR TITLE
Class metadata loading fallback hook

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -21,6 +21,7 @@ namespace Doctrine\Common\Persistence\Mapping;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Util\ClassUtils;
+use ReflectionException;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
@@ -50,7 +51,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     private $cacheDriver;
 
     /**
-     * @var array
+     * @var ClassMetadata[]
      */
     private $loadedMetadata = array();
 
@@ -89,7 +90,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * Returns an array of all the loaded metadata currently in memory.
      *
-     * @return array
+     * @return ClassMetadata[]
      */
     public function getLoadedMetadata()
     {
@@ -178,7 +179,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @param string $className The name of the class.
      *
-     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
+     * @return ClassMetadata
+     *
+     * @throws ReflectionException
+     * @throws MappingException
      */
     public function getMetadataFor($className)
     {
@@ -186,39 +190,47 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             return $this->loadedMetadata[$className];
         }
 
-        $realClassName = $className;
-
         // Check for namespace alias
         if (strpos($className, ':') !== false) {
             list($namespaceAlias, $simpleClassName) = explode(':', $className);
+
             $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         } else {
-            $realClassName = ClassUtils::getRealClass($realClassName);
+            $realClassName = ClassUtils::getRealClass($className);
         }
 
         if (isset($this->loadedMetadata[$realClassName])) {
             // We do not have the alias name in the map, include it
-            $this->loadedMetadata[$className] = $this->loadedMetadata[$realClassName];
-
-            return $this->loadedMetadata[$realClassName];
+            return $this->loadedMetadata[$className] = $this->loadedMetadata[$realClassName];
         }
 
-        if ($this->cacheDriver) {
-            if (($cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt)) !== false) {
-                $this->loadedMetadata[$realClassName] = $cached;
-                $this->wakeupReflection($cached, $this->getReflectionService());
-            } else {
-                foreach ($this->loadMetadata($realClassName) as $loadedClassName) {
-                    $this->cacheDriver->save(
-                        $loadedClassName . $this->cacheSalt, $this->loadedMetadata[$loadedClassName], null
-                    );
+        $loadingException = null;
+
+        try {
+            if ($this->cacheDriver) {
+                if (($cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt)) !== false) {
+                    $this->loadedMetadata[$realClassName] = $cached;
+
+                    $this->wakeupReflection($cached, $this->getReflectionService());
+                } else {
+                    foreach ($this->loadMetadata($realClassName) as $loadedClassName) {
+                        $this->cacheDriver->save(
+                            $loadedClassName . $this->cacheSalt,
+                            $this->loadedMetadata[$loadedClassName],
+                            null
+                        );
+                    }
                 }
+            } else {
+                $this->loadMetadata($realClassName);
             }
-        } else {
-            $this->loadMetadata($realClassName);
+        } catch (MappingException $loadingException) {
+            if (! $this->loadedMetadata[$realClassName] = $this->onNotFoundMetadata($realClassName)) {
+                throw $loadingException;
+            }
         }
 
-        if ($className != $realClassName) {
+        if ($className !== $realClassName) {
             // We do not have the alias name in the map, include it
             $this->loadedMetadata[$className] = $this->loadedMetadata[$realClassName];
         }
@@ -332,6 +344,20 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         }
 
         return $loaded;
+    }
+
+    /**
+     * Provides a fallback hook for loading metadata when loading failed due to reflection/mapping exceptions
+     *
+     * Override this method to implement a fallback strategy for failed metadata loading
+     *
+     * @param string $className
+     *
+     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata|null
+     */
+    protected function onNotFoundMetadata($className)
+    {
+        return null;
     }
 
     /**

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -30,7 +30,7 @@ class MappingException extends \Exception
      * @param string $className
      * @param array  $namespaces
      *
-     * @return MappingException
+     * @return self
      */
     public static function classNotFoundInNamespaces($className, $namespaces)
     {
@@ -39,7 +39,7 @@ class MappingException extends \Exception
     }
 
     /**
-     * @return MappingException
+     * @return self
      */
     public static function pathRequired()
     {
@@ -50,7 +50,7 @@ class MappingException extends \Exception
     /**
      * @param string|null $path
      *
-     * @return MappingException
+     * @return self
      */
     public static function fileMappingDriversRequireConfiguredDirectoryPath($path = null)
     {
@@ -68,7 +68,7 @@ class MappingException extends \Exception
      * @param string $entityName
      * @param string $fileName
      *
-     * @return MappingException
+     * @return self
      */
     public static function mappingFileNotFound($entityName, $fileName)
     {
@@ -79,7 +79,7 @@ class MappingException extends \Exception
      * @param string $entityName
      * @param string $fileName
      *
-     * @return MappingException
+     * @return self
      */
     public static function invalidMappingFile($entityName, $fileName)
     {
@@ -89,7 +89,7 @@ class MappingException extends \Exception
     /**
      * @param string $className
      *
-     * @return \Doctrine\Common\Persistence\Mapping\MappingException
+     * @return self
      */
     public static function nonExistingClass($className)
     {

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -78,10 +78,36 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
     public function testGetAliasedMetadata()
     {
-        $loadedMetadata = $this->cmf->getMetadataFor('prefix:ChildEntity');
+        $this->cmf->getMetadataFor('prefix:ChildEntity');
 
         $this->assertTrue($this->cmf->hasMetadataFor(__NAMESPACE__ . '\ChildEntity'));
         $this->assertTrue($this->cmf->hasMetadataFor('prefix:ChildEntity'));
+    }
+
+    public function testWillFallbackOnNotLoadedMetadata()
+    {
+        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+
+        $this->cmf->fallbackCallback = function () use ($classMetadata) {
+            return $classMetadata;
+        };
+
+        $this->cmf->metadata = null;
+
+        $this->assertSame($classMetadata, $this->cmf->getMetadataFor('Foo'));
+    }
+
+    public function testWillFailOnFallbackFailureWithNotLoadedMetadata()
+    {
+        $this->cmf->fallbackCallback = function () {
+            return null;
+        };
+
+        $this->cmf->metadata = null;
+
+        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+
+        $this->cmf->getMetadataFor('Foo');
     }
 }
 
@@ -89,6 +115,9 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
 {
     public $driver;
     public $metadata;
+
+    /** @var callable|null */
+    public $fallbackCallback;
 
     public function __construct($driver, $metadata)
     {
@@ -131,6 +160,15 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
     protected function isEntity(ClassMetadata $class)
     {
         return true;
+    }
+
+    protected function onNotFoundMetadata($className)
+    {
+        if (! $fallback = $this->fallbackCallback) {
+            return null;
+        }
+
+        return $fallback();
     }
 }
 


### PR DESCRIPTION
Enables loading class metadata when loading failed (in subclasses).

See doctrine/doctrine2#385

Note that I preferred inheritance to avoid having an `EventManager` in here, though it may be a perfectly acceptable dependency in this case, therefore it is up for discussion.