### PR TITLE
new interface for mapped property names interface

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/PropertyNamesAware.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/PropertyNamesAware.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Persistence\Mapping;
+
+/**
+ * Make sure the ClassMetadata can also return the object mapped properties
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ * @author Fábio Carneiro <fahecs@gmail.com>
+ * @license MIT
+ */
+interface PropertyNamesAware
+{
+    /**
+     * Get a list of all mapped fields and associations
+     *
+     * @return array The mapped properties.
+     */
+    public function getMappedPropertyNames();
+}


### PR DESCRIPTION
The current implementation of ClassMetadata does not provide any method to return the mapped property names, and since we can't add it to the current ClassMetadata interface and the DoctrineObject hydrator does not use the implementation, its necessary to have another interface to make sure the new feature of ClassMetadata implemetation is available and keep both the DoctrineObject and ClassMetadata implementation backwards compatible.