### PR TITLE
Fix fatal error when "classexist" tries to call the protected loader

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -236,16 +236,16 @@ class ClassLoader
         }
 
         foreach (spl_autoload_functions() as $loader) {
-            if (is_array($loader) && is_callable($loader)) { // array(???, ???)
+            if (is_array($loader)) { // array(???, ???)
                 if (is_object($loader[0])) {
                     if ($loader[0] instanceof ClassLoader) { // array($obj, 'methodName')
                         if ($loader[0]->canLoadClass($className)) {
                             return true;
                         }
-                    } else if ($loader[0]->{$loader[1]}($className)) {
+                    } else if (is_callable($loader) && $loader[0]->{$loader[1]}($className)) {
                         return true;
                     }
-                } else if ($loader[0]::$loader[1]($className)) { // array('ClassName', 'methodName')
+                } else if (is_callable($loader) && $loader[0]::$loader[1]($className)) { // array('ClassName', 'methodName')
                     return true;
                 }
             } else if ($loader instanceof \Closure) { // function($className) {..}

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -66,8 +66,15 @@ class ClassLoaderTest extends \Doctrine\Tests\DoctrineTestCase
     {
         require_once __DIR__ . '/ClassLoaderTest/ExternalLoader.php';
 
-        \ClassLoaderTest\ExternalLoader::register();
+        // Test static call
+        \ClassLoaderTest\ExternalLoader::registerStatic();
         $this->assertFalse(ClassLoader::classExists('ClassLoaderTest\Class\That\Does\Not\Exist'));
-        \ClassLoaderTest\ExternalLoader::unregister();
+        \ClassLoaderTest\ExternalLoader::unregisterStatic();
+
+        // Test object
+        $loader = new \ClassLoaderTest\ExternalLoader();
+        $loader->register();
+        $this->assertFalse(ClassLoader::classExists('ClassLoaderTest\Class\That\Does\Not\Exist'));
+        $loader->unregister();
     }
 }

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
@@ -4,21 +4,35 @@ namespace ClassLoaderTest;
 
 class ExternalLoader
 {
-    public static function register() {
-        spl_autoload_register(array('ClassLoaderTest\ExternalLoader', 'load'));
+    public static function registerStatic() {
+        spl_autoload_register(array('ClassLoaderTest\ExternalLoader', 'load1'));
         spl_autoload_register(array('ClassLoaderTest\ExternalLoader', 'load2'));
         spl_autoload_register('ClassLoaderTest\ExternalLoader::load3');
     }
 
-    public static function unregister() {
-        spl_autoload_unregister(array('ClassLoaderTest\ExternalLoader', 'load'));
+    public static function unregisterStatic() {
+        spl_autoload_unregister(array('ClassLoaderTest\ExternalLoader', 'load1'));
         spl_autoload_unregister(array('ClassLoaderTest\ExternalLoader', 'load2'));
         spl_autoload_unregister('ClassLoaderTest\ExternalLoader::load3');
     }
 
-    public static function load() {}
+    public static function load1() {}
 
     protected static function load2() {}
 
     protected static function load3() {}
+
+    public function register() {
+        spl_autoload_register(array($this, 'load4'));
+        spl_autoload_register(array($this, 'load5'));
+    }
+
+    public function unregister() {
+        spl_autoload_unregister(array($this, 'load4'));
+        spl_autoload_unregister(array($this, 'load5'));
+    }
+
+    public function load4() {}
+
+    protected function load5() {}
 }


### PR DESCRIPTION
Fix fatal error when `Doctrine\Common\ClassLoader::classExists` tries call the protected loader
