### PR TITLE
[WIP] Improved conversion for aliased classnames

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -190,7 +190,10 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     {
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
-            list($namespaceAlias, $simpleClassName) = explode(':', $class);
+            if (2 < count($classNameAlias = explode(':', $class))) {
+                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $class));
+            }
+            list($namespaceAlias, $simpleClassName) = $classNameAlias;
             $class = $this->getAliasNamespace($namespaceAlias) . '\\' . $simpleClassName;
         }
 

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -190,10 +190,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     {
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
-            if (2 < count($classNameAlias = explode(':', $class))) {
-                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $class));
-            }
-            list($namespaceAlias, $simpleClassName) = $classNameAlias;
+            list($namespaceAlias, $simpleClassName) = explode(':', $class, 2);
             $class = $this->getAliasNamespace($namespaceAlias) . '\\' . $simpleClassName;
         }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -192,10 +192,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($className, ':') !== false) {
-            if (2 < count($classNameAlias = explode(':', $className))) {
-                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $className));
-            }
-            list($namespaceAlias, $simpleClassName) = $classNameAlias;
+            list($namespaceAlias, $simpleClassName) = explode(':', $className, 2);
 
             $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         } else {
@@ -398,10 +395,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
-            if (2 < count($classNameAlias = explode(':', $class))) {
-                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $class));
-            }
-            list($namespaceAlias, $simpleClassName) = $classNameAlias;
+            list($namespaceAlias, $simpleClassName) = explode(':', $class, 2);
             $class = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -192,7 +192,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($className, ':') !== false) {
-            list($namespaceAlias, $simpleClassName) = explode(':', $className);
+            if (2 < count($classNameAlias = explode(':', $className))) {
+                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $className));
+            }
+            list($namespaceAlias, $simpleClassName) = $classNameAlias;
 
             $realClassName = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         } else {
@@ -395,7 +398,10 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
-            list($namespaceAlias, $simpleClassName) = explode(':', $class);
+            if (2 < count($classNameAlias = explode(':', $class))) {
+                throw new \InvalidArgumentException(sprintf('Invalid classname "%s".', $class));
+            }
+            list($namespaceAlias, $simpleClassName) = $classNameAlias;
             $class = $this->getFqcnFromAlias($namespaceAlias, $simpleClassName);
         }
 

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Doctrine\Tests\Common\Persistence;
+
+use \PHPUnit_Framework_MockObject_Generator;
+use Doctrine\Common\Persistence\AbstractManagerRegistry;
+use Doctrine\Tests\Common\Persistence\Mapping\TestClassMetadataFactory;
+use Doctrine\Tests\DoctrineTestCase;
+
+/**
+ * @groups DCOM-270
+ * @uses Doctrine\Tests\Common\Persistence\TestObject
+ */
+class ManagerRegistryTest extends DoctrineTestCase
+{
+    /**
+     * @var TestManagerRegistry
+     */
+    private $mr;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->mr = new TestManagerRegistry(
+            'ORM',
+            array('default_connection'),
+            array('default_manager'),
+            'default',
+            'default',
+            'Doctrine\Common\Persistence\ObjectManagerAware'
+        );
+    }
+
+    public function testGetManagerForClass()
+    {
+        $this->mr->getManagerForClass('Doctrine\Tests\Common\Persistence\TestObject');
+    }
+
+    public function testGetManagerForInvalidClass()
+    {
+        $this->setExpectedException(
+            'ReflectionException',
+            'Class Doctrine\Tests\Common\Persistence\TestObjectInexistent does not exist'
+        );
+
+        $this->mr->getManagerForClass('prefix:TestObjectInexistent');
+    }
+
+    public function testGetManagerForAliasedClass()
+    {
+        $this->mr->getManagerForClass('prefix:TestObject');
+    }
+
+    public function testGetManagerForInvalidAliasedClass()
+    {
+        $this->setExpectedException(
+            'ReflectionException',
+            'Class Doctrine\Tests\Common\Persistence\TestObject:Foo does not exist'
+        );
+
+        $this->mr->getManagerForClass('prefix:TestObject:Foo');
+    }
+}
+
+class TestManager
+{
+    public function getMetadataFactory()
+    {
+        $driver = PHPUnit_Framework_MockObject_Generator::getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $metadata = PHPUnit_Framework_MockObject_Generator::getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+
+        return new TestClassMetadataFactory($driver, $metadata);
+    }
+}
+
+class TestManagerRegistry extends AbstractManagerRegistry
+{
+    protected function getService($name)
+    {
+        return new TestManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function resetService($name)
+    {
+
+    }
+
+    public function getAliasNamespace($alias)
+    {
+        return __NAMESPACE__;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -97,6 +97,14 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->cmf->getMetadataFor('prefix:ChildEntity:Foo');
     }
 
+    /**
+     * @group DCOM-270
+     */
+    public function testClassIsTransient()
+    {
+        $this->assertTrue($this->cmf->isTransient('prefix:ChildEntity:Foo'));
+    }
+
     public function testWillFallbackOnNotLoadedMetadata()
     {
         $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
@@ -182,6 +190,11 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         return $fallback();
+    }
+
+    public function isTransient($class)
+    {
+        return true;
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -84,6 +84,19 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertTrue($this->cmf->hasMetadataFor('prefix:ChildEntity'));
     }
 
+    /**
+     * @group DCOM-270
+     */
+    public function testGetInvalidAliasedMetadata()
+    {
+        $this->setExpectedException(
+            'Doctrine\Common\Persistence\Mapping\MappingException',
+            'Class \'Doctrine\Tests\Common\Persistence\Mapping\ChildEntity:Foo\' does not exist'
+        );
+
+        $this->cmf->getMetadataFor('prefix:ChildEntity:Foo');
+    }
+
     public function testWillFallbackOnNotLoadedMetadata()
     {
         $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');


### PR DESCRIPTION
Improved conversion for aliased classnames

**Before:**
```Doctrine\Tests\Common\Persistence\Mapping:ChildEntity:Foo``` resolves (silently) to ```Doctrine\Tests\Common\Persistence\Mapping\ChildEntity```

**After:**
```Doctrine\Tests\Common\Persistence\Mapping:ChildEntity:Foo``` resolves to ```Doctrine\Tests\Common\Persistence\Mapping\ChildEntity:Foo``` in order to get validation in lower layers.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

TODO:
- [x] Add tests for AbstractClassMetadataFactory::getMetadataFor()
- [x] Add tests for MappingDriver::isTransient()
- [x] Add tests for AbstractManagerRegistry::getManagerForClass()