### PR TITLE
Support for Variadic arguments (PHP 5.6 - Argument unpacking)

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -789,11 +789,12 @@ EOT;
                 $methods .= '        }' . "\n\n";
             }
 
-            $callParamsString = implode(', ', $this->getParameterNames($method->getParameters()));
+            $invokeParamsString = implode(', ', $this->getParameterNamesForInvoke($method->getParameters()));
+            $callParamsString = implode(', ', $this->getParameterNamesForParentCall($method->getParameters()));
 
             $methods .= "\n        \$this->__initializer__ "
                 . "&& \$this->__initializer__->__invoke(\$this, " . var_export($name, true)
-                . ", array(" . $callParamsString . "));"
+                . ", array(" . $invokeParamsString . "));"
                 . "\n\n        return parent::" . $name . '(' . $callParamsString . ');'
                 . "\n" . '    }' . "\n";
         }
@@ -906,6 +907,12 @@ EOT;
                 $parameterDefinition .= '&';
             }
 
+            if (method_exists($param, 'isVariadic')) {
+                if ($param->isVariadic()) {
+                    $parameterDefinition .= '...';
+                }
+            }
+
             $parameters[]     = '$' . $param->getName();
             $parameterDefinition .= '$' . $param->getName();
 
@@ -961,11 +968,36 @@ EOT;
      *
      * @return string[]
      */
-    private function getParameterNames(array $parameters)
+    private function getParameterNamesForInvoke(array $parameters)
     {
         return array_map(
             function (\ReflectionParameter $parameter) {
                 return '$' . $parameter->getName();
+            },
+            $parameters
+        );
+    }
+
+    /**
+     * @param \ReflectionParameter[] $parameters
+     *
+     * @return string[]
+     */
+    private function getParameterNamesForParentCall(array $parameters)
+    {
+        return array_map(
+            function (\ReflectionParameter $parameter) {
+                $name = '';
+
+                if (method_exists($parameter, 'isVariadic')) {
+                    if ($parameter->isVariadic()) {
+                        $name .= '...';
+                    }
+                }
+
+                $name .= '$' . $parameter->getName();
+
+                return $name;
             },
             $parameters
         );

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -163,6 +163,27 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'call(callable $foo)'));
     }
 
+    public function testClassWithVariadicArgumentOnProxiedMethod()
+    {
+        if (PHP_VERSION_ID < 50600) {
+            $this->markTestSkipped('`...` is only supported in PHP >=5.6.0');
+        }
+
+        if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
+            $className = 'Doctrine\Tests\Common\Proxy\VariadicTypeHintClass';
+            $metadata = $this->createClassMetadata($className, array('id'));
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        $classCode = file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyVariadicTypeHintClass.php');
+
+        $this->assertEquals(1, substr_count($classCode, 'function addType(...$types)'));
+        $this->assertEquals(1, substr_count($classCode, '__invoke($this, \'addType\', array($types))'));
+        $this->assertEquals(1, substr_count($classCode, 'parent::addType(...$types)'));
+    }
+
     public function testClassWithInvalidTypeHintOnProxiedMethod()
     {
         $className = 'Doctrine\Tests\Common\Proxy\InvalidTypeHintClass';

--- a/tests/Doctrine/Tests/Common/Proxy/VariadicTypeHintClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/VariadicTypeHintClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class VariadicTypeHintClass
+{
+    /**
+     * @param ...$types
+     */
+    public function addType(...$types)
+    {
+    }
+}


### PR DESCRIPTION
See http://www.doctrine-project.org/jira/browse/DCOM-272

It converts
```php
    /**
     * @param ...$types
     */
    public function addType(...$types)
    {
    }
```

into
```php
    /**
     * {@inheritDoc}
     */
    public function addType(...$types)
    {

        $this->__initializer__ && $this->__initializer__->__invoke($this, 'addType', array($types));

        return parent::addType(...$types);
    }
```

This works but I don't know if the `__invoke` call is correct. 