### PR TITLE
Update DefaultFileLocator.php

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -51,7 +51,7 @@ class DefaultFileLocator implements FileLocator
      * documents and operates in the specified operating mode.
      *
      * @param string|array $paths         One or multiple paths where mapping documents can be found.
-     * @param string|null  $fileExtension The file extension of mapping documents.
+     * @param string|null  $fileExtension The file extension of mapping documents, usually prefixed with a dot.
      */
     public function __construct($paths, $fileExtension = null)
     {


### PR DESCRIPTION
It is implicit that a file extension needs a dot, thus it is unclear that we need to supply it in $fileExtension. I actually wasted quite some time trying to figure out what I'm doing wrong.