### PR TITLE
composer: bump to PHPUnit 4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "~4.7"
     },
     "autoload": {
         "psr-0": { "Doctrine\\Common\\": "lib/" }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "doctrine/lexer": "1.*",
         "doctrine/annotations": "1.*"
     },
-    "minimum-stability": "dev",
     "require-dev": {
         "phpunit/phpunit": "~4.7"
     },

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -107,8 +107,8 @@ class ClassLoaderTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testSupportsTraitAutoloading()
     {
-        if (! function_exists('trait_exists')) {
-            $this->markTestSkipped('You need a PHP version that supports traits in order to run this test');
+        if (PHP_VERSION_ID < 50400) {
+            $this->markTestSkipped('Traits are only supported in PHP >=5.4.0');
         }
 
         $classLoader = new ClassLoader();


### PR DESCRIPTION
PHPUnit 4 is here, 5 on the way

Min stability dev is not needed, ref: https://github.com/doctrine/common/commit/d2d2e0a64d4686dd0908c9226c8acfe5bcb4089f