### PR TITLE
getManagerForClass should try to retrieve the default manager

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -200,9 +200,11 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
         }
 
         // First, try to retrieve the default one
-        $defaultManager = $this->getService($this->managers[$this->getDefaultManagerName()]);
-        if (!$defaultManager->getMetadataFactory()->isTransient($class)) {
-            return $defaultManager;
+        if (isset($this->managers[$this->getDefaultManagerName()])) {
+            $defaultManager = $this->getService($this->managers[$this->getDefaultManagerName()]);
+            if (!$defaultManager->getMetadataFactory()->isTransient($class)) {
+                return $defaultManager;
+            }
         }
 
         foreach ($this->managers as $id) {

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -199,6 +199,12 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
             $class = $proxyClass->getParentClass()->getName();
         }
 
+        // First, try to retrieve the default one
+        $defaultManager = $this->getService($this->managers[$this->getDefaultManagerName()]);
+        if (!$defaultManager->getMetadataFactory()->isTransient($class)) {
+            return $defaultManager;
+        }
+
         foreach ($this->managers as $id) {
             $manager = $this->getService($id);
 

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -26,9 +26,9 @@ class ManagerRegistryTest extends DoctrineTestCase
         $this->mr = new TestManagerRegistry(
             'ORM',
             array('default_connection'),
-            array('default_manager'),
+            array('bar' => 'bar', 'default_manager' => 'default_manager', 'foo' => 'foo'),
             'default',
-            'default',
+            'foo',
             'Doctrine\Common\Persistence\ObjectManagerAware'
         );
     }


### PR DESCRIPTION
getManagerForClass should try to retrieve the default manager instead of the first one found in the list.
