### PR TITLE
Allow access to variables in concrete implementations

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -33,32 +33,32 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var array
      */
-    private $connections;
+    protected $connections;
 
     /**
      * @var array
      */
-    private $managers;
+    protected $managers;
 
     /**
      * @var string
      */
-    private $defaultConnection;
+    protected $defaultConnection;
 
     /**
      * @var string
      */
-    private $defaultManager;
+    protected $defaultManager;
 
     /**
      * @var string
      */
-    private $proxyInterfaceName;
+    protected $proxyInterfaceName;
 
     /**
      * Constructor.


### PR DESCRIPTION
It seems the variables in this abstract class should be protected instead of private so concrete implementations can modify them as needed.