### PR TITLE
Fixed fatal error in AbstractManagerRegistry

### DIFF
--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -196,6 +196,9 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
 
         $proxyClass = new \ReflectionClass($class);
         if ($proxyClass->implementsInterface($this->proxyInterfaceName)) {
+            if (!$proxyClass->getParentClass()) {
+                return null;
+            }
             $class = $proxyClass->getParentClass()->getName();
         }
 

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -38,6 +38,11 @@ class ManagerRegistryTest extends DoctrineTestCase
         $this->mr->getManagerForClass('Doctrine\Tests\Common\Persistence\TestObject');
     }
 
+    public function testGetManagerForProxyInterface()
+    {
+        $this->mr->getManagerForClass('Doctrine\Common\Persistence\ObjectManagerAware');
+    }
+
     public function testGetManagerForInvalidClass()
     {
         $this->setExpectedException(


### PR DESCRIPTION
```
AbstractManagerRegistry::getManagerForClass('Doctrine\Common\Persistence\Proxy');
// Fatal Error Call to a member function getName() on boolean
```