### PR TITLE
Cleanup - drop unsupported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3.3
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": "~5.6|~7.0",
         "doctrine/inflector": "1.*",
         "doctrine/cache": "1.*",
         "doctrine/collections": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/annotations": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7"
+        "phpunit/phpunit": "~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~5.5|~7.0",
         "doctrine/inflector": "1.*",
         "doctrine/cache": "1.*",
         "doctrine/collections": "1.*",
@@ -21,7 +21,7 @@
         "doctrine/annotations": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0"
+        "phpunit/phpunit": "~4.8|~5.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -153,7 +153,7 @@ class ClassLoader
      */
     public function register()
     {
-        spl_autoload_register(array($this, 'loadClass'));
+        spl_autoload_register([$this, 'loadClass']);
     }
 
     /**
@@ -163,7 +163,7 @@ class ClassLoader
      */
     public function unregister()
     {
-        spl_autoload_unregister(array($this, 'loadClass'));
+        spl_autoload_unregister([$this, 'loadClass']);
     }
 
     /**

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -275,6 +275,6 @@ class ClassLoader
     {
         return class_exists($type, $autoload)
             || interface_exists($type, $autoload)
-            || (function_exists('trait_exists') && trait_exists($type, $autoload));
+            || trait_exists($type, $autoload);
     }
 }

--- a/lib/Doctrine/Common/EventManager.php
+++ b/lib/Doctrine/Common/EventManager.php
@@ -38,7 +38,7 @@ class EventManager
      *
      * @var array
      */
-    private $_listeners = array();
+    private $_listeners = [];
 
     /**
      * Dispatches an event to all registered listeners.

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -141,7 +141,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      */
     public function getConnections()
     {
-        $connections = array();
+        $connections = [];
         foreach ($this->connections as $name => $id) {
             $connections[$name] = $this->getService($id);
         }
@@ -226,7 +226,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      */
     public function getManagers()
     {
-        $dms = array();
+        $dms = [];
         foreach ($this->managers as $name => $id) {
             $dms[$name] = $this->getService($id);
         }

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -53,7 +53,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     /**
      * @var ClassMetadata[]
      */
-    private $loadedMetadata = array();
+    private $loadedMetadata = [];
 
     /**
      * @var bool
@@ -110,7 +110,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         }
 
         $driver = $this->getDriver();
-        $metadata = array();
+        $metadata = [];
         foreach ($driver->getAllClassNames() as $className) {
             $metadata[] = $this->getMetadataFor($className);
         }
@@ -277,7 +277,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     protected function getParentClasses($name)
     {
         // Collect parent classes, ignoring transient (not-mapped) classes.
-        $parentClasses = array();
+        $parentClasses = [];
         foreach (array_reverse($this->getReflectionService()->getParentClasses($name)) as $parentClass) {
             if ( ! $this->getDriver()->isTransient($parentClass)) {
                 $parentClasses[] = $parentClass;
@@ -306,7 +306,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
             $this->initialize();
         }
 
-        $loaded = array();
+        $loaded = [];
 
         $parentClasses = $this->getParentClasses($name);
         $parentClasses[] = $name;
@@ -314,7 +314,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         // Move down the hierarchy of parent classes, starting from the topmost class
         $parent = null;
         $rootEntityFound = false;
-        $visited = array();
+        $visited = [];
         $reflService = $this->getReflectionService();
         foreach ($parentClasses as $className) {
             if (isset($this->loadedMetadata[$className])) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -45,14 +45,14 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @var array
      */
-    protected $paths = array();
+    protected $paths = [];
 
     /**
      * The paths excluded from path where to look for mapping files.
      *
      * @var array
      */
-    protected $excludePaths = array();
+    protected $excludePaths = [];
 
     /**
      * The file extension of mapping documents.
@@ -73,7 +73,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @var array
      */
-    protected $entityAnnotationClasses = array();
+    protected $entityAnnotationClasses = [];
 
     /**
      * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
@@ -200,8 +200,8 @@ abstract class AnnotationDriver implements MappingDriver
             throw MappingException::pathRequired();
         }
 
-        $classes = array();
-        $includedFiles = array();
+        $classes = [];
+        $includedFiles = [];
 
         foreach ($this->paths as $path) {
             if ( ! is_dir($path)) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -37,7 +37,7 @@ class DefaultFileLocator implements FileLocator
      *
      * @var array
      */
-    protected $paths = array();
+    protected $paths = [];
 
     /**
      * The file extension of mapping documents.
@@ -125,7 +125,7 @@ class DefaultFileLocator implements FileLocator
      */
     public function getAllClassNames($globalBasename)
     {
-        $classes = array();
+        $classes = [];
 
         if ($this->paths) {
             foreach ($this->paths as $path) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -145,11 +145,14 @@ abstract class FileDriver implements MappingDriver
             $this->initialize();
         }
 
-        $classNames = (array)$this->locator->getAllClassNames($this->globalBasename);
-        if ($this->classCache) {
-            $classNames = array_merge(array_keys($this->classCache), $classNames);
+        if (! $this->classCache) {
+            return (array) $this->locator->getAllClassNames($this->globalBasename);
         }
-        return $classNames;
+
+        return array_merge(
+            array_keys($this->classCache),
+            (array) $this->locator->getAllClassNames($this->globalBasename)
+        );
     }
 
     /**

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -178,7 +178,7 @@ abstract class FileDriver implements MappingDriver
      */
     protected function initialize()
     {
-        $this->classCache = array();
+        $this->classCache = [];
         if (null !== $this->globalBasename) {
             foreach ($this->locator->getPaths() as $path) {
                 $file = $path.'/'.$this->globalBasename.$this->locator->getFileExtension();

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -39,7 +39,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @var MappingDriver|null
      */
-    private $defaultDriver = null;
+    private $defaultDriver;
 
     /**
      * @var array

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -44,7 +44,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * @var array
      */
-    private $drivers = array();
+    private $drivers = [];
 
     /**
      * Gets the default driver.
@@ -117,8 +117,8 @@ class MappingDriverChain implements MappingDriver
      */
     public function getAllClassNames()
     {
-        $classNames = array();
-        $driverClasses = array();
+        $classNames = [];
+        $driverClasses = [];
 
         /* @var $driver MappingDriver */
         foreach ($this->drivers AS $namespace => $driver) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -44,8 +44,7 @@ class PHPDriver extends FileDriver
      */
     public function __construct($locator, $fileExtension = null)
     {
-        $fileExtension = ".php";
-        parent::__construct($locator, $fileExtension);
+        parent::__construct($locator, '.php');
     }
 
     /**
@@ -54,6 +53,7 @@ class PHPDriver extends FileDriver
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {
         $this->metadata = $metadata;
+
         $this->loadMappingFile($this->locator->findMappingFile($className));
     }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -65,6 +65,6 @@ class PHPDriver extends FileDriver
         $metadata = $this->metadata;
         include $file;
 
-        return array($metadata->getName() => $metadata);
+        return [$metadata->getName() => $metadata];
     }
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -40,7 +40,7 @@ class StaticPHPDriver implements MappingDriver
      *
      * @var array
      */
-    private $paths = array();
+    private $paths = [];
 
     /**
      * Map of all class names.
@@ -93,8 +93,8 @@ class StaticPHPDriver implements MappingDriver
             throw MappingException::pathRequired();
         }
 
-        $classes = array();
-        $includedFiles = array();
+        $classes = [];
+        $includedFiles = [];
 
         foreach ($this->paths as $path) {
             if (!is_dir($path)) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -37,14 +37,14 @@ class SymfonyFileLocator implements FileLocator
      *
      * @var array
      */
-    protected $paths = array();
+    protected $paths = [];
 
     /**
      * A map of mapping directory path to namespace prefix used to expand class shortnames.
      *
      * @var array
      */
-    protected $prefixes = array();
+    protected $prefixes = [];
 
     /**
      * File extension that is searched for.
@@ -164,7 +164,7 @@ class SymfonyFileLocator implements FileLocator
      */
     public function getAllClassNames($globalBasename = null)
     {
-        $classes = array();
+        $classes = [];
 
         if ($this->paths) {
             foreach ((array) $this->paths as $path) {

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -31,7 +31,7 @@ class StaticReflectionService implements ReflectionService
      */
     public function getParentClasses($class)
     {
-        return array();
+        return [];
     }
 
     /**

--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -198,7 +198,7 @@ abstract class PersistentObject implements ObjectManagerAware
                 throw new \InvalidArgumentException("Expected persistent object of type '".$targetClass."'");
             }
             if (!($this->$field instanceof Collection)) {
-                $this->$field = new ArrayCollection($this->$field ?: array());
+                $this->$field = new ArrayCollection($this->$field ?: []);
             }
             $this->$field->add($args[0]);
             $this->completeOwningSide($field, $targetClass, $args[0]);

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -87,7 +87,7 @@ abstract class AbstractProxyFactory
     /**
      * @var \Doctrine\Common\Proxy\ProxyDefinition[]
      */
-    private $definitions = array();
+    private $definitions = [];
 
     /**
      * @param \Doctrine\Common\Proxy\ProxyGenerator                     $proxyGenerator

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1012,7 +1012,7 @@ EOT;
      */
     private function getMethodReturnType(\ReflectionMethod $method)
     {
-        if (PHP_VERSION_ID < 70000 || ! $method->hasReturnType()) {
+        if (! (method_exists($method, 'hasReturnType') && $method->hasReturnType())) {
             return '';
         }
 

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -909,10 +909,8 @@ EOT;
                 $parameterDefinition .= '&';
             }
 
-            if (method_exists($param, 'isVariadic')) {
-                if ($param->isVariadic()) {
-                    $parameterDefinition .= '...';
-                }
+            if ($param->isVariadic()) {
+                $parameterDefinition .= '...';
             }
 
             $parameters[]     = '$' . $param->getName();
@@ -943,7 +941,7 @@ EOT;
             return 'array';
         }
 
-        if (method_exists($parameter, 'isCallable') && $parameter->isCallable()) {
+        if ($parameter->isCallable()) {
             return 'callable';
         }
 
@@ -995,10 +993,8 @@ EOT;
             function (\ReflectionParameter $parameter) {
                 $name = '';
 
-                if (method_exists($parameter, 'isVariadic')) {
-                    if ($parameter->isVariadic()) {
-                        $name .= '...';
-                    }
+                if ($parameter->isVariadic()) {
+                    $name .= '...';
                 }
 
                 $name .= '$' . $parameter->getName();

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -945,7 +945,7 @@ EOT;
             return 'callable';
         }
 
-        if (PHP_VERSION_ID >= 70000 && $parameter->hasType() && $parameter->getType()->isBuiltin()) {
+        if (method_exists($parameter, 'hasType') && $parameter->hasType() && $parameter->getType()->isBuiltin()) {
             return (string) $parameter->getType();
         }
 

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -59,7 +59,7 @@ class ProxyGenerator
      * @var string[]|callable[]
      */
     protected $placeholders = array(
-        'baseProxyInterface'   => 'Doctrine\Common\Proxy\Proxy',
+        'baseProxyInterface'   => Proxy::class,
         'additionalProperties' => '',
     );
 

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -909,7 +909,7 @@ EOT;
                 $parameterDefinition .= '&';
             }
 
-            if ($param->isVariadic()) {
+            if (method_exists($param, 'isVariadic') && $param->isVariadic()) {
                 $parameterDefinition .= '...';
             }
 
@@ -993,7 +993,7 @@ EOT;
             function (\ReflectionParameter $parameter) {
                 $name = '';
 
-                if ($parameter->isVariadic()) {
+                if (method_exists($parameter, 'isVariadic') && $parameter->isVariadic()) {
                     $name .= '...';
                 }
 

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -58,10 +58,10 @@ class ProxyGenerator
      *
      * @var string[]|callable[]
      */
-    protected $placeholders = array(
+    protected $placeholders = [
         'baseProxyInterface'   => Proxy::class,
         'additionalProperties' => '',
-    );
+    ];
 
     /**
      * Template used as a blueprint to generate proxies.
@@ -106,7 +106,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      *
      * @see \Doctrine\Common\Persistence\Proxy::__getLazyProperties
      */
-    public static $lazyPropertiesDefaults = array(<lazyPropertiesDefaults>);
+    public static $lazyPropertiesDefaults = [<lazyPropertiesDefaults>];
 
 <additionalProperties>
 
@@ -129,7 +129,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      */
     public function __load()
     {
-        $this->__initializer__ && $this->__initializer__->__invoke($this, \'__load\', array());
+        $this->__initializer__ && $this->__initializer__->__invoke($this, \'__load\', []);
     }
 
     /**
@@ -263,12 +263,12 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         preg_match_all('(<([a-zA-Z]+)>)', $this->proxyClassTemplate, $placeholderMatches);
 
         $placeholderMatches = array_combine($placeholderMatches[0], $placeholderMatches[1]);
-        $placeholders       = array();
+        $placeholders       = [];
 
         foreach ($placeholderMatches as $placeholder => $name) {
             $placeholders[$placeholder] = isset($this->placeholders[$name])
                 ? $this->placeholders[$name]
-                : array($this, 'generate' . $name);
+                : [$this, 'generate' . $name];
         }
 
         foreach ($placeholders as & $placeholder) {
@@ -358,7 +358,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     private function generateLazyPropertiesDefaults(ClassMetadata $class)
     {
         $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
-        $values               = array();
+        $values               = [];
 
         foreach ($lazyPublicProperties as $key => $value) {
             $values[] = var_export($key, true) . ' => ' . var_export($value, true);
@@ -385,7 +385,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     {
 
 EOT;
-        $toUnset = array();
+        $toUnset = [];
 
         foreach ($this->getLazyLoadedPublicProperties($class) as $lazyPublicProperty => $unused) {
             $toUnset[] = '$this->' . $lazyPublicProperty;
@@ -443,7 +443,7 @@ EOT;
         if ( ! empty($lazyPublicProperties)) {
             $magicGet .= <<<'EOT'
         if (array_key_exists($name, $this->__getLazyProperties())) {
-            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', array($name));
+            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
 
             return $this->$name;
         }
@@ -454,7 +454,7 @@ EOT;
 
         if ($hasParentGet) {
             $magicGet .= <<<'EOT'
-        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', array($name));
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
 
         return parent::__get($name);
 
@@ -502,7 +502,7 @@ EOT;
         if ( ! empty($lazyPublicProperties)) {
             $magicSet .= <<<'EOT'
         if (array_key_exists($name, $this->__getLazyProperties())) {
-            $this->__initializer__ && $this->__initializer__->__invoke($this, '__set', array($name, $value));
+            $this->__initializer__ && $this->__initializer__->__invoke($this, '__set', [$name, $value]);
 
             $this->$name = $value;
 
@@ -515,7 +515,7 @@ EOT;
 
         if ($hasParentSet) {
             $magicSet .= <<<'EOT'
-        $this->__initializer__ && $this->__initializer__->__invoke($this, '__set', array($name, $value));
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__set', [$name, $value]);
 
         return parent::__set($name, $value);
 EOT;
@@ -559,7 +559,7 @@ EOT;
         if ( ! empty($lazyPublicProperties)) {
             $magicIsset .= <<<'EOT'
         if (array_key_exists($name, $this->__getLazyProperties())) {
-            $this->__initializer__ && $this->__initializer__->__invoke($this, '__isset', array($name));
+            $this->__initializer__ && $this->__initializer__->__invoke($this, '__isset', [$name]);
 
             return isset($this->$name);
         }
@@ -570,7 +570,7 @@ EOT;
 
         if ($hasParentIsset) {
             $magicIsset .= <<<'EOT'
-        $this->__initializer__ && $this->__initializer__->__invoke($this, '__isset', array($name));
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__isset', [$name]);
 
         return parent::__isset($name);
 
@@ -605,7 +605,7 @@ EOT;
 
         if ($hasParentSleep) {
             return $sleepImpl . <<<'EOT'
-        $properties = array_merge(array('__isInitialized__'), parent::__sleep());
+        $properties = array_merge(['__isInitialized__'], parent::__sleep());
 
         if ($this->__isInitialized__) {
             $properties = array_diff($properties, array_keys($this->__getLazyProperties()));
@@ -616,7 +616,7 @@ EOT;
 EOT;
         }
 
-        $allProperties = array('__isInitialized__');
+        $allProperties = ['__isInitialized__'];
 
         /* @var $prop \ReflectionProperty */
         foreach ($class->getReflectionClass()->getProperties() as $prop) {
@@ -645,10 +645,10 @@ EOT;
 
         return $sleepImpl . <<<EOT
         if (\$this->__isInitialized__) {
-            return array($allProperties);
+            return [$allProperties];
         }
 
-        return array($protectedProperties);
+        return [$protectedProperties];
     }
 EOT;
     }
@@ -662,7 +662,7 @@ EOT;
      */
     private function generateWakeupImpl(ClassMetadata $class)
     {
-        $unsetPublicProperties = array();
+        $unsetPublicProperties = [];
         $hasWakeup             = $class->getReflectionClass()->hasMethod('__wakeup');
 
         foreach (array_keys($this->getLazyLoadedPublicProperties($class)) as $lazyPublicProperty) {
@@ -727,7 +727,7 @@ EOT;
      */
     public function __clone()
     {
-        \$this->__cloner__ && \$this->__cloner__->__invoke(\$this, '__clone', array());
+        \$this->__cloner__ && \$this->__cloner__->__invoke(\$this, '__clone', []);
 $callParentClone    }
 EOT;
     }
@@ -742,16 +742,16 @@ EOT;
     private function generateMethods(ClassMetadata $class)
     {
         $methods           = '';
-        $methodNames       = array();
+        $methodNames       = [];
         $reflectionMethods = $class->getReflectionClass()->getMethods(\ReflectionMethod::IS_PUBLIC);
-        $skippedMethods    = array(
+        $skippedMethods    = [
             '__sleep'   => true,
             '__clone'   => true,
             '__wakeup'  => true,
             '__get'     => true,
             '__set'     => true,
             '__isset'   => true,
-        );
+        ];
 
         foreach ($reflectionMethods as $method) {
             $name = $method->getName();
@@ -784,7 +784,7 @@ EOT;
             if ($this->isShortIdentifierGetter($method, $class)) {
                 $identifier = lcfirst(substr($name, 3));
                 $fieldType  = $class->getTypeOfField($identifier);
-                $cast       = in_array($fieldType, array('integer', 'smallint')) ? '(int) ' : '';
+                $cast       = in_array($fieldType, ['integer', 'smallint']) ? '(int) ' : '';
 
                 $methods .= '        if ($this->__isInitialized__ === false) {' . "\n";
                 $methods .= '            return ' . $cast . ' parent::' . $method->getName() . "();\n";
@@ -796,7 +796,7 @@ EOT;
 
             $methods .= "\n        \$this->__initializer__ "
                 . "&& \$this->__initializer__->__invoke(\$this, " . var_export($name, true)
-                . ", array(" . $invokeParamsString . "));"
+                . ", [" . $invokeParamsString . "]);"
                 . "\n\n        return parent::" . $name . '(' . $callParamsString . ');'
                 . "\n" . '    }' . "\n";
         }
@@ -873,7 +873,7 @@ EOT;
     private function getLazyLoadedPublicProperties(ClassMetadata $class)
     {
         $defaultProperties = $class->getReflectionClass()->getDefaultProperties();
-        $properties = array();
+        $properties = [];
 
         foreach ($class->getReflectionClass()->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
             $name = $property->getName();
@@ -895,7 +895,7 @@ EOT;
      */
     private function buildParametersString(ClassMetadata $class, \ReflectionMethod $method, array $parameters)
     {
-        $parameterDefinitions = array();
+        $parameterDefinitions = [];
 
         /* @var $param \ReflectionParameter */
         foreach ($parameters as $param) {

--- a/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
@@ -402,7 +402,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function newInstanceArgs(array $args = array())
+    public function newInstanceArgs(array $args = [])
     {
         throw new ReflectionException('Method not implemented');
     }

--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -69,18 +69,18 @@ class StaticReflectionParser implements ReflectionProviderInterface
      *
      * @var array
      */
-    protected $useStatements = array();
+    protected $useStatements = [];
 
     /**
      * The docComment of the class.
      *
      * @var string
      */
-    protected $docComment = array(
+    protected $docComment = [
         'class' => '',
-        'property' => array(),
-        'method' => array()
-    );
+        'property' => [],
+        'method' => []
+    ];
 
     /**
      * The name of the class this class extends, if any.

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Common\Util;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\Proxy;
 
 /**
@@ -95,7 +96,7 @@ final class Debug
         $return = null;
         $isObj = is_object($var);
 
-        if ($isObj && in_array('Doctrine\Common\Collections\Collection', class_implements($var))) {
+        if ($var instanceof Collection) {
             $var = $var->toArray();
         }
 

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -102,7 +102,7 @@ final class Debug
 
         if ($maxDepth) {
             if (is_array($var)) {
-                $return = array();
+                $return = [];
 
                 foreach ($var as $k => $v) {
                     $return[$k] = self::export($v, $maxDepth - 1);

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -107,10 +107,6 @@ class ClassLoaderTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testSupportsTraitAutoloading()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('Traits are only supported in PHP >=5.4.0');
-        }
-
         $classLoader = new ClassLoader();
         $classLoader->setIncludePath(__DIR__);
         $classLoader->setFileExtension('.class.php');

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
@@ -5,14 +5,14 @@ namespace ClassLoaderTest;
 class ExternalLoader
 {
     public static function registerStatic() {
-        spl_autoload_register(array(ExternalLoader::class, 'load1'));
-        spl_autoload_register(array(ExternalLoader::class, 'load2'));
+        spl_autoload_register([ExternalLoader::class, 'load1']);
+        spl_autoload_register([ExternalLoader::class, 'load2']);
         spl_autoload_register(ExternalLoader::class . '::load3');
     }
 
     public static function unregisterStatic() {
-        spl_autoload_unregister(array(ExternalLoader::class, 'load1'));
-        spl_autoload_unregister(array(ExternalLoader::class, 'load2'));
+        spl_autoload_unregister([ExternalLoader::class, 'load1']);
+        spl_autoload_unregister([ExternalLoader::class, 'load2']);
         spl_autoload_unregister(ExternalLoader::class . '::load3');
     }
 
@@ -23,13 +23,13 @@ class ExternalLoader
     protected static function load3() {}
 
     public function register() {
-        spl_autoload_register(array($this, 'load4'));
-        spl_autoload_register(array($this, 'load5'));
+        spl_autoload_register([$this, 'load4']);
+        spl_autoload_register([$this, 'load5']);
     }
 
     public function unregister() {
-        spl_autoload_unregister(array($this, 'load4'));
-        spl_autoload_unregister(array($this, 'load5'));
+        spl_autoload_unregister([$this, 'load4']);
+        spl_autoload_unregister([$this, 'load5']);
     }
 
     public function load4() {}

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest/ExternalLoader.php
@@ -5,15 +5,15 @@ namespace ClassLoaderTest;
 class ExternalLoader
 {
     public static function registerStatic() {
-        spl_autoload_register(array('ClassLoaderTest\ExternalLoader', 'load1'));
-        spl_autoload_register(array('ClassLoaderTest\ExternalLoader', 'load2'));
-        spl_autoload_register('ClassLoaderTest\ExternalLoader::load3');
+        spl_autoload_register(array(ExternalLoader::class, 'load1'));
+        spl_autoload_register(array(ExternalLoader::class, 'load2'));
+        spl_autoload_register(ExternalLoader::class . '::load3');
     }
 
     public static function unregisterStatic() {
-        spl_autoload_unregister(array('ClassLoaderTest\ExternalLoader', 'load1'));
-        spl_autoload_unregister(array('ClassLoaderTest\ExternalLoader', 'load2'));
-        spl_autoload_unregister('ClassLoaderTest\ExternalLoader::load3');
+        spl_autoload_unregister(array(ExternalLoader::class, 'load1'));
+        spl_autoload_unregister(array(ExternalLoader::class, 'load2'));
+        spl_autoload_unregister(ExternalLoader::class . '::load3');
     }
 
     public static function load1() {}

--- a/tests/Doctrine/Tests/Common/EventManagerTest.php
+++ b/tests/Doctrine/Tests/Common/EventManagerTest.php
@@ -27,14 +27,14 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testInitialState()
     {
-        $this->assertEquals(array(), $this->_eventManager->getListeners());
+        $this->assertEquals([], $this->_eventManager->getListeners());
         $this->assertFalse($this->_eventManager->hasListeners(self::preFoo));
         $this->assertFalse($this->_eventManager->hasListeners(self::postFoo));
     }
 
     public function testAddEventListener()
     {
-        $this->_eventManager->addEventListener(array('preFoo', 'postFoo'), $this);
+        $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
         $this->assertTrue($this->_eventManager->hasListeners(self::preFoo));
         $this->assertTrue($this->_eventManager->hasListeners(self::postFoo));
         $this->assertEquals(1, count($this->_eventManager->getListeners(self::preFoo)));
@@ -44,7 +44,7 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testDispatchEvent()
     {
-        $this->_eventManager->addEventListener(array('preFoo', 'postFoo'), $this);
+        $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
         $this->_eventManager->dispatchEvent(self::preFoo);
         $this->assertTrue($this->_preFooInvoked);
         $this->assertFalse($this->_postFooInvoked);
@@ -52,9 +52,9 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
     public function testRemoveEventListener()
     {
-        $this->_eventManager->addEventListener(array('preBar'), $this);
+        $this->_eventManager->addEventListener(['preBar'], $this);
         $this->assertTrue($this->_eventManager->hasListeners(self::preBar));
-        $this->_eventManager->removeEventListener(array('preBar'), $this);
+        $this->_eventManager->removeEventListener(['preBar'], $this);
         $this->assertFalse($this->_eventManager->hasListeners(self::preBar));
     }
 
@@ -83,6 +83,6 @@ class TestEventSubscriber implements \Doctrine\Common\EventSubscriber
 {
     public function getSubscribedEvents()
     {
-        return array('preFoo', 'postFoo');
+        return ['preFoo', 'postFoo'];
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -28,8 +28,8 @@ class ManagerRegistryTest extends DoctrineTestCase
     {
         $this->mr = new TestManagerRegistry(
             'ORM',
-            array('default_connection'),
-            array('default_manager'),
+            ['default_connection'],
+            ['default_manager'],
             'default',
             'default',
             ObjectManagerAware::class

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -3,6 +3,9 @@
 namespace Doctrine\Tests\Common\Persistence;
 
 use Doctrine\Common\Persistence\AbstractManagerRegistry;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\ObjectManagerAware;
 use Doctrine\Tests\Common\Persistence\Mapping\TestClassMetadataFactory;
 use Doctrine\Tests\DoctrineTestCase;
 use PHPUnit_Framework_TestCase;
@@ -29,18 +32,18 @@ class ManagerRegistryTest extends DoctrineTestCase
             array('default_manager'),
             'default',
             'default',
-            'Doctrine\Common\Persistence\ObjectManagerAware'
+            ObjectManagerAware::class
         );
     }
 
     public function testGetManagerForClass()
     {
-        $this->mr->getManagerForClass('Doctrine\Tests\Common\Persistence\TestObject');
+        $this->mr->getManagerForClass(TestObject::class);
     }
 
     public function testGetManagerForProxyInterface()
     {
-        $this->assertNull($this->mr->getManagerForClass('Doctrine\Common\Persistence\ObjectManagerAware'));
+        $this->assertNull($this->mr->getManagerForClass(ObjectManagerAware::class));
     }
 
     public function testGetManagerForInvalidClass()
@@ -73,8 +76,8 @@ class TestManager extends PHPUnit_Framework_TestCase
 {
     public function getMetadataFactory()
     {
-        $driver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $driver   = $this->getMock(MappingDriver::class);
+        $metadata = $this->getMock(ClassMetadata::class);
 
         return new TestClassMetadataFactory($driver, $metadata);
     }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
@@ -13,17 +13,17 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
     public function testGetAllClassNames()
     {
         $reader = new AnnotationReader();
-        $driver = new SimpleAnnotationDriver($reader, array(__DIR__ . '/_files/annotation'));
+        $driver = new SimpleAnnotationDriver($reader, [__DIR__ . '/_files/annotation']);
 
         $classes = $driver->getAllClassNames();
 
-        $this->assertEquals(array(TestClass::class), $classes);
+        $this->assertEquals([TestClass::class], $classes);
     }
 }
 
 class SimpleAnnotationDriver extends AnnotationDriver
 {
-    protected $entityAnnotationClasses = array(Entity::class => true);
+    protected $entityAnnotationClasses = [Entity::class => true];
 
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\Common\Persistence\Mapping;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Entity;
+use Doctrine\TestClass;
 
 class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,13 +17,13 @@ class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
 
         $classes = $driver->getAllClassNames();
 
-        $this->assertEquals(array('Doctrine\TestClass'), $classes);
+        $this->assertEquals(array(TestClass::class), $classes);
     }
 }
 
 class SimpleAnnotationDriver extends AnnotationDriver
 {
-    protected $entityAnnotationClasses = array('Doctrine\Entity' => true);
+    protected $entityAnnotationClasses = array(Entity::class => true);
 
     public function loadMetadataForClass($className, ClassMetadata $metadata)
     {

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
@@ -2,25 +2,29 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Common\Persistence\Mapping\MappingException;
+use Doctrine\Tests\Common\Persistence\Mapping;
 use Doctrine\Tests\DoctrineTestCase;
 
 class DriverChainTest extends DoctrineTestCase
 {
     public function testDelegateToMatchingNamespaceDriver()
     {
-        $className = 'Doctrine\Tests\Common\Persistence\Mapping\DriverChainEntity';
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $className = DriverChainEntity::class;
+        $classMetadata = $this->getMock(ClassMetadata::class);
 
         $chain = new MappingDriverChain();
 
-        $driver1 = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver1 = $this->getMock(MappingDriver::class);
         $driver1->expects($this->never())
                 ->method('loadMetadataForClass');
         $driver1->expectS($this->never())
                 ->method('isTransient');
 
-        $driver2 = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver2 = $this->getMock(MappingDriver::class);
         $driver2->expects($this->at(0))
                 ->method('loadMetadataForClass')
                 ->with($this->equalTo($className), $this->equalTo($classMetadata));
@@ -39,28 +43,25 @@ class DriverChainTest extends DoctrineTestCase
 
     public function testLoadMetadata_NoDelegatorFound_ThrowsMappingException()
     {
-        $className = 'Doctrine\Tests\Common\Persistence\Mapping\DriverChainEntity';
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $className = DriverChainEntity::class;
+        $classMetadata = $this->getMock(ClassMetadata::class);
 
         $chain = new MappingDriverChain();
 
-        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->setExpectedException(MappingException::class);
         $chain->loadMetadataForClass($className, $classMetadata);
     }
 
     public function testGatherAllClassNames()
     {
-        $className = 'Doctrine\Tests\Common\Persistence\Mapping\DriverChainEntity';
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\ClassMetadata');
-
         $chain = new MappingDriverChain();
 
-        $driver1 = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver1 = $this->getMock(MappingDriver::class);
         $driver1->expects($this->once())
                 ->method('getAllClassNames')
                 ->will($this->returnValue(array('Doctrine\Tests\Models\Company\Foo')));
 
-        $driver2 = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver2 = $this->getMock(MappingDriver::class);
         $driver2->expects($this->once())
                 ->method('getAllClassNames')
                 ->will($this->returnValue(array('Doctrine\Tests\ORM\Mapping\Bar', 'Doctrine\Tests\ORM\Mapping\Baz', 'FooBarBaz')));
@@ -80,7 +81,7 @@ class DriverChainTest extends DoctrineTestCase
      */
     public function testIsTransient()
     {
-        $driver1 = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver1 = $this->getMock(MappingDriver::class);
         $chain = new MappingDriverChain();
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\CMS');
 
@@ -92,8 +93,8 @@ class DriverChainTest extends DoctrineTestCase
      */
     public function testDefaultDriver()
     {
-        $companyDriver      = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
-        $defaultDriver      = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $companyDriver      = $this->getMock(MappingDriver::class);
+        $defaultDriver      = $this->getMock(MappingDriver::class);
         $entityClassName    = 'Doctrine\Tests\ORM\Mapping\DriverChainEntity';
         $managerClassName   = 'Doctrine\Tests\Models\Company\CompanyManager';
         $chain              = new MappingDriverChain();
@@ -125,8 +126,8 @@ class DriverChainTest extends DoctrineTestCase
 
     public function testDefaultDriverGetAllClassNames()
     {
-        $companyDriver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
-        $defaultDriver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $companyDriver = $this->getMock(MappingDriver::class);
+        $defaultDriver = $this->getMock(MappingDriver::class);
         $chain         = new MappingDriverChain();
 
         $companyDriver->expects($this->once())

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ChainDriverTest.php
@@ -59,21 +59,21 @@ class DriverChainTest extends DoctrineTestCase
         $driver1 = $this->getMock(MappingDriver::class);
         $driver1->expects($this->once())
                 ->method('getAllClassNames')
-                ->will($this->returnValue(array('Doctrine\Tests\Models\Company\Foo')));
+                ->will($this->returnValue(['Doctrine\Tests\Models\Company\Foo']));
 
         $driver2 = $this->getMock(MappingDriver::class);
         $driver2->expects($this->once())
                 ->method('getAllClassNames')
-                ->will($this->returnValue(array('Doctrine\Tests\ORM\Mapping\Bar', 'Doctrine\Tests\ORM\Mapping\Baz', 'FooBarBaz')));
+                ->will($this->returnValue(['Doctrine\Tests\ORM\Mapping\Bar', 'Doctrine\Tests\ORM\Mapping\Baz', 'FooBarBaz']));
 
         $chain->addDriver($driver1, 'Doctrine\Tests\Models\Company');
         $chain->addDriver($driver2, 'Doctrine\Tests\ORM\Mapping');
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'Doctrine\Tests\Models\Company\Foo',
             'Doctrine\Tests\ORM\Mapping\Bar',
             'Doctrine\Tests\ORM\Mapping\Baz'
-        ), $chain->getAllClassNames());
+        ], $chain->getAllClassNames());
     }
 
     /**
@@ -132,18 +132,18 @@ class DriverChainTest extends DoctrineTestCase
 
         $companyDriver->expects($this->once())
             ->method('getAllClassNames')
-            ->will($this->returnValue(array('Doctrine\Tests\Models\Company\Foo')));
+            ->will($this->returnValue(['Doctrine\Tests\Models\Company\Foo']));
 
         $defaultDriver->expects($this->once())
             ->method('getAllClassNames')
-            ->will($this->returnValue(array('Other\Class')));
+            ->will($this->returnValue(['Other\Class']));
 
         $chain->setDefaultDriver($defaultDriver);
         $chain->addDriver($companyDriver, 'Doctrine\Tests\Models\Company');
 
         $classNames = $chain->getAllClassNames();
 
-        $this->assertEquals(array('Doctrine\Tests\Models\Company\Foo', 'Other\Class'), $classNames);
+        $this->assertEquals(['Doctrine\Tests\Models\Company\Foo', 'Other\Class'], $classNames);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -2,8 +2,9 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
-use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory;
@@ -18,8 +19,8 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
     public function setUp()
     {
-        $driver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $driver = $this->getMock(MappingDriver::class);
+        $metadata = $this->getMock(ClassMetadata::class);
         $this->cmf = new TestClassMetadataFactory($driver, $metadata);
     }
 
@@ -35,35 +36,34 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     {
         $metadata = $this->cmf->getMetadataFor('stdClass');
 
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadata', $metadata);
+        $this->assertInstanceOf(ClassMetadata::class, $metadata);
         $this->assertTrue($this->cmf->hasMetadataFor('stdClass'));
     }
 
     public function testGetMetadataForAbsentClass()
     {
-        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->setExpectedException(MappingException::class);
         $this->cmf->getMetadataFor(__NAMESPACE__ . '\AbsentClass');
     }
 
     public function testGetParentMetadata()
     {
-        $metadata = $this->cmf->getMetadataFor(__NAMESPACE__ . '\ChildEntity');
+        $metadata = $this->cmf->getMetadataFor(ChildEntity::class);
 
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Mapping\ClassMetadata', $metadata);
-        $this->assertTrue($this->cmf->hasMetadataFor(__NAMESPACE__ . '\ChildEntity'));
-        $this->assertTrue($this->cmf->hasMetadataFor(__NAMESPACE__ . '\RootEntity'));
+        $this->assertInstanceOf(ClassMetadata::class, $metadata);
+        $this->assertTrue($this->cmf->hasMetadataFor(ChildEntity::class));
+        $this->assertTrue($this->cmf->hasMetadataFor(RootEntity::class));
     }
 
     public function testGetCachedMetadata()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->getMock(ClassMetadata::class);
         $cache = new ArrayCache();
-        $cache->save(__NAMESPACE__. '\ChildEntity$CLASSMETADATA', $metadata);
+        $cache->save(ChildEntity::class . '$CLASSMETADATA', $metadata);
 
         $this->cmf->setCacheDriver($cache);
 
-        $loadedMetadata = $this->cmf->getMetadataFor(__NAMESPACE__ . '\ChildEntity');
-        $this->assertSame($loadedMetadata, $metadata);
+        $this->assertSame($metadata, $this->cmf->getMetadataFor(ChildEntity::class));
     }
 
     public function testCacheGetMetadataFor()
@@ -71,9 +71,9 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $cache = new ArrayCache();
         $this->cmf->setCacheDriver($cache);
 
-        $loadedMetadata = $this->cmf->getMetadataFor(__NAMESPACE__ . '\ChildEntity');
+        $loadedMetadata = $this->cmf->getMetadataFor(ChildEntity::class);
 
-        $this->assertSame($loadedMetadata, $cache->fetch(__NAMESPACE__. '\ChildEntity$CLASSMETADATA'));
+        $this->assertSame($loadedMetadata, $cache->fetch(ChildEntity::class. '$CLASSMETADATA'));
     }
 
     public function testGetAliasedMetadata()
@@ -90,7 +90,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     public function testGetInvalidAliasedMetadata()
     {
         $this->setExpectedException(
-            'Doctrine\Common\Persistence\Mapping\MappingException',
+            MappingException::class,
             'Class \'Doctrine\Tests\Common\Persistence\Mapping\ChildEntity:Foo\' does not exist'
         );
 
@@ -107,7 +107,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
     public function testWillFallbackOnNotLoadedMetadata()
     {
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata = $this->getMock(ClassMetadata::class);
 
         $this->cmf->fallbackCallback = function () use ($classMetadata) {
             return $classMetadata;
@@ -126,7 +126,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
 
         $this->cmf->metadata = null;
 
-        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->setExpectedException(MappingException::class);
 
         $this->cmf->getMetadataFor('Foo');
     }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
@@ -12,16 +12,16 @@ class DefaultFileLocatorTest extends DoctrineTestCase
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path));
-        $this->assertEquals(array($path), $locator->getPaths());
+        $locator = new DefaultFileLocator([$path]);
+        $this->assertEquals([$path], $locator->getPaths());
 
         $locator = new DefaultFileLocator($path);
-        $this->assertEquals(array($path), $locator->getPaths());
+        $this->assertEquals([$path], $locator->getPaths());
     }
 
     public function testGetFileExtension()
     {
-        $locator = new DefaultFileLocator(array(), ".yml");
+        $locator = new DefaultFileLocator([], ".yml");
         $this->assertEquals(".yml", $locator->getFileExtension());
         $locator->setFileExtension(".xml");
         $this->assertEquals(".xml", $locator->getFileExtension());
@@ -31,15 +31,15 @@ class DefaultFileLocatorTest extends DoctrineTestCase
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path, $path));
-        $this->assertEquals(array($path), $locator->getPaths());
+        $locator = new DefaultFileLocator([$path, $path]);
+        $this->assertEquals([$path], $locator->getPaths());
     }
 
     public function testFindMappingFile()
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path), ".yml");
+        $locator = new DefaultFileLocator([$path], ".yml");
 
         $this->assertEquals(__DIR__ . '/_files' . DIRECTORY_SEPARATOR . 'stdClass.yml', $locator->findMappingFile('stdClass'));
     }
@@ -48,7 +48,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path), ".yml");
+        $locator = new DefaultFileLocator([$path], ".yml");
 
         $this->setExpectedException(
             MappingException::class,
@@ -61,12 +61,12 @@ class DefaultFileLocatorTest extends DoctrineTestCase
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path), ".yml");
+        $locator = new DefaultFileLocator([$path], ".yml");
         $allClasses = $locator->getAllClassNames(null);
         $globalClasses = $locator->getAllClassNames("global");
 
-        $expectedAllClasses    = array('global', 'stdClass', 'subDirClass');
-        $expectedGlobalClasses = array('subDirClass', 'stdClass');
+        $expectedAllClasses    = ['global', 'stdClass', 'subDirClass'];
+        $expectedGlobalClasses = ['subDirClass', 'stdClass'];
 
         sort($allClasses);
         sort($globalClasses);
@@ -81,15 +81,15 @@ class DefaultFileLocatorTest extends DoctrineTestCase
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path), ".xml");
-        $this->assertEquals(array(), $locator->getAllClassNames("global"));
+        $locator = new DefaultFileLocator([$path], ".xml");
+        $this->assertEquals([], $locator->getAllClassNames("global"));
     }
 
     public function testFileExists()
     {
         $path = __DIR__ . "/_files";
 
-        $locator = new DefaultFileLocator(array($path), ".yml");
+        $locator = new DefaultFileLocator([$path], ".yml");
 
         $this->assertTrue($locator->fileExists("stdClass"));
         $this->assertFalse($locator->fileExists("stdClass2"));

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 
@@ -50,7 +51,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $locator = new DefaultFileLocator(array($path), ".yml");
 
         $this->setExpectedException(
-            'Doctrine\Common\Persistence\Mapping\MappingException',
+            MappingException::class,
             "No mapping file found named 'stdClass2.yml' for class 'stdClass2'"
         );
         $locator->findMappingFile('stdClass2');

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -11,7 +11,7 @@ class FileDriverTest extends DoctrineTestCase
 {
     public function testGlobalBasename()
     {
-        $driver = new TestFileDriver(array());
+        $driver = new TestFileDriver([]);
 
         $this->assertNull($driver->getGlobalBasename());
 
@@ -49,7 +49,7 @@ class FileDriverTest extends DoctrineTestCase
 
         $classNames = $driver->getAllClassNames();
 
-        $this->assertEquals(array('stdGlobal', 'stdGlobal2'), $classNames);
+        $this->assertEquals(['stdGlobal', 'stdGlobal2'], $classNames);
     }
 
     public function testGetAllClassNamesFromMappingFile()
@@ -58,12 +58,12 @@ class FileDriverTest extends DoctrineTestCase
         $locator->expects($this->any())
                 ->method('getAllClassNames')
                 ->with($this->equalTo(null))
-                ->will($this->returnValue(array('stdClass')));
+                ->will($this->returnValue(['stdClass']));
         $driver = new TestFileDriver($locator);
 
         $classNames = $driver->getAllClassNames();
 
-        $this->assertEquals(array('stdClass'), $classNames);
+        $this->assertEquals(['stdClass'], $classNames);
     }
 
     public function testGetAllClassNamesBothSources()
@@ -72,13 +72,13 @@ class FileDriverTest extends DoctrineTestCase
         $locator->expects($this->any())
                 ->method('getAllClassNames')
                 ->with($this->equalTo('global'))
-                ->will($this->returnValue(array('stdClass')));
+                ->will($this->returnValue(['stdClass']));
         $driver = new TestFileDriver($locator);
         $driver->setGlobalBasename("global");
 
         $classNames = $driver->getAllClassNames();
 
-        $this->assertEquals(array('stdGlobal', 'stdGlobal2', 'stdClass'), $classNames);
+        $this->assertEquals(['stdGlobal', 'stdGlobal2', 'stdClass'], $classNames);
     }
 
     public function testIsNotTransient()
@@ -121,7 +121,7 @@ class FileDriverTest extends DoctrineTestCase
     {
         $locator = $this->getMock(FileLocator::class);
         $locator->expects($this->any())->method('getFileExtension')->will($this->returnValue('.yml'));
-        $locator->expects($this->any())->method('getPaths')->will($this->returnValue(array(__DIR__ . "/_files")));
+        $locator->expects($this->any())->method('getPaths')->will($this->returnValue([__DIR__ . "/_files"]));
         return $locator;
     }
 }
@@ -131,9 +131,9 @@ class TestFileDriver extends FileDriver
     protected function loadMappingFile($file)
     {
         if (strpos($file, "global.yml") !== false) {
-            return array('stdGlobal' => 'stdGlobal', 'stdGlobal2' => 'stdGlobal2');
+            return ['stdGlobal' => 'stdGlobal', 'stdGlobal2' => 'stdGlobal2'];
         }
-        return array('stdClass' => 'stdClass');
+        return ['stdClass' => 'stdClass'];
     }
 
     public function loadMetadataForClass($className, ClassMetadata $metadata)

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
@@ -118,7 +119,7 @@ class FileDriverTest extends DoctrineTestCase
 
     private function newLocator()
     {
-        $locator = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\FileLocator');
+        $locator = $this->getMock(FileLocator::class);
         $locator->expects($this->any())->method('getFileExtension')->will($this->returnValue('.yml'));
         $locator->expects($this->any())->method('getPaths')->will($this->returnValue(array(__DIR__ . "/_files")));
         return $locator;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
@@ -13,7 +13,7 @@ class PHPDriverTest extends DoctrineTestCase
         $metadata = $this->getMock(ClassMetadata::class);
         $metadata->expects($this->once())->method('getFieldNames');
 
-        $driver = new PHPDriver(array(__DIR__ . "/_files"));
+        $driver = new PHPDriver([__DIR__ . "/_files"]);
         $driver->loadMetadataForClass('TestEntity', $metadata);
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
 
@@ -9,7 +10,7 @@ class PHPDriverTest extends DoctrineTestCase
 {
     public function testLoadMetadata()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->getMock(ClassMetadata::class);
         $metadata->expects($this->once())->method('getFieldNames');
 
         $driver = new PHPDriver(array(__DIR__ . "/_files"));

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -19,7 +19,9 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
 
 /**
  * @group DCOM-93
@@ -45,7 +47,7 @@ class RuntimeReflectionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testClassNamespaceName()
     {
-        $this->assertEquals("Doctrine\Tests\Common\Persistence\Mapping", $this->reflectionService->getClassNamespace(__CLASS__));
+        $this->assertEquals('Doctrine\Tests\Common\Persistence\Mapping', $this->reflectionService->getClassNamespace(__CLASS__));
     }
 
     public function testGetParentClasses()
@@ -56,7 +58,7 @@ class RuntimeReflectionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testGetParentClassesForAbsentClass()
     {
-        $this->setExpectedException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->setExpectedException(MappingException::class);
         $this->reflectionService->getParentClasses(__NAMESPACE__ . '\AbsentClass');
     }
 
@@ -78,7 +80,7 @@ class RuntimeReflectionServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf("ReflectionProperty", $reflProp);
 
         $reflProp = $this->reflectionService->getAccessibleProperty(__CLASS__, "unusedPublicProperty");
-        $this->assertInstanceOf("Doctrine\Common\Reflection\RuntimePublicReflectionProperty", $reflProp);
+        $this->assertInstanceOf(RuntimePublicReflectionProperty::class, $reflProp);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
@@ -13,13 +13,13 @@ class StaticPHPDriverTest extends DoctrineTestCase
         $metadata = $this->getMock(ClassMetadata::class);
         $metadata->expects($this->once())->method('getFieldNames');
 
-        $driver = new StaticPHPDriver(array(__DIR__));
+        $driver = new StaticPHPDriver([__DIR__]);
         $driver->loadMetadataForClass(TestEntity::class, $metadata);
     }
 
     public function testGetAllClassNames()
     {
-        $driver = new StaticPHPDriver(array(__DIR__));
+        $driver = new StaticPHPDriver([__DIR__]);
         $classNames = $driver->getAllClassNames();
 
         $this->assertContains(TestEntity::class, $classNames);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
 
@@ -9,11 +10,11 @@ class StaticPHPDriverTest extends DoctrineTestCase
 {
     public function testLoadMetadata()
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->getMock(ClassMetadata::class);
         $metadata->expects($this->once())->method('getFieldNames');
 
         $driver = new StaticPHPDriver(array(__DIR__));
-        $driver->loadMetadataForClass(__NAMESPACE__ . '\\TestEntity', $metadata);
+        $driver->loadMetadataForClass(TestEntity::class, $metadata);
     }
 
     public function testGetAllClassNames()
@@ -21,8 +22,7 @@ class StaticPHPDriverTest extends DoctrineTestCase
         $driver = new StaticPHPDriver(array(__DIR__));
         $classNames = $driver->getAllClassNames();
 
-        $this->assertContains(
-            'Doctrine\Tests\Common\Persistence\Mapping\TestEntity', $classNames);
+        $this->assertContains(TestEntity::class, $classNames);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
@@ -20,12 +20,16 @@
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\StaticReflectionService;
+use Doctrine\Tests\Common\Persistence\Mapping;
 
 /**
  * @group DCOM-93
  */
 class StaticReflectionServiceTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var StaticReflectionService
+     */
     private $reflectionService;
 
     public function setUp()
@@ -40,7 +44,7 @@ class StaticReflectionServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testClassNamespaceName()
     {
-        $this->assertEquals("Doctrine\Tests\Common\Persistence\Mapping", $this->reflectionService->getClassNamespace(__CLASS__));
+        $this->assertEquals(Mapping::class, $this->reflectionService->getClassNamespace(__CLASS__));
     }
 
     public function testGetParentClasses()

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -13,11 +13,11 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix));
-        $this->assertEquals(array($path), $locator->getPaths());
+        $locator = new SymfonyFileLocator([$path => $prefix]);
+        $this->assertEquals([$path], $locator->getPaths());
 
-        $locator = new SymfonyFileLocator(array($path => $prefix));
-        $this->assertEquals(array($path), $locator->getPaths());
+        $locator = new SymfonyFileLocator([$path => $prefix]);
+        $this->assertEquals([$path], $locator->getPaths());
     }
 
     public function testGetPrefixes()
@@ -25,13 +25,13 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix));
-        $this->assertEquals(array($path => $prefix), $locator->getNamespacePrefixes());
+        $locator = new SymfonyFileLocator([$path => $prefix]);
+        $this->assertEquals([$path => $prefix], $locator->getNamespacePrefixes());
     }
 
     public function testGetFileExtension()
     {
-        $locator = new SymfonyFileLocator(array(), ".yml");
+        $locator = new SymfonyFileLocator([], ".yml");
         $this->assertEquals(".yml", $locator->getFileExtension());
         $locator->setFileExtension(".xml");
         $this->assertEquals(".xml", $locator->getFileExtension());
@@ -42,7 +42,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml");
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml");
 
         $this->assertTrue($locator->fileExists("Foo\stdClass"));
         $this->assertTrue($locator->fileExists("Foo\global"));
@@ -55,12 +55,12 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml");
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml");
         $allClasses = $locator->getAllClassNames(null);
         $globalClasses = $locator->getAllClassNames("global");
 
-        $expectedAllClasses    = array("Foo\\Bar\\subDirClass", "Foo\\global", "Foo\\stdClass");
-        $expectedGlobalClasses = array("Foo\\Bar\\subDirClass", "Foo\\stdClass");
+        $expectedAllClasses    = ["Foo\\Bar\\subDirClass", "Foo\\global", "Foo\\stdClass"];
+        $expectedGlobalClasses = ["Foo\\Bar\\subDirClass", "Foo\\stdClass"];
 
         sort($allClasses);
         sort($globalClasses);
@@ -80,15 +80,15 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        new SymfonyFileLocator(array($path => $prefix), ".yml", null);
+        new SymfonyFileLocator([$path => $prefix], ".yml", null);
     }
 
     public function customNamespaceSeparatorProvider()
     {
-        return array(
-            'directory separator' => array(DIRECTORY_SEPARATOR, "/_custom_ns/dir"),
-            'default dot separator' => array('.', "/_custom_ns/dot"),
-        );
+        return [
+            'directory separator' => [DIRECTORY_SEPARATOR, "/_custom_ns/dir"],
+            'default dot separator' => ['.', "/_custom_ns/dot"],
+        ];
     }
 
     /**
@@ -104,35 +104,35 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . $dir;
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml", $separator);
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml", $separator);
         $classes = $locator->getAllClassNames(null);
         sort($classes);
 
-        $this->assertEquals(array("Foo\\stdClass", "Foo\\sub\\subClass", "Foo\\sub\\subsub\\subSubClass"), $classes);
+        $this->assertEquals(["Foo\\stdClass", "Foo\\sub\\subClass", "Foo\\sub\\subsub\\subSubClass"], $classes);
     }
 
     public function customNamespaceLookupQueryProvider()
     {
-        return array(
-            'directory separator'  => array(
+        return [
+            'directory separator'  => [
                 DIRECTORY_SEPARATOR,
                 "/_custom_ns/dir",
-                array(
+                [
                     "stdClass.yml"               => "Foo\\stdClass",
                     "sub/subClass.yml"           => "Foo\\sub\\subClass",
                     "sub/subsub/subSubClass.yml" => "Foo\\sub\\subsub\\subSubClass",
-                )
-            ),
-            'default dot separator' => array(
+                ]
+            ],
+            'default dot separator' => [
                 '.',
                 "/_custom_ns/dot",
-                array(
+                [
                     "stdClass.yml"               => "Foo\\stdClass",
                     "sub.subClass.yml"           => "Foo\\sub\\subClass",
                     "sub.subsub.subSubClass.yml" => "Foo\\sub\\subsub\\subSubClass",
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /** @dataProvider customNamespaceLookupQueryProvider
@@ -147,7 +147,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path   = __DIR__ . $dir;
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml", $separator);
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml", $separator);
 
         foreach ($files as $filePath => $className) {
             $this->assertEquals(realpath($path .'/'. $filePath), realpath($locator->findMappingFile($className)));
@@ -161,7 +161,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml");
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml");
 
         $this->assertEquals(__DIR__ . "/_files/stdClass.yml", $locator->findMappingFile("Foo\\stdClass"));
     }
@@ -171,7 +171,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        $locator = new SymfonyFileLocator(array($path => $prefix), ".yml");
+        $locator = new SymfonyFileLocator([$path => $prefix], ".yml");
 
         $this->setExpectedException(
             MappingException::class,

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 
@@ -96,7 +97,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
      * @param $separator string Directory separator to test against
      * @param $dir       string Path to load mapping data from
      *
-     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws MappingException
      */
     public function testGetClassNamesWithCustomNsSeparator($separator, $dir)
     {
@@ -139,7 +140,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
      * @param $dir       string Path to load mapping data from
      * @param $files     array  Files to lookup classnames
      *
-     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws MappingException
      */
     public function testFindMappingFileWithCustomNsSeparator($separator, $dir, $files)
     {
@@ -173,7 +174,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $locator = new SymfonyFileLocator(array($path => $prefix), ".yml");
 
         $this->setExpectedException(
-            "Doctrine\Common\Persistence\Mapping\MappingException",
+            MappingException::class,
             "No mapping file found named '".__DIR__."/_files/stdClass2.yml' for class 'Foo\stdClass2'."
         );
         $locator->findMappingFile("Foo\\stdClass2");

--- a/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
@@ -31,15 +31,15 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $class = new \ReflectionClass(ObjectManager::class);
 
-        $methods = array();
+        $methods = [];
         foreach ($class->getMethods() as $method) {
             if ($method->getNumberOfRequiredParameters() === 0) {
-               $methods[] = array($method->getName(), array());
+               $methods[] = [$method->getName(), []];
             } elseif ($method->getNumberOfRequiredParameters() > 0) {
-                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: array());
+                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: []];
             }
             if ($method->getNumberOfParameters() != $method->getNumberOfRequiredParameters()) {
-                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: array());
+                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: []];
             }
         }
 
@@ -56,8 +56,8 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
             ->method($method)
             ->will($this->returnValue('INNER VALUE FROM ' . $method));
 
-        call_user_func_array(array($stub, 'with'), $parameters);
+        call_user_func_array([$stub, 'with'], $parameters);
 
-        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array(array($this->decorated, $method), $parameters));
+        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array([$this->decorated, $method], $parameters));
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
@@ -15,18 +15,21 @@ class NullObjectManagerDecorator extends ObjectManagerDecorator
 
 class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ObjectManager
+     */
     private $wrapped;
     private $decorated;
 
     public function setUp()
     {
-        $this->wrapped = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->wrapped   = $this->getMock(ObjectManager::class);
         $this->decorated = new NullObjectManagerDecorator($this->wrapped);
     }
 
     public function getMethodParameters()
     {
-        $class = new \ReflectionClass('Doctrine\Common\Persistence\ObjectManager');
+        $class = new \ReflectionClass(ObjectManager::class);
 
         $methods = array();
         foreach ($class->getMethods() as $method) {

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -156,13 +156,13 @@ class TestObjectMetadata implements ClassMetadata
 
     public function getAssociationMappedByTargetField($assocName)
     {
-        $assoc = array('children' => 'parent');
+        $assoc = ['children' => 'parent'];
         return $assoc[$assocName];
     }
 
     public function getAssociationNames()
     {
-        return array('parent', 'children');
+        return ['parent', 'children'];
     }
 
     public function getAssociationTargetClass($assocName)
@@ -172,12 +172,12 @@ class TestObjectMetadata implements ClassMetadata
 
     public function getFieldNames()
     {
-        return array('id', 'name');
+        return ['id', 'name'];
     }
 
     public function getIdentifier()
     {
-        return array('id');
+        return ['id'];
     }
 
     public function getName()
@@ -192,18 +192,18 @@ class TestObjectMetadata implements ClassMetadata
 
     public function getTypeOfField($fieldName)
     {
-        $types = array('id' => 'integer', 'name' => 'string');
+        $types = ['id' => 'integer', 'name' => 'string'];
         return $types[$fieldName];
     }
 
     public function hasAssociation($fieldName)
     {
-        return in_array($fieldName, array('parent', 'children'));
+        return in_array($fieldName, ['parent', 'children']);
     }
 
     public function hasField($fieldName)
     {
-        return in_array($fieldName, array('id', 'name'));
+        return in_array($fieldName, ['id', 'name']);
     }
 
     public function isAssociationInverseSide($assocName)

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Common\Persistence;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\PersistentObject;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
@@ -18,7 +19,7 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
     public function setUp()
     {
         $this->cm = new TestObjectMetadata;
-        $this->om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $this->om = $this->getMock(ObjectManager::class);
         $this->om->expects($this->any())->method('getClassMetadata')
                  ->will($this->returnValue($this->cm));
         $this->object = new TestObject;
@@ -34,7 +35,7 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
     public function testNonMatchingObjectManager()
     {
         $this->setExpectedException('RuntimeException');
-        $om = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $om = $this->getMock(ObjectManager::class);
         $this->object->injectObjectManager($om, $this->cm);
     }
 

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -2,15 +2,22 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Proxy\ProxyDefinition;
+use OutOfBoundsException;
 
 class AbstractProxyFactoryTest extends DoctrineTestCase
 {
     public function testGenerateProxyClasses()
     {
-        $metadata       = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $proxyGenerator = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
+        $metadata       = $this->getMock(ClassMetadata::class);
+        $proxyGenerator = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
 
         $proxyGenerator
             ->expects($this->once())
@@ -19,9 +26,10 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
             ->expects($this->once())
             ->method('generateProxyClass');
 
-        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $metadataFactory = $this->getMock(ClassMetadataFactory::class);
+        /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory    = $this->getMockForAbstractClass(
-            'Doctrine\Common\Proxy\AbstractProxyFactory',
+            AbstractProxyFactory::class,
             array($proxyGenerator, $metadataFactory, true)
         );
 
@@ -37,19 +45,20 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
     public function testGetProxy()
     {
-        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $metadata        = $this->getMock(ClassMetadata::class);
+        $proxy           = $this->getMock(Proxy::class);
         $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
-        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
             ->expects($this->once())
             ->method('getMetadataFor')
             ->will($this->returnValue($metadata));
 
+        /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory = $this->getMockForAbstractClass(
-            'Doctrine\Common\Proxy\AbstractProxyFactory',
+            AbstractProxyFactory::class,
             array($proxyGenerator, $metadataFactory, true)
         );
 
@@ -65,19 +74,21 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
     public function testResetUnitializedProxy()
     {
-        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $metadata        = $this->getMock(ClassMetadata::class);
+        /* @var $proxy \PHPUnit_Framework_MockObject_MockObject|Proxy */
+        $proxy           = $this->getMock(Proxy::class);
         $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
-        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
             ->expects($this->once())
             ->method('getMetadataFor')
             ->will($this->returnValue($metadata));
 
+        /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory = $this->getMockForAbstractClass(
-            'Doctrine\Common\Proxy\AbstractProxyFactory',
+            AbstractProxyFactory::class,
             array($proxyGenerator, $metadataFactory, true)
         );
 
@@ -102,34 +113,37 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
     public function testDisallowsResettingInitializedProxy()
     {
-        $proxyFactory = $this->getMockForAbstractClass('Doctrine\Common\Proxy\AbstractProxyFactory',  array(), '', false);
-        $proxy        = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        /* @var $proxyFactory AbstractProxyFactory */
+        $proxyFactory = $this->getMockForAbstractClass(AbstractProxyFactory::class,  array(), '', false);
+        /* @var $proxy Proxy|\PHPUnit_Framework_MockObject_MockObject */
+        $proxy        = $this->getMock(Proxy::class);
 
         $proxy
             ->expects($this->any())
             ->method('__isInitialized')
             ->will($this->returnValue(true));
 
-        $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
 
         $proxyFactory->resetUninitializedProxy($proxy);
     }
 
     public function testMissingPrimaryKeyValue()
     {
-        $metadata        = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-        $proxy           = $this->getMock('Doctrine\Common\Proxy\Proxy');
+        $metadata        = $this->getMock(ClassMetadata::class);
+        $proxy           = $this->getMock(Proxy::class);
         $definition      = new ProxyDefinition(get_class($proxy), array('missingKey'), array(), null, null);
-        $proxyGenerator  = $this->getMock('Doctrine\Common\Proxy\ProxyGenerator', array(), array(), '', false);
-        $metadataFactory = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
             ->expects($this->once())
             ->method('getMetadataFor')
             ->will($this->returnValue($metadata));
 
+        /* @var $proxyFactory AbstractProxyFactory|\PHPUnit_Framework_MockObject_MockObject */
         $proxyFactory = $this->getMockForAbstractClass(
-            'Doctrine\Common\Proxy\AbstractProxyFactory',
+            AbstractProxyFactory::class,
             array($proxyGenerator, $metadataFactory, true)
         );
 
@@ -138,9 +152,9 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
             ->method('createProxyDefinition')
             ->will($this->returnValue($definition));
 
-        $this->setExpectedException('\OutOfBoundsException');
+        $this->setExpectedException(OutOfBoundsException::class);
 
-        $generatedProxy = $proxyFactory->getProxy('Class', array());
+        $proxyFactory->getProxy('Class', array());
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -17,7 +17,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
     public function testGenerateProxyClasses()
     {
         $metadata       = $this->getMock(ClassMetadata::class);
-        $proxyGenerator = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $proxyGenerator = $this->getMock(ProxyGenerator::class, [], [], '', false);
 
         $proxyGenerator
             ->expects($this->once())
@@ -30,7 +30,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory    = $this->getMockForAbstractClass(
             AbstractProxyFactory::class,
-            array($proxyGenerator, $metadataFactory, true)
+            [$proxyGenerator, $metadataFactory, true]
         );
 
         $proxyFactory
@@ -38,7 +38,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
             ->method('skipClass')
             ->will($this->returnValue(false));
 
-        $generated = $proxyFactory->generateProxyClasses(array($metadata), sys_get_temp_dir());
+        $generated = $proxyFactory->generateProxyClasses([$metadata], sys_get_temp_dir());
 
         $this->assertEquals(1, $generated, 'One proxy was generated');
     }
@@ -47,8 +47,8 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
     {
         $metadata        = $this->getMock(ClassMetadata::class);
         $proxy           = $this->getMock(Proxy::class);
-        $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
-        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $definition      = new ProxyDefinition(get_class($proxy), [], [], null, null);
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, [], [], '', false);
         $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
@@ -59,7 +59,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory = $this->getMockForAbstractClass(
             AbstractProxyFactory::class,
-            array($proxyGenerator, $metadataFactory, true)
+            [$proxyGenerator, $metadataFactory, true]
         );
 
         $proxyFactory
@@ -67,7 +67,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
             ->method('createProxyDefinition')
             ->will($this->returnValue($definition));
 
-        $generatedProxy = $proxyFactory->getProxy('Class', array('id' => 1));
+        $generatedProxy = $proxyFactory->getProxy('Class', ['id' => 1]);
 
         $this->assertInstanceOf(get_class($proxy), $generatedProxy);
     }
@@ -77,8 +77,8 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         $metadata        = $this->getMock(ClassMetadata::class);
         /* @var $proxy \PHPUnit_Framework_MockObject_MockObject|Proxy */
         $proxy           = $this->getMock(Proxy::class);
-        $definition      = new ProxyDefinition(get_class($proxy), array(), array(), null, null);
-        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $definition      = new ProxyDefinition(get_class($proxy), [], [], null, null);
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, [], [], '', false);
         $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
@@ -89,7 +89,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         /* @var $proxyFactory \PHPUnit_Framework_MockObject_MockObject|AbstractProxyFactory */
         $proxyFactory = $this->getMockForAbstractClass(
             AbstractProxyFactory::class,
-            array($proxyGenerator, $metadataFactory, true)
+            [$proxyGenerator, $metadataFactory, true]
         );
 
         $proxyFactory
@@ -114,7 +114,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
     public function testDisallowsResettingInitializedProxy()
     {
         /* @var $proxyFactory AbstractProxyFactory */
-        $proxyFactory = $this->getMockForAbstractClass(AbstractProxyFactory::class,  array(), '', false);
+        $proxyFactory = $this->getMockForAbstractClass(AbstractProxyFactory::class,  [], '', false);
         /* @var $proxy Proxy|\PHPUnit_Framework_MockObject_MockObject */
         $proxy        = $this->getMock(Proxy::class);
 
@@ -132,8 +132,8 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
     {
         $metadata        = $this->getMock(ClassMetadata::class);
         $proxy           = $this->getMock(Proxy::class);
-        $definition      = new ProxyDefinition(get_class($proxy), array('missingKey'), array(), null, null);
-        $proxyGenerator  = $this->getMock(ProxyGenerator::class, array(), array(), '', false);
+        $definition      = new ProxyDefinition(get_class($proxy), ['missingKey'], [], null, null);
+        $proxyGenerator  = $this->getMock(ProxyGenerator::class, [], [], '', false);
         $metadataFactory = $this->getMock(ClassMetadataFactory::class);
 
         $metadataFactory
@@ -144,7 +144,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         /* @var $proxyFactory AbstractProxyFactory|\PHPUnit_Framework_MockObject_MockObject */
         $proxyFactory = $this->getMockForAbstractClass(
             AbstractProxyFactory::class,
-            array($proxyGenerator, $metadataFactory, true)
+            [$proxyGenerator, $metadataFactory, true]
         );
 
         $proxyFactory
@@ -154,7 +154,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
 
         $this->setExpectedException(OutOfBoundsException::class);
 
-        $proxyFactory->getProxy('Class', array());
+        $proxyFactory->getProxy('Class', []);
     }
 }
 

--- a/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
@@ -30,11 +30,11 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
 {
     public static function dataResolveFile()
     {
-        return array(
-            array('/tmp', 'MyProxy', 'MyProxy\__CG__\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__RealClass.php'),
-            array('/tmp', 'MyProxy\Subdir', 'MyProxy\Subdir\__CG__\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__RealClass.php'),
-            array('/tmp', 'MyProxy', 'MyProxy\__CG__\Other\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__OtherRealClass.php'),
-        );
+        return [
+            ['/tmp', 'MyProxy', 'MyProxy\__CG__\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__RealClass.php'],
+            ['/tmp', 'MyProxy\Subdir', 'MyProxy\Subdir\__CG__\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__RealClass.php'],
+            ['/tmp', 'MyProxy', 'MyProxy\__CG__\Other\RealClass', '/tmp' . DIRECTORY_SEPARATOR . '__CG__OtherRealClass.php'],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AutoloaderTest.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
+use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
 use Doctrine\Common\Proxy\Autoloader;
 
@@ -62,7 +63,7 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
     public function testRegisterWithInvalidCallback()
     {
         $this->setExpectedException(
-            'Doctrine\Common\Proxy\Exception\InvalidArgumentException',
+            InvalidArgumentException::class,
             'Invalid \$notFoundCallback given: must be a callable, "stdClass" given'
         );
 

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
@@ -38,28 +38,28 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * @var array
      */
-    protected $identifier = array(
+    protected $identifier = [
         'publicIdentifierField'    => true,
         'protectedIdentifierField' => true,
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $fields = array(
+    protected $fields = [
         'publicIdentifierField'    => true,
         'protectedIdentifierField' => true,
         'publicPersistentField'    => true,
         'protectedPersistentField' => true,
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $associations = array(
+    protected $associations = [
         'publicAssociation'        => true,
         'protectedAssociation'     => true,
-    );
+    ];
 
     /**
      * {@inheritDoc}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicSleepClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicSleepClass.php
@@ -32,6 +32,6 @@ class MagicSleepClass
      */
     public function __sleep()
     {
-        return array('serializedField');
+        return ['serializedField'];
     }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -20,6 +20,9 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
+use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use ReflectionClass;
 use ReflectionMethod;
@@ -106,7 +109,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     public function testClassWithSleepProxyGeneration()
     {
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\SleepClass', false)) {
-            $className = 'Doctrine\Tests\Common\Proxy\SleepClass';
+            $className = SleepClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
@@ -125,7 +128,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     public function testClassWithStaticPropertyProxyGeneration()
     {
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\StaticPropertyClass', false)) {
-            $className = 'Doctrine\Tests\Common\Proxy\StaticPropertyClass';
+            $className = StaticPropertyClass::class;
             $metadata = $this->createClassMetadata($className, array());
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
@@ -151,7 +154,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         }
 
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\CallableTypeHintClass', false)) {
-            $className = 'Doctrine\Tests\Common\Proxy\CallableTypeHintClass';
+            $className = CallableTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
@@ -170,7 +173,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         }
 
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
-            $className = 'Doctrine\Tests\Common\Proxy\VariadicTypeHintClass';
+            $className = VariadicTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
@@ -191,7 +194,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         }
 
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ScalarTypeHintsClass', false)) {
-            $className = 'Doctrine\Tests\Common\Proxy\ScalarTypeHintsClass';
+            $className = ScalarTypeHintsClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
@@ -212,7 +215,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Method return types are only supported in PHP >= 7.0.0.');
         }
 
-        $className = 'Doctrine\Tests\Common\Proxy\ReturnTypesClass';
+        $className = ReturnTypesClass::class;
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ReturnTypesClass', false)) {
             $metadata = $this->createClassMetadata($className, array('id'));
 
@@ -232,12 +235,12 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testClassWithInvalidTypeHintOnProxiedMethod()
     {
-        $className = 'Doctrine\Tests\Common\Proxy\InvalidTypeHintClass';
+        $className = InvalidTypeHintClass::class;
         $metadata = $this->createClassMetadata($className, array('id'));
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
         $this->setExpectedException(
-            'Doctrine\Common\Proxy\Exception\UnexpectedValueException',
+            UnexpectedValueException::class,
             'The type hint of parameter "foo" in method "invalidTypeHintMethod"'
                 .' in class "' . $className . '" is invalid.'
         );
@@ -246,19 +249,19 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testNoConfigDirThrowsException()
     {
-        $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         new ProxyGenerator(null, null);
     }
 
     public function testNoNamespaceThrowsException()
     {
-        $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         new ProxyGenerator(__DIR__ . '/generated', null);
     }
 
     public function testInvalidPlaceholderThrowsException()
     {
-        $this->setExpectedException('Doctrine\Common\Proxy\Exception\InvalidArgumentException');
+        $this->setExpectedException(InvalidArgumentException::class);
         $generator = new ProxyGenerator(__DIR__ . '/generated', 'SomeNamespace');
         $generator->setPlaceholder('<somePlaceholder>', array());
     }
@@ -267,20 +270,22 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     {
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
-        $className = __NAMESPACE__ . '\\EvalBase';
-
-        $metadata = $this->createClassMetadata($className, array('id'));
-
-        $proxyGenerator->generateProxyClass($metadata);
+        $proxyGenerator->generateProxyClass($this->createClassMetadata(EvalBase::class, array('id')));
 
         $reflClass = new ReflectionClass('Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\EvalBase');
 
         $this->assertContains("eval()'d code", $reflClass->getFileName());
     }
 
+    /**
+     * @param       $className
+     * @param array $ids
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ClassMetadata
+     */
     private function createClassMetadata($className, array $ids)
     {
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->getMock(ClassMetadata::class);
         $reflClass = new ReflectionClass($className);
         $metadata->expects($this->any())->method('getReflectionClass')->will($this->returnValue($reflClass));
         $metadata->expects($this->any())->method('getIdentifierFieldNames')->will($this->returnValue($ids));

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -149,10 +149,6 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testClassWithCallableTypeHintOnProxiedMethod()
     {
-        if (PHP_VERSION_ID < 50400) {
-            $this->markTestSkipped('`callable` is only supported in PHP >=5.4.0');
-        }
-
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\CallableTypeHintClass', false)) {
             $className = CallableTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));
@@ -168,10 +164,6 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testClassWithVariadicArgumentOnProxiedMethod()
     {
-        if (PHP_VERSION_ID < 50600) {
-            $this->markTestSkipped('`...` is only supported in PHP >=5.6.0');
-        }
-
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
             $className = VariadicTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -110,7 +110,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     {
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\SleepClass', false)) {
             $className = SleepClass::class;
-            $metadata = $this->createClassMetadata($className, array('id'));
+            $metadata = $this->createClassMetadata($className, ['id']);
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -129,7 +129,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     {
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\StaticPropertyClass', false)) {
             $className = StaticPropertyClass::class;
-            $metadata = $this->createClassMetadata($className, array());
+            $metadata = $this->createClassMetadata($className, []);
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -151,7 +151,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     {
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\CallableTypeHintClass', false)) {
             $className = CallableTypeHintClass::class;
-            $metadata = $this->createClassMetadata($className, array('id'));
+            $metadata = $this->createClassMetadata($className, ['id']);
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -170,7 +170,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
             $className = VariadicTypeHintClass::class;
-            $metadata = $this->createClassMetadata($className, array('id'));
+            $metadata = $this->createClassMetadata($className, ['id']);
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -179,7 +179,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         $classCode = file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyVariadicTypeHintClass.php');
 
         $this->assertEquals(1, substr_count($classCode, 'function addType(...$types)'));
-        $this->assertEquals(1, substr_count($classCode, '__invoke($this, \'addType\', array($types))'));
+        $this->assertEquals(1, substr_count($classCode, '__invoke($this, \'addType\', [$types])'));
         $this->assertEquals(1, substr_count($classCode, 'parent::addType(...$types)'));
     }
 
@@ -191,7 +191,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ScalarTypeHintsClass', false)) {
             $className = ScalarTypeHintsClass::class;
-            $metadata = $this->createClassMetadata($className, array('id'));
+            $metadata = $this->createClassMetadata($className, ['id']);
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -213,7 +213,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
         $className = ReturnTypesClass::class;
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ReturnTypesClass', false)) {
-            $metadata = $this->createClassMetadata($className, array('id'));
+            $metadata = $this->createClassMetadata($className, ['id']);
 
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
             $this->generateAndRequire($proxyGenerator, $metadata);
@@ -232,7 +232,7 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     public function testClassWithInvalidTypeHintOnProxiedMethod()
     {
         $className = InvalidTypeHintClass::class;
-        $metadata = $this->createClassMetadata($className, array('id'));
+        $metadata = $this->createClassMetadata($className, ['id']);
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
         $this->setExpectedException(
@@ -259,14 +259,14 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
     {
         $this->setExpectedException(InvalidArgumentException::class);
         $generator = new ProxyGenerator(__DIR__ . '/generated', 'SomeNamespace');
-        $generator->setPlaceholder('<somePlaceholder>', array());
+        $generator->setPlaceholder('<somePlaceholder>', []);
     }
 
     public function testUseEvalIfNoFilenameIsGiven()
     {
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
-        $proxyGenerator->generateProxyClass($this->createClassMetadata(EvalBase::class, array('id')));
+        $proxyGenerator->generateProxyClass($this->createClassMetadata(EvalBase::class, ['id']));
 
         $reflClass = new ReflectionClass('Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\EvalBase');
 

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -164,6 +164,10 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testClassWithVariadicArgumentOnProxiedMethod()
     {
+        if (PHP_VERSION_ID < 50600) {
+            $this->markTestSkipped('`...` is only supported in PHP >=5.6.0');
+        }
+
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
             $className = VariadicTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, array('id'));

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -593,10 +593,6 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
 
     public function testCallingVariadicMethodCausesLazyLoading()
     {
-        if (PHP_VERSION_ID < 50600) {
-            $this->markTestSkipped('Test applies only to PHP 5.6+');
-        }
-
         $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\VariadicTypeHintClass';
 
         /* @var $metadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -593,6 +593,10 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
 
     public function testCallingVariadicMethodCausesLazyLoading()
     {
+        if (PHP_VERSION_ID < 50600) {
+            $this->markTestSkipped('`...` is only supported in PHP >=5.6.0');
+        }
+
         $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\VariadicTypeHintClass';
 
         /* @var $metadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -47,10 +47,10 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
      */
     protected $lazyObject;
 
-    protected $identifier = array(
+    protected $identifier = [
         'publicIdentifierField' => 'publicIdentifierFieldValue',
         'protectedIdentifierField' => 'protectedIdentifierFieldValue',
-    );
+    ];
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Callable
@@ -62,8 +62,8 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->proxyLoader = $loader      = $this->getMock('stdClass', array('load'), array(), '', false);
-        $this->initializerCallbackMock    = $this->getMock('stdClass', array('__invoke'));
+        $this->proxyLoader = $loader      = $this->getMock('stdClass', ['load'], [], '', false);
+        $this->initializerCallbackMock    = $this->getMock('stdClass', ['__invoke']);
         $identifier                       = $this->identifier;
         $this->lazyLoadableObjectMetadata = $metadata = new LazyLoadableObjectClassMetadata();
 
@@ -131,7 +131,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
     {
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, 'testInitializationTriggeringMethod', array()),
+            [$this->lazyObject, 'testInitializationTriggeringMethod', []],
             function (Proxy $proxy) {
                 $proxy->__setInitializer(null);
             }
@@ -146,7 +146,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__get', array('publicPersistentField')),
+            [$this->lazyObject, '__get', ['publicPersistentField']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', 'loadedValue');
             }
@@ -161,7 +161,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__get', array('publicAssociation')),
+            [$this->lazyObject, '__get', ['publicAssociation']],
             function () use ($test) {
                 $test->setProxyValue('publicAssociation', 'loadedAssociation');
             }
@@ -175,7 +175,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
     {
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, 'getProtectedAssociation', array()),
+            [$this->lazyObject, 'getProtectedAssociation', []],
             function (Proxy $proxy) {
                 $proxy->__setInitializer(null);
             }
@@ -190,7 +190,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__get', array('publicPersistentField')),
+            [$this->lazyObject, '__get', ['publicPersistentField']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', 'loadedValue');
                 $test->setProxyValue('publicAssociation', 'publicAssociationValue');
@@ -233,7 +233,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
     {
         $lazyObject = $this->lazyObject;
         $test = $this;
-        $cb = $this->getMock('stdClass', array('cb'));
+        $cb = $this->getMock('stdClass', ['cb']);
         $cb
             ->expects($this->once())
             ->method('cb')
@@ -244,7 +244,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
                 $proxy->publicAssociation = 'clonedAssociation';
             }));
 
-        $this->lazyObject->__setCloner($this->getClosure(array($cb, 'cb')));
+        $this->lazyObject->__setCloner($this->getClosure([$cb, 'cb']));
 
         $cloned = clone $this->lazyObject;
         $this->assertSame('clonedAssociation', $cloned->publicAssociation);
@@ -277,7 +277,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadProxyMethod()
     {
-        $this->configureInitializerMock(2, array($this->lazyObject, '__load', array()));
+        $this->configureInitializerMock(2, [$this->lazyObject, '__load', []]);
 
         $this->lazyObject->__load();
         $this->lazyObject->__load();
@@ -290,10 +290,10 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('load')
             ->with(
-                array(
+                [
                     'publicIdentifierField' => 'publicIdentifierFieldValue',
                     'protectedIdentifierField' => 'protectedIdentifierFieldValue',
-                ),
+                ],
                 $this->lazyObject
             )
             ->will($this->returnCallback(function ($id, LazyLoadableObject $lazyObject) {
@@ -324,10 +324,10 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
             ->proxyLoader
             ->expects($this->exactly(2))
             ->method('load')
-            ->with(array(
+            ->with([
                 'publicIdentifierField'    => 'publicIdentifierFieldValue',
                 'protectedIdentifierField' => 'protectedIdentifierFieldValue',
-            ))
+            ])
             ->will($this->returnCallback(function () {
                 $blueprint = new LazyLoadableObject();
                 $blueprint->publicPersistentField = 'checked-persistent-field';
@@ -526,7 +526,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__set', array('publicPersistentField', 'newPublicPersistentFieldValue')),
+            [$this->lazyObject, '__set', ['publicPersistentField', 'newPublicPersistentFieldValue']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', 'overrideValue');
                 $test->setProxyValue('publicAssociation', 'newAssociationValue');
@@ -543,7 +543,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__set', array('publicAssociation', 'newPublicAssociationValue')),
+            [$this->lazyObject, '__set', ['publicAssociation', 'newPublicAssociationValue']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', 'newPublicPersistentFieldValue');
                 $test->setProxyValue('publicAssociation', 'overrideValue');
@@ -560,7 +560,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__isset', array('publicPersistentField')),
+            [$this->lazyObject, '__isset', ['publicPersistentField']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', null);
                 $test->setProxyValue('publicAssociation', 'setPublicAssociation');
@@ -578,7 +578,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $test = $this;
         $this->configureInitializerMock(
             1,
-            array($this->lazyObject, '__isset', array('publicAssociation')),
+            [$this->lazyObject, '__isset', ['publicAssociation']],
             function () use ($test) {
                 $test->setProxyValue('publicPersistentField', 'newPersistentFieldValue');
                 $test->setProxyValue('publicAssociation', 'setPublicAssociation');
@@ -619,7 +619,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         }
 
         /* @var $invocationMock callable|\PHPUnit_Framework_MockObject_MockObject */
-        $invocationMock = $this->getMock('stdClass', array('__invoke'));
+        $invocationMock = $this->getMock('stdClass', ['__invoke']);
 
         /* @var $lazyObject VariadicTypeHintClass */
         $lazyObject = new $proxyClassName(
@@ -632,19 +632,19 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $invocationMock
             ->expects($this->at(0))
             ->method('__invoke')
-            ->with($lazyObject, 'addType', array(array('type1', 'type2')));
+            ->with($lazyObject, 'addType', [['type1', 'type2']]);
         $invocationMock
             ->expects($this->at(1))
             ->method('__invoke')
-            ->with($lazyObject, 'addTypeWithMultipleParameters', array('foo', 'bar', array('baz1', 'baz2')));
+            ->with($lazyObject, 'addTypeWithMultipleParameters', ['foo', 'bar', ['baz1', 'baz2']]);
 
         $lazyObject->addType('type1', 'type2');
-        $this->assertSame(array('type1', 'type2'), $lazyObject->types);
+        $this->assertSame(['type1', 'type2'], $lazyObject->types);
 
         $lazyObject->addTypeWithMultipleParameters('foo', 'bar', 'baz1', 'baz2');
         $this->assertSame('foo', $lazyObject->foo);
         $this->assertSame('bar', $lazyObject->bar);
-        $this->assertSame(array('baz1', 'baz2'), $lazyObject->baz);
+        $this->assertSame(['baz1', 'baz2'], $lazyObject->baz);
     }
 
     /**
@@ -682,7 +682,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         $invocationMocker = $this->initializerCallbackMock->expects($invocationCountMatcher)->method('__invoke');
 
         if (null !== $callParamsMatch) {
-            call_user_func_array(array($invocationMocker, 'with'), $callParamsMatch);
+            call_user_func_array([$invocationMocker, 'with'], $callParamsMatch);
         }
 
         if ($callbackClosure) {

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -599,17 +599,17 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
 
         $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\VariadicTypeHintClass';
 
-        /* @var $metadata \Doctrine\Common\Persistence\Mapping\ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        /* @var $metadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
+        $metadata = $this->getMock(ClassMetadata::class);
 
         $metadata
             ->expects($this->any())
             ->method('getName')
-            ->will($this->returnValue('Doctrine\Tests\Common\Proxy\VariadicTypeHintClass'));
+            ->will($this->returnValue(VariadicTypeHintClass::class));
         $metadata
             ->expects($this->any())
             ->method('getReflectionClass')
-            ->will($this->returnValue(new \ReflectionClass('Doctrine\Tests\Common\Proxy\VariadicTypeHintClass')));
+            ->will($this->returnValue(new \ReflectionClass(VariadicTypeHintClass::class)));
 
         // creating the proxy class
         if (!class_exists($proxyClassName, false)) {
@@ -621,7 +621,7 @@ class ProxyLogicTest extends PHPUnit_Framework_TestCase
         /* @var $invocationMock callable|\PHPUnit_Framework_MockObject_MockObject */
         $invocationMock = $this->getMock('stdClass', array('__invoke'));
 
-        /* @var $lazyObject \Doctrine\Tests\Common\Proxy\VariadicTypeHintClass */
+        /* @var $lazyObject VariadicTypeHintClass */
         $lazyObject = new $proxyClassName(
             function ($proxy, $method, $parameters) use ($invocationMock) {
                 $invocationMock($proxy, $method, $parameters);

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -19,9 +19,9 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\Common\Proxy\Proxy;
-use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 
@@ -67,7 +67,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicGet()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicGetClass');
+        $proxyClassName = $this->generateProxyClass(MagicGetClass::class);
         $proxy          = new $proxyClassName(
             function (Proxy $proxy, $method, $params) use (&$counter) {
                 if ( ! in_array($params[0], array('publicField', 'test', 'notDefined'))) {
@@ -99,7 +99,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
      */
     public function testInheritedMagicGetByRef()
     {
-        $proxyClassName    = $this->generateProxyClass(__NAMESPACE__ . '\\MagicGetByRefClass');
+        $proxyClassName    = $this->generateProxyClass(MagicGetByRefClass::class);
         /* @var $proxy \Doctrine\Tests\Common\Proxy\MagicGetByRefClass */
         $proxy             = new $proxyClassName();
         $proxy->valueField = 123;
@@ -118,7 +118,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicSet()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicSetClass');
+        $proxyClassName = $this->generateProxyClass(MagicSetClass::class);
         $proxy          = new $proxyClassName(
             function (Proxy  $proxy, $method, $params) use (&$counter) {
                 if ( ! in_array($params[0], array('publicField', 'test', 'notDefined'))) {
@@ -147,7 +147,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicSleep()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicSleepClass');
+        $proxyClassName = $this->generateProxyClass(MagicSleepClass::class);
         $proxy          = new $proxyClassName();
 
         $this->assertSame('defaultValue', $proxy->serializedField);
@@ -164,7 +164,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicWakeup()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicWakeupClass');
+        $proxyClassName = $this->generateProxyClass(MagicWakeupClass::class);
         $proxy          = new $proxyClassName();
 
         $this->assertSame('defaultValue', $proxy->wakeupValue);
@@ -185,7 +185,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicIsset()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicIssetClass');
+        $proxyClassName = $this->generateProxyClass(MagicIssetClass::class);
         $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
             if (in_array($params[0], array('publicField', 'test', 'nonExisting'))) {
                 $initializer = $proxy->__getInitializer();
@@ -215,7 +215,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
 
     public function testInheritedMagicClone()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\MagicCloneClass');
+        $proxyClassName = $this->generateProxyClass(MagicCloneClass::class);
         $proxy          = new $proxyClassName(
             null,
             function ($proxy) {
@@ -235,7 +235,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
      */
     public function testClonesPrivateProperties()
     {
-        $proxyClassName = $this->generateProxyClass(__NAMESPACE__ . '\\SerializedClass');
+        $proxyClassName = $this->generateProxyClass(SerializedClass::class);
         /* @var $proxy SerializedClass */
         $proxy          = new $proxyClassName();
 
@@ -263,7 +263,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
             return $proxyClassName;
         }
 
-        $metadata = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $metadata = $this->getMock(ClassMetadata::class);
 
         $metadata
             ->expects($this->any())

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -42,10 +42,10 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
      */
     protected $lazyObject;
 
-    protected $identifier = array(
+    protected $identifier = [
         'publicIdentifierField' => 'publicIdentifierFieldValue',
         'protectedIdentifierField' => 'protectedIdentifierFieldValue',
-    );
+    ];
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Callable
@@ -70,7 +70,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
         $proxyClassName = $this->generateProxyClass(MagicGetClass::class);
         $proxy          = new $proxyClassName(
             function (Proxy $proxy, $method, $params) use (&$counter) {
-                if ( ! in_array($params[0], array('publicField', 'test', 'notDefined'))) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
                     throw new \InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
                 }
 
@@ -121,7 +121,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
         $proxyClassName = $this->generateProxyClass(MagicSetClass::class);
         $proxy          = new $proxyClassName(
             function (Proxy  $proxy, $method, $params) use (&$counter) {
-                if ( ! in_array($params[0], array('publicField', 'test', 'notDefined'))) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
                     throw new \InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
                 }
 
@@ -187,7 +187,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
     {
         $proxyClassName = $this->generateProxyClass(MagicIssetClass::class);
         $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
-            if (in_array($params[0], array('publicField', 'test', 'nonExisting'))) {
+            if (in_array($params[0], ['publicField', 'test', 'nonExisting'])) {
                 $initializer = $proxy->__getInitializer();
 
                 $proxy->__setInitializer(null);
@@ -273,7 +273,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
         $metadata
             ->expects($this->any())
             ->method('getIdentifier')
-            ->will($this->returnValue(array('id')));
+            ->will($this->returnValue(['id']));
 
         $metadata
             ->expects($this->any())
@@ -291,7 +291,7 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('hasField')
             ->will($this->returnCallback(function ($fieldName) {
-                return in_array($fieldName, array('id', 'publicField'));
+                return in_array($fieldName, ['id', 'publicField']);
             }));
 
         $metadata
@@ -302,17 +302,17 @@ class ProxyMagicMethodsTest extends PHPUnit_Framework_TestCase
         $metadata
             ->expects($this->any())
             ->method('getFieldNames')
-            ->will($this->returnValue(array('id', 'publicField')));
+            ->will($this->returnValue(['id', 'publicField']));
 
         $metadata
             ->expects($this->any())
             ->method('getIdentifierFieldNames')
-            ->will($this->returnValue(array('id')));
+            ->will($this->returnValue(['id']));
 
         $metadata
             ->expects($this->any())
             ->method('getAssociationNames')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $metadata
             ->expects($this->any())

--- a/tests/Doctrine/Tests/Common/Proxy/SleepClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/SleepClass.php
@@ -14,6 +14,6 @@ class SleepClass
      */
     public function __sleep()
     {
-        return array('id');
+        return ['id'];
     }
 }

--- a/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
@@ -10,7 +10,7 @@ class RuntimePublicReflectionPropertyTest extends PHPUnit_Framework_TestCase
 {
     public function testGetValueOnProxyPublicProperty()
     {
-        $getCheckMock = $this->getMock('stdClass', array('callGet'));
+        $getCheckMock = $this->getMock('stdClass', ['callGet']);
         $getCheckMock->expects($this->never())->method('callGet');
         $initializer = function () use ($getCheckMock) {
             call_user_func($getCheckMock);
@@ -31,10 +31,10 @@ class RuntimePublicReflectionPropertyTest extends PHPUnit_Framework_TestCase
 
     public function testSetValueOnProxyPublicProperty()
     {
-        $setCheckMock = $this->getMock('stdClass', array('neverCallSet'));
+        $setCheckMock = $this->getMock('stdClass', ['neverCallSet']);
         $setCheckMock->expects($this->never())->method('neverCallSet');
         $initializer = function () use ($setCheckMock) {
-            call_user_func(array($setCheckMock, 'neverCallSet'));
+            call_user_func([$setCheckMock, 'neverCallSet']);
         };
 
         $mockProxy = new RuntimePublicReflectionPropertyTestProxyMock();
@@ -52,10 +52,10 @@ class RuntimePublicReflectionPropertyTest extends PHPUnit_Framework_TestCase
         $reflProperty->setValue($mockProxy, 'otherNewValue');
         $this->assertSame('otherNewValue', $mockProxy->checkedProperty);
 
-        $setCheckMock = $this->getMock('stdClass', array('callSet'));
+        $setCheckMock = $this->getMock('stdClass', ['callSet']);
         $setCheckMock->expects($this->once())->method('callSet');
         $initializer = function () use ($setCheckMock) {
-            call_user_func(array($setCheckMock, 'callSet'));
+            call_user_func([$setCheckMock, 'callSet']);
         };
 
         $mockProxy->__setInitializer($initializer);

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\Common\Reflection;
 
+use Doctrine\Tests\Common\Reflection\NoParent;
+use Doctrine\Tests\Common\Reflection\Dummies\NoParent as NoParentDummy;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Common\Reflection\StaticReflectionParser;
 use Doctrine\Common\Reflection\Psr0FindFile;
@@ -41,23 +43,23 @@ class StaticReflectionParserTest extends DoctrineTestCase
     public function parentClassData()
     {
         $data = array();
-        $noParentClassName = 'Doctrine\\Tests\\Common\\Reflection\\NoParent';
-        $dummyParentClassName = 'Doctrine\\Tests\\Common\\Reflection\\Dummies\\NoParent';
+        $noParentClassName = NoParent::class;
+        $dummyParentClassName = NoParentDummy::class;
         foreach (array(false, true) as $classAnnotationOptimize) {
             $data[] = array(
               $classAnnotationOptimize, $noParentClassName, $noParentClassName,
             );
             $data[] = array(
-              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\FullyClassifiedParent', $noParentClassName,
+              $classAnnotationOptimize, FullyClassifiedParent::class, $noParentClassName,
             );
             $data[] = array(
-              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\SameNamespaceParent', $noParentClassName,
+              $classAnnotationOptimize, SameNamespaceParent::class, $noParentClassName,
             );
             $data[] = array(
-              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\DeeperNamespaceParent', $dummyParentClassName,
+              $classAnnotationOptimize, DeeperNamespaceParent::class, $dummyParentClassName,
             );
             $data[] = array(
-              $classAnnotationOptimize, 'Doctrine\\Tests\\Common\\Reflection\\UseParent', $dummyParentClassName,
+              $classAnnotationOptimize, UseParent::class, $dummyParentClassName,
             );
         }
         return $data;
@@ -71,7 +73,7 @@ class StaticReflectionParserTest extends DoctrineTestCase
         $paths = array(
           'Doctrine\\Tests' => array($testsRoot),
         );
-        $staticReflectionParser = new StaticReflectionParser('Doctrine\\Tests\\Common\\Reflection\\ExampleAnnotationClass', new Psr0FindFile($paths), $classAnnotationOptimize);
+        $staticReflectionParser = new StaticReflectionParser(ExampleAnnotationClass::class, new Psr0FindFile($paths), $classAnnotationOptimize);
         $expectedDocComment = '/**
  * @Annotation(
  *   key = "value"

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -28,9 +28,9 @@ class StaticReflectionParserTest extends DoctrineTestCase
         }
 
         $testsRoot = substr(__DIR__, 0, -strlen(__NAMESPACE__) - 1);
-        $paths = array(
-            'Doctrine\\Tests' => array($testsRoot),
-        );
+        $paths = [
+            'Doctrine\\Tests' => [$testsRoot],
+        ];
         $staticReflectionParser = new StaticReflectionParser($parsedClassName, new Psr0FindFile($paths), $classAnnotationOptimize);
         $declaringClassName = $staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', 'test')->getClassName();
         $this->assertEquals($expectedClassName, $declaringClassName);
@@ -42,25 +42,25 @@ class StaticReflectionParserTest extends DoctrineTestCase
      */
     public function parentClassData()
     {
-        $data = array();
+        $data = [];
         $noParentClassName = NoParent::class;
         $dummyParentClassName = NoParentDummy::class;
-        foreach (array(false, true) as $classAnnotationOptimize) {
-            $data[] = array(
+        foreach ([false, true] as $classAnnotationOptimize) {
+            $data[] = [
               $classAnnotationOptimize, $noParentClassName, $noParentClassName,
-            );
-            $data[] = array(
+            ];
+            $data[] = [
               $classAnnotationOptimize, FullyClassifiedParent::class, $noParentClassName,
-            );
-            $data[] = array(
+            ];
+            $data[] = [
               $classAnnotationOptimize, SameNamespaceParent::class, $noParentClassName,
-            );
-            $data[] = array(
+            ];
+            $data[] = [
               $classAnnotationOptimize, DeeperNamespaceParent::class, $dummyParentClassName,
-            );
-            $data[] = array(
+            ];
+            $data[] = [
               $classAnnotationOptimize, UseParent::class, $dummyParentClassName,
-            );
+            ];
         }
         return $data;
     }
@@ -70,9 +70,9 @@ class StaticReflectionParserTest extends DoctrineTestCase
      */
     public function testClassAnnotationOptimizedParsing($classAnnotationOptimize) {
         $testsRoot = substr(__DIR__, 0, -strlen(__NAMESPACE__) - 1);
-        $paths = array(
-          'Doctrine\\Tests' => array($testsRoot),
-        );
+        $paths = [
+          'Doctrine\\Tests' => [$testsRoot],
+        ];
         $staticReflectionParser = new StaticReflectionParser(ExampleAnnotationClass::class, new Psr0FindFile($paths), $classAnnotationOptimize);
         $expectedDocComment = '/**
  * @Annotation(
@@ -87,9 +87,9 @@ class StaticReflectionParserTest extends DoctrineTestCase
      */
     public function classAnnotationOptimize()
     {
-        return array(
-            array(false),
-            array(true)
-        );
+        return [
+            [false],
+            [true]
+        ];
     }
 }

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -9,13 +9,13 @@ namespace Doctrine\Tests\Common\Util
     {
         static public function dataGetClass()
         {
-            return array(
-                array(\stdClass::class, \stdClass::class),
-                array(\Doctrine\Common\Util\ClassUtils::class, \Doctrine\Common\Util\ClassUtils::class),
-                array( 'MyProject\Proxies\__CG__\stdClass', \stdClass::class),
-                array( 'MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\stdClass', \stdClass::class),
-                array( 'MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject', ChildObject::class)
-            );
+            return [
+                [\stdClass::class, \stdClass::class],
+                [\Doctrine\Common\Util\ClassUtils::class, \Doctrine\Common\Util\ClassUtils::class],
+                [ 'MyProject\Proxies\__CG__\stdClass', \stdClass::class],
+                [ 'MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\stdClass', \stdClass::class],
+                [ 'MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject', ChildObject::class]
+            ];
         }
 
         /**

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -10,11 +10,11 @@ namespace Doctrine\Tests\Common\Util
         static public function dataGetClass()
         {
             return array(
-                array('stdClass', 'stdClass'),
-                array('Doctrine\Common\Util\ClassUtils', 'Doctrine\Common\Util\ClassUtils'),
-                array( 'MyProject\Proxies\__CG__\stdClass', 'stdClass' ),
-                array( 'MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\stdClass', 'stdClass' ),
-                array( 'MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject','Doctrine\Tests\Common\Util\ChildObject' )
+                array(\stdClass::class, \stdClass::class),
+                array(\Doctrine\Common\Util\ClassUtils::class, \Doctrine\Common\Util\ClassUtils::class),
+                array( 'MyProject\Proxies\__CG__\stdClass', \stdClass::class),
+                array( 'MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\stdClass', \stdClass::class),
+                array( 'MyProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject', ChildObject::class)
             );
         }
 

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -27,12 +27,12 @@ class DebugTest extends DoctrineTestCase
 
     public function testExportArrayTraversable()
     {
-        $obj = new \ArrayObject(array('foobar'));
+        $obj = new \ArrayObject(['foobar']);
 
         $var = Debug::export($obj, 2);
         $this->assertContains('foobar', $var->__STORAGE__);
 
-        $it = new \ArrayIterator(array('foobar'));
+        $it = new \ArrayIterator(['foobar']);
 
         $var = Debug::export($it, 5);
         $this->assertContains('foobar', $var->__STORAGE__);


### PR DESCRIPTION
Currently removes 5.3, 5.4 and 5.5 support from `doctrine/common`.

I'll probably revert the 5.5 drop for now, though.