### PR TITLE
Improve MappingData retrieval by caching Results.

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -117,6 +117,8 @@ abstract class FileDriver implements MappingDriver
             throw MappingException::invalidMappingFile($className, str_replace('\\', '.', $className) . $this->locator->getFileExtension());
         }
 
+        $this->classCache[$className] = $result[$className];
+
         return $result[$className];
     }
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -55,10 +55,10 @@ class FileDriverTest extends DoctrineTestCase
         $driver = new TestFileDriver($locator);
 
         // not cached
-        $driver->getElement('stdClass');
+        $this->assertEquals('stdClass', $driver->getElement('stdClass'));
 
         // cached call
-        $driver->getElement('stdClass');
+        $this->assertEquals('stdClass', $driver->getElement('stdClass'));
     }
 
     public function testGetAllClassNamesGlobalBasename()

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -42,6 +42,25 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals('stdClass', $driver->getElement('stdClass'));
     }
 
+    public function testGetElementUpdatesClassCache()
+    {
+        $locator = $this->newLocator();
+
+        // findMappingFile should only be called once
+        $locator->expects($this->once())
+            ->method('findMappingFile')
+            ->with($this->equalTo('stdClass'))
+            ->will($this->returnValue(__DIR__ . '/_files/stdClass.yml'));
+
+        $driver = new TestFileDriver($locator);
+
+        // not cached
+        $driver->getElement('stdClass');
+
+        // cached call
+        $driver->getElement('stdClass');
+    }
+
     public function testGetAllClassNamesGlobalBasename()
     {
         $driver = new TestFileDriver($this->newLocator());


### PR DESCRIPTION
In cases where mapping Data is not cached by calling ```initilaize();```
It makes sense to cache results after parsing the Yaml file.