### PR TITLE
Don't fail if the cached type is not ClassMetadata

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -208,7 +208,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
 
         try {
             if ($this->cacheDriver) {
-                if (($cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt)) !== false) {
+                if (($cached = $this->cacheDriver->fetch($realClassName . $this->cacheSalt)) instanceof ClassMetadata) {
                     $this->loadedMetadata[$realClassName] = $cached;
 
                     $this->wakeupReflection($cached, $this->getReflectionService());


### PR DESCRIPTION
This is a random error and I didn't found yet how to reproduce it. It may related with Zend OPCache as usuallly is thrown while hot deploy new versions

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Doctrine\\ORM\\Mapping\\ClassMetadataFactory::wakeupReflection() must implement interface Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata, array given,
called in /v2/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php on line 214 and defined in /v2/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php:718
Stack trace:
#0 /v2/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php(214): Doctrine\\ORM\\Mapping\\ClassMetadataFactory->wakeupReflection(Array, Object(Doctrine\\Common\\Persistence\\Mapping\\RuntimeReflectionService))
#1 /v2/vendor/doctrine/orm/lib/Doctrine/ORM/EntityManager.php(281): Doctrine\\Common\\Persistence\\Mapping\\AbstractClassMetadataFactory->getMetadataFor('Model\\\\...')
#2 /v2/vendor/doctrine/orm/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php(44): Doctrine\\ORM\\EntityManager->getClassMetadata('Model\\\\...')
#3 /v2/vendor/doctrine/orm/ in /v2/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php on line 718
```
