### PR TITLE
Remove empty /lib/vendor directory from auto-generated ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ tests export-ignore
 build.properties export-ignore
 build.xml export-ignore
 phpunit.xml.dist export-ignore
+/lib/vendor export-ignore


### PR DESCRIPTION
In the downloaded ZIP archive there's an empty /lib/vendor directory... let's remove it
