### PR TITLE
Improve the phpdoc of ObjectRepository

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -34,7 +34,7 @@ interface ObjectRepository
      *
      * @param mixed $id The identifier.
      *
-     * @return object The object.
+     * @return object|null The object.
      */
     public function find($id);
 
@@ -68,7 +68,7 @@ interface ObjectRepository
      *
      * @param array $criteria The criteria.
      *
-     * @return object The object.
+     * @return object|null The object.
      */
     public function findOneBy(array $criteria);
 


### PR DESCRIPTION
`find()` and `findOne()` methods can return `null` but it wasn't documented. I had to go to the implementation to be absolutely certain.