### PR TITLE
Allows invalid type hints

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -767,6 +767,14 @@ EOT;
                 continue;
             }
 
+            // Checks earlier that the parameters type hint are valid.
+            try {
+                $parameters = $this->buildParametersString($class, $method, $method->getParameters());
+            } catch (UnexpectedValueException $exception) {
+                // in case a type hint is invalid, the method won't be callable anyway
+                continue;
+            }
+
             $methodNames[$name] = true;
             $methods .= "\n    /**\n"
                 . "     * {@inheritDoc}\n"
@@ -777,7 +785,7 @@ EOT;
                 $methods .= '&';
             }
 
-            $methods .= $name . '(' . $this->buildParametersString($class, $method, $method->getParameters()) . ')';
+            $methods .= $name . '(' . $parameters . ')';
             $methods .= $this->getMethodReturnType($method);
             $methods .= "\n" . '    {' . "\n";
 

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyClassGeneratorTest.php
@@ -235,12 +235,10 @@ class ProxyClassGeneratorTest extends PHPUnit_Framework_TestCase
         $metadata = $this->createClassMetadata($className, ['id']);
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
 
-        $this->setExpectedException(
-            UnexpectedValueException::class,
-            'The type hint of parameter "foo" in method "invalidTypeHintMethod"'
-                .' in class "' . $className . '" is invalid.'
-        );
-        $proxyGenerator->generateProxyClass($metadata);
+        $this->generateAndRequire($proxyGenerator, $metadata);
+        $classCode = file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyInvalidTypeHintClass.php');
+
+        $this->assertNotContains('function foo', $classCode);
     }
 
     public function testNoConfigDirThrowsException()


### PR DESCRIPTION
The doctrine proxies can't be generated when a class contains an invalid type hint but this behaviour causes issues in case a type hint is voluntary invalid (see https://github.com/FriendsOfSymfony/FOSCommentBundle/issues/538#issuecomment-225862002).

So my proposal is to simply ignore methods containing invalid type hints because they won't be callable anyway.