### PR TITLE
Add enum abstraction

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+\Doctrine\Common\Enum\Factory::registerEngine(new \Doctrine\Common\Enum\Engine\SPL());
+\Doctrine\Common\Enum\Factory::registerEngine(new \Doctrine\Common\Enum\Engine\MyCLabs());

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "autoload": {
         "psr-4": {
             "Doctrine\\Common\\": "lib/Doctrine/Common"
-        }
+        },
+        "files": [ "bootstrap.php" ]
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/Common/Enum/AbstractEngine.php
+++ b/lib/Doctrine/Common/Enum/AbstractEngine.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Enum;
+
+/**
+ * AbstractEngine
+ */
+abstract class AbstractEngine implements Engine
+{
+    const BASE_CLASS_NAME = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($enumName)
+    {
+        return class_exists(static::BASE_CLASS_NAME) &&
+            is_subclass_of($enumName, static::BASE_CLASS_NAME);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue($enum)
+    {
+        if (!$this->supports($enum)) {
+            throw new \InvalidArgumentException(sprintf(
+                "A %s is expected in getValue().",
+                static::BASE_CLASS_NAME
+            ));
+        }
+
+        return (string) $enum;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createByKey($enumName, $key)
+    {
+        if (!$this->supports($enumName)) {
+            throw new \InvalidArgumentException(sprintf(
+                "A %s is expected in createByKey().",
+                static::BASE_CLASS_NAME
+            ));
+        }
+
+        return new $enumName($enumName::$key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createByValue($enumName, $value)
+    {
+        if (!$this->supports($enumName)) {
+            throw new \InvalidArgumentException(sprintf(
+                "A %s is expected in createByValue().",
+                static::BASE_CLASS_NAME
+            ));
+        }
+
+        return new $enumName($value);
+    }
+}

--- a/lib/Doctrine/Common/Enum/Engine.php
+++ b/lib/Doctrine/Common/Enum/Engine.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Enum;
+
+/**
+ * Engine
+ */
+interface Engine
+{
+    /**
+     * Checks if the Enum class is supported by the engine.
+     *
+     * @param string $enumName
+     *
+     * @return bool
+     */
+    public function supports($enumName);
+
+    /**
+     * Returns a list of accepted values for the enum.
+     *
+     * @param string $enumName
+     * @return array
+     *
+     * @throws \InvalidArgumentException if a unsupported enum is passed.
+     */
+    public function getValues($enumName);
+
+    /**
+     * Returns the current value of the enum.
+     *
+     * @param mixed $enum
+     * @return array
+     *
+     * @throws \InvalidArgumentException if a unsupported enum is passed.
+     */
+    public function getValue($enum);
+
+    /**
+     * Creates a enum instance by specifying the enum name and the value.
+     *
+     * @param string $enumName
+     * @param mixed  $key
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException if a unsupported enumName is passed.
+     * @throws \UnexpectedValueException if key is not valid for the enum.
+     */
+    public function createByKey($enumName, $key);
+
+    /**
+     * Creates a enum instance by specifying the enum name and the value.
+     *
+     * @param string $enumName
+     * @param mixed  $value
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException if a unsupported enumName is passed.
+     * @throws \UnexpectedValueException if value is not valid for the enum.
+     */
+    public function createByValue($enumName, $value);
+}

--- a/lib/Doctrine/Common/Enum/Engine/MyCLabs.php
+++ b/lib/Doctrine/Common/Enum/Engine/MyCLabs.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Enum\Engine;
+
+use Doctrine\Common\Enum\AbstractEngine;
+use Doctrine\Common\Enum\Engine;
+
+/**
+ * MyCLabs
+ */
+class MyCLabs extends AbstractEngine implements Engine
+{
+    const BASE_CLASS_NAME = '\MyCLabs\Enum\Enum';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues($enumName)
+    {
+        if (!$this->supports($enumName)) {
+            throw new \InvalidArgumentException(sprintf(
+                "A %s is expected in getValues().",
+                self::BASE_CLASS_NAME
+            ));
+        }
+
+        return $enumName::values();
+    }
+}

--- a/lib/Doctrine/Common/Enum/Engine/SPL.php
+++ b/lib/Doctrine/Common/Enum/Engine/SPL.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Enum\Engine;
+
+use Doctrine\Common\Enum\AbstractEngine;
+use Doctrine\Common\Enum\Engine;
+
+/**
+ * SPL
+ */
+class SPL extends AbstractEngine implements Engine
+{
+    const BASE_CLASS_NAME = '\SplEnum';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValues($enumName)
+    {
+        if (!$this->supports($enumName)) {
+            throw new \InvalidArgumentException(sprintf(
+                "A %s is expected in getValues().",
+                self::BASE_CLASS_NAME
+            ));
+        }
+
+        /** @var $dummy \SplEnum */
+        $dummy = new $enumName($enumName::__default);
+
+        return $dummy->getConstList();
+    }
+}

--- a/lib/Doctrine/Common/Enum/Factory.php
+++ b/lib/Doctrine/Common/Enum/Factory.php
@@ -1,0 +1,128 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Enum;
+
+/**
+ * Factory
+ */
+class Factory
+{
+    /**
+     * A map of engines to handle enum operations.
+     *
+     * @var Engine[]
+     */
+    static private $engines = array();
+
+    /**
+     * Adds an engine to the factory.
+     *
+     * @param Engine $engine
+     *
+     * @return void
+     */
+    public static function registerEngine(Engine $engine)
+    {
+        if (!in_array($engine, self::$engines)) {
+            self::$engines[] = $engine;
+        }
+    }
+
+    /**
+     * Returns first engine that supports handling of $enum.
+     *
+     * @param string $enumName
+     *
+     * @return Engine
+     *
+     * @throws \InvalidArgumentException if no engine is found.
+     */
+    private static function findSupportingEngine($enumName)
+    {
+        foreach (self::$engines as $engine) {
+            if ($engine->supports($enumName)) {
+                return $engine;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            "No engine is supporting %s.",
+            $enumName
+        ));
+    }
+
+    /**
+     * Returns a list of accepted values for the enum.
+     *
+     * @param string $enumName
+     * @return array
+     *
+     * @throws \InvalidArgumentException if a unsupported enum is passed.
+     */
+    public static function getValues($enumName)
+    {
+        return self::findSupportingEngine($enumName)->getValues($enumName);
+    }
+
+    /**
+     * Returns the current value of the enum.
+     *
+     * @param mixed $enum
+     * @return array
+     *
+     * @throws \InvalidArgumentException if a unsupported enum is passed.
+     */
+    public static function getValue($enum)
+    {
+        return self::findSupportingEngine(get_class($enum))->getValue($enum);
+    }
+
+    /**
+     * Creates a enum instance by specifying the enum name and the value.
+     *
+     * @param string $enumName
+     * @param mixed  $key
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException if a unsupported enumName is passed.
+     * @throws \UnexpectedValueException if key is not valid for the enum.
+     */
+    public static function createByKey($enumName, $key)
+    {
+        return self::findSupportingEngine($enumName)->createByKey($enumName, $key);
+    }
+
+    /**
+     * Creates a enum instance by specifying the enum name and the value.
+     *
+     * @param string $enumName
+     * @param mixed  $value
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException if a unsupported enumName is passed.
+     * @throws \UnexpectedValueException if value is not valid for the enum.
+     */
+    public static function createByValue($enumName, $value)
+    {
+        return self::findSupportingEngine($enumName)->createByValue($enumName, $value);
+    }
+}


### PR DESCRIPTION
Adding abstraction to handle enum types.

For working with enum objects in doctrine and becuase of the fact that there is no standard way of defining enums currently we need to abstract the handling for the dbal in a way that it can be extended to support other enum libraries and maybe a native enum implementation in the future.

Tests will be added as soon as people show there interest in the feature.