### PR TITLE
Detect id getter methods named exactly as id field

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -838,12 +838,15 @@ EOT;
      */
     private function isShortIdentifierGetter($method, ClassMetadata $class)
     {
-        $identifier = lcfirst(substr($method->getName(), 3));
+        $identifier = (
+            substr($method->getName(), 0, 3) === 'get'
+            ? lcfirst(substr($method->getName(), 3))
+            : $method->getName()
+        );
         $startLine = $method->getStartLine();
         $endLine = $method->getEndLine();
         $cheapCheck = (
             $method->getNumberOfParameters() == 0
-            && substr($method->getName(), 0, 3) == 'get'
             && in_array($identifier, $class->getIdentifier(), true)
             && $class->hasField($identifier)
             && (($endLine - $startLine) <= 4)


### PR DESCRIPTION
Support not loading full entity when calling method named like id field
(e.g. `id()`) on Proxy.

Some people are using naming convention that does not prefix getters with "get" and uses instead just the field name on (usually very rare) getter function.
Doctrine tries to detect id getter methods and avoid loading proxied entities when such method is called, but it does not support getters named exactly the same as the underlying id field. This PR adds support for such methods to already existing "get" prefixed id getter method detection.
