### PR TITLE
Util\Debug: export parent class private attributes and DateTimeImmutable

### DIFF
--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -109,7 +109,7 @@ final class Debug
                 }
             } else if ($isObj) {
                 $return = new \stdclass();
-                if ($var instanceof \DateTime || $var instanceof \DateTimeInterface) {
+                if ($var instanceof \DateTimeInterface) {
                     $return->__CLASS__ = get_class($var);
                     $return->date = $var->format('c');
                     $return->timezone = $var->getTimezone()->getName();

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -159,16 +159,17 @@ final class Debug
             $currentClassName = $reflClass->getName();
 
             foreach ($reflClass->getProperties() as $reflProperty) {
-                $name = $reflProperty->getName();
+                $attributeKey = $reflProperty->isPrivate() ? $currentClassName . '#' : '';
+                $attributeKey .= $reflProperty->getName();
 
-                if (isset($parsedAttributes[$name])) {
+                if (isset($parsedAttributes[$attributeKey])) {
                     continue;
                 }
 
-                $parsedAttributes[$name] = true;
+                $parsedAttributes[$attributeKey] = true;
 
                 $name =
-                      $name
+                      $reflProperty->getName()
                     . ($return->__CLASS__ !== $currentClassName || $reflProperty->isPrivate() ? ':' . $currentClassName : '')
                     . ($reflProperty->isPrivate() ? ':private' : '')
                     . ($reflProperty->isProtected() ? ':protected' : '')

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -109,10 +109,10 @@ final class Debug
                 }
             } else if ($isObj) {
                 $return = new \stdclass();
-                if ($var instanceof \DateTime) {
-                    $return->__CLASS__ = "DateTime";
+                if ($var instanceof \DateTime || $var instanceof \DateTimeInterface) {
+                    $return->__CLASS__ = get_class($var);
                     $return->date = $var->format('c');
-                    $return->timezone = $var->getTimeZone()->getName();
+                    $return->timezone = $var->getTimezone()->getName();
                 } else {
                     $reflClass = ClassUtils::newReflectionObject($var);
                     $return->__CLASS__ = ClassUtils::getClass($var);

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -77,11 +77,11 @@ final class Debug
         $dumpText = ($stripTags ? strip_tags(html_entity_decode($dump)) : $dump);
 
         ini_set('html_errors', $html);
-        
+
         if ($echo) {
             echo $dumpText;
         }
-        
+
         return $dumpText;
     }
 
@@ -100,42 +100,46 @@ final class Debug
             $var = $var->toArray();
         }
 
-        if ($maxDepth) {
-            if (is_array($var)) {
-                $return = [];
-
-                foreach ($var as $k => $v) {
-                    $return[$k] = self::export($v, $maxDepth - 1);
-                }
-            } else if ($isObj) {
-                $return = new \stdclass();
-                if ($var instanceof \DateTimeInterface) {
-                    $return->__CLASS__ = get_class($var);
-                    $return->date = $var->format('c');
-                    $return->timezone = $var->getTimezone()->getName();
-                } else {
-                    $return->__CLASS__ = ClassUtils::getClass($var);
-
-                    if ($var instanceof Proxy) {
-                        $return->__IS_PROXY__ = true;
-                        $return->__PROXY_INITIALIZED__ = $var->__isInitialized();
-                    }
-
-                    if ($var instanceof \ArrayObject || $var instanceof \ArrayIterator) {
-                        $return->__STORAGE__ = self::export($var->getArrayCopy(), $maxDepth - 1);
-                    }
-
-                    self::fillReturnWithClassAttributes($var, $return, $maxDepth);
-                }
-            } else {
-                $return = $var;
-            }
-        } else {
-            $return = is_object($var) ? get_class($var)
+        if (! $maxDepth) {
+            return is_object($var) ? get_class($var)
                 : (is_array($var) ? 'Array(' . count($var) . ')' : $var);
         }
 
-        return $return;
+        if (is_array($var)) {
+            $return = [];
+
+            foreach ($var as $k => $v) {
+                $return[$k] = self::export($v, $maxDepth - 1);
+            }
+
+            return $return;
+        }
+
+        if (! $isObj) {
+            return $var;
+        }
+
+        $return = new \stdclass();
+        if ($var instanceof \DateTimeInterface) {
+            $return->__CLASS__ = get_class($var);
+            $return->date = $var->format('c');
+            $return->timezone = $var->getTimezone()->getName();
+
+            return $return;
+        }
+
+        $return->__CLASS__ = ClassUtils::getClass($var);
+
+        if ($var instanceof Proxy) {
+            $return->__IS_PROXY__ = true;
+            $return->__PROXY_INITIALIZED__ = $var->__isInitialized();
+        }
+
+        if ($var instanceof \ArrayObject || $var instanceof \ArrayIterator) {
+            $return->__STORAGE__ = self::export($var->getArrayCopy(), $maxDepth - 1);
+        }
+
+        return self::fillReturnWithClassAttributes($var, $return, $maxDepth);
     }
 
     /**
@@ -145,7 +149,7 @@ final class Debug
      * @param stdClass $return
      * @param int      $maxDepth
      *
-     * @return void
+     * @return mixed
      */
     private static function fillReturnWithClassAttributes($var, \stdClass $return, $maxDepth)
     {
@@ -174,6 +178,8 @@ final class Debug
                 $return->$name = self::export($reflProperty->getValue($var), $maxDepth - 1);
             }
         } while ($reflClass = $reflClass->getParentClass());
+
+        return $return;
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -90,7 +90,7 @@ class DebugTest extends DoctrineTestCase
         );
 
         $print_r_class = print_r($class, true);
-        $print_r_expected = print_r($class, true);
+        $print_r_expected = print_r($expected, true);
 
         $print_r_class = substr($print_r_class, strpos($print_r_class, '('));
         $print_r_expected = substr($print_r_expected, strpos($print_r_expected, '('));

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -19,10 +19,23 @@ class DebugTest extends DoctrineTestCase
 
     public function testExportDateTime()
     {
-        $obj = new \DateTime( "2010-10-10 10:10:10" );
+        $obj = new \DateTime('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
+
+        $var = Debug::export($obj, 2);
+        $this->assertEquals('DateTime', $var->__CLASS__ );
+        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date );
+    }
+
+    /**
+     * @requires PHP 5.5
+     */
+    public function testExportDateTimeImmutable()
+    {
+        $obj = new \DateTimeImmutable('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
         $var = Debug::export( $obj, 2 );
-        $this->assertEquals( "DateTime", $var->__CLASS__ );
+        $this->assertEquals('DateTimeImmutable', $var->__CLASS__ );
+        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date );
     }
 
     public function testExportArrayTraversable()

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -33,7 +33,7 @@ class DebugTest extends DoctrineTestCase
     {
         $obj = new \DateTimeImmutable('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
-        $var = Debug::export( $obj, 2 );
+        $var = Debug::export($obj, 2);
         $this->assertEquals('DateTimeImmutable', $var->__CLASS__ );
         $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date );
     }
@@ -74,5 +74,24 @@ class DebugTest extends DoctrineTestCase
 
         $this->assertEmpty($outputValue);
         $this->assertNotSame($outputValue, $dump);
+    }
+
+    public function testExportParentPrivateAttributes()
+    {
+        $class = new TestAsset\ChildClass();
+
+        $expected = array(
+            '__CLASS__' => 'Doctrine\Tests\Common\Util\TestAsset\ChildClass',
+            'childPublicAttribute' => 4,
+            'childProtectedAttribute:protected' => 5,
+            'childPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ChildClass:private' => 6,
+            'parentPublicAttribute' => 1,
+            'parentProtectedAttribute:protected' => 2,
+            'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ParentClass:private' => 3,
+        );
+
+        $var = Debug::export($class, 3);
+
+        $this->assertSame($expected, (array) $var);
     }
 }

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -22,20 +22,26 @@ class DebugTest extends DoctrineTestCase
         $obj = new \DateTime('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
         $var = Debug::export($obj, 2);
-        $this->assertEquals('DateTime', $var->__CLASS__ );
-        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date );
+        $this->assertEquals('DateTime', $var->__CLASS__);
+        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date);
     }
 
-    /**
-     * @requires PHP 5.5
-     */
     public function testExportDateTimeImmutable()
     {
         $obj = new \DateTimeImmutable('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
         $var = Debug::export($obj, 2);
-        $this->assertEquals('DateTimeImmutable', $var->__CLASS__ );
-        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date );
+        $this->assertEquals('DateTimeImmutable', $var->__CLASS__);
+        $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date);
+    }
+
+    public function testExportDateTimeZone()
+    {
+        $obj = new \DateTimeImmutable('2010-10-10 12:34:56', new \DateTimeZone('Europe/Rome'));
+
+        $var = Debug::export($obj, 2);
+        $this->assertEquals('DateTimeImmutable', $var->__CLASS__);
+        $this->assertEquals('2010-10-10T12:34:56+02:00', $var->date);
     }
 
     public function testExportArrayTraversable()

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -81,7 +81,6 @@ class DebugTest extends DoctrineTestCase
         $class = new TestAsset\ChildClass();
 
         $expected = array(
-            '__CLASS__' => 'Doctrine\Tests\Common\Util\TestAsset\ChildClass',
             'childPublicAttribute' => 4,
             'childProtectedAttribute:protected' => 5,
             'childPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ChildClass:private' => 6,
@@ -90,8 +89,18 @@ class DebugTest extends DoctrineTestCase
             'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ParentClass:private' => 3,
         );
 
-        $var = Debug::export($class, 3);
+        $print_r_class = print_r($class, true);
+        $print_r_expected = print_r($class, true);
 
-        $this->assertSame($expected, (array) $var);
+        $print_r_class = substr($print_r_class, strpos($print_r_class, '('));
+        $print_r_expected = substr($print_r_expected, strpos($print_r_expected, '('));
+
+        $this->assertSame($print_r_class, $print_r_expected);
+
+        $var = Debug::export($class, 3);
+        $var = (array) $var;
+        unset($var['__CLASS__']);
+
+        $this->assertSame($expected, $var);
     }
 }

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -82,19 +82,11 @@ class DebugTest extends DoctrineTestCase
         $this->assertNotSame($outputValue, $dump);
     }
 
-    public function testExportParentPrivateAttributes()
+    /**
+     * @dataProvider provideAttributesCases
+     */
+    public function testExportParentAttributes(TestAsset\ParentClass $class, array $expected)
     {
-        $class = new TestAsset\ChildClass();
-
-        $expected = array(
-            'childPublicAttribute' => 4,
-            'childProtectedAttribute:protected' => 5,
-            'childPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ChildClass:private' => 6,
-            'parentPublicAttribute' => 1,
-            'parentProtectedAttribute:protected' => 2,
-            'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ParentClass:private' => 3,
-        );
-
         $print_r_class = print_r($class, true);
         $print_r_expected = print_r($expected, true);
 
@@ -108,5 +100,31 @@ class DebugTest extends DoctrineTestCase
         unset($var['__CLASS__']);
 
         $this->assertSame($expected, $var);
+    }
+
+    public function provideAttributesCases()
+    {
+        return array(
+            'different-attributes' => array(
+                new TestAsset\ChildClass(),
+                array(
+                    'childPublicAttribute' => 4,
+                    'childProtectedAttribute:protected' => 5,
+                    'childPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ChildClass:private' => 6,
+                    'parentPublicAttribute' => 1,
+                    'parentProtectedAttribute:protected' => 2,
+                    'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ParentClass:private' => 3,
+                ),
+            ),
+            'same-attributes' => array(
+                new TestAsset\ChildWithSameAttributesClass(),
+                array(
+                    'parentPublicAttribute' => 4,
+                    'parentProtectedAttribute:protected' => 5,
+                    'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ChildWithSameAttributesClass:private' => 6,
+                    'parentPrivateAttribute:Doctrine\Tests\Common\Util\TestAsset\ParentClass:private' => 3,
+                ),
+            ),
+        );
     }
 }

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ChildClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ChildClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Common\Util\TestAsset;
+
+final class ChildClass extends ParentClass
+{
+    public $childPublicAttribute = 4;
+    protected $childProtectedAttribute = 5;
+    private $childPrivateAttribute = 6;
+}

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ChildWithSameAttributesClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ChildWithSameAttributesClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Common\Util\TestAsset;
+
+final class ChildWithSameAttributesClass extends ParentClass
+{
+    public $parentPublicAttribute = 4;
+    protected $parentProtectedAttribute = 5;
+    private $parentPrivateAttribute = 6;
+}

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ParentClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ParentClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Common\Util\TestAsset;
+
+abstract class ParentClass
+{
+    public $parentPublicAttribute = 1;
+    protected $parentProtectedAttribute = 2;
+    private $parentPrivateAttribute = 3;
+}


### PR DESCRIPTION
This patch enhances DateTime export for the new DateTimeImmutable and fixes the behaviour dumping also the private attributes of parent class emulating `print_r`