### PR TITLE
ProxyGenerator: Added support for PHP 7.1 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script:

--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -41,19 +41,43 @@ class UnexpectedValueException extends BaseUnexpectedValueException implements P
     }
 
     /**
-     * @param string     $className
-     * @param string     $methodName
-     * @param string     $parameterName
-     * @param \Exception $previous
+     * @param string          $className
+     * @param string          $methodName
+     * @param string          $parameterName
+     * @param \Exception|null $previous
      *
      * @return self
      */
-    public static function invalidParameterTypeHint($className, $methodName, $parameterName, \Exception $previous)
-    {
+    public static function invalidParameterTypeHint(
+        $className,
+        $methodName,
+        $parameterName,
+        \Exception $previous = null
+    ) {
         return new self(
             sprintf(
                 'The type hint of parameter "%s" in method "%s" in class "%s" is invalid.',
                 $parameterName,
+                $methodName,
+                $className
+            ),
+            0,
+            $previous
+        );
+    }
+
+    /**
+     * @param $className
+     * @param $methodName
+     * @param \Exception|null $previous
+     *
+     * @return self
+     */
+    public static function invalidReturnTypeHint($className, $methodName, \Exception $previous = null)
+    {
+        return new self(
+            sprintf(
+                'The return type of method "%s" in class "%s" is invalid.',
                 $methodName,
                 $className
             ),

--- a/tests/Doctrine/Tests/Common/Proxy/InvalidReturnTypeClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/InvalidReturnTypeClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class InvalidReturnTypeClass
+{
+    /**
+     * @return InvalidReturnType (non existing class return type)
+     */
+    public function invalidReturnTypeMethod() : InvalidReturnType
+    {
+
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/IterableTypeHintClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/IterableTypeHintClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test PHP 7.1 iterable pseudotype
+ */
+class IterableTypeHintClass
+{
+    public function parameterType(iterable $param)
+    {
+    }
+
+    public function returnType() : iterable
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoid.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoid.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset representing a lazy loadable object with void method
+ *
+ * @since  2.7
+ */
+class LazyLoadableObjectWithVoid
+{
+    /** @var int */
+    public $value = 0;
+
+    public function incrementingAndReturningVoid() : void
+    {
+        $this->value++;
+    }
+
+    public function addingAndReturningVoid(int $i) : void
+    {
+        $this->value += $i;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
@@ -1,0 +1,168 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use ReflectionClass;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+
+/**
+ * Class metadata test asset for @see LazyLoadableObjectWithVoid
+ *
+ * @since  2.7
+ */
+class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
+{
+    /**
+     * @var ReflectionClass
+     */
+    protected $reflectionClass;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if (null === $this->reflectionClass) {
+            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithVoid');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'integer';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/NullableTypeHintsClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/NullableTypeHintsClass.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test PHP 7.1 nullable type hints / return types class.
+ */
+class NullableTypeHintsClass
+{
+    public function nullableTypeHintInt(?int $param)
+    {
+    }
+
+    public function nullableTypeHintObject(?\stdClass $param)
+    {
+    }
+
+    public function nullableTypeHintSelf(?self $param)
+    {
+    }
+
+    public function nullableTypeHintWithDefault(?int $param = 123)
+    {
+    }
+
+    public function nullableTypeHintWithDefaultNull(?int $param = null)
+    {
+    }
+
+    public function notNullableTypeHintWithDefaultNull(int $param = null)
+    {
+    }
+
+    public function returnsNullableInt() : ?int
+    {
+    }
+
+    public function returnsNullableObject() : ?\stdClass
+    {
+    }
+
+    public function returnsNullableSelf() : ?self
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine\Common\Proxy\ProxyGenerator;
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+/**
+ * Test that identifier getter does not cause lazy loading. These tests make assumptions about the structure of LazyLoadableObjectWithTypehints
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @author Jan Langer <jan.langer@slevomat.cz>
+ */
+class ProxyLogicVoidReturnTypeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $proxyLoader;
+
+    /**
+     * @var ClassMetadata
+     */
+    protected $lazyLoadableObjectMetadata;
+
+    /**
+     * @var LazyLoadableObjectWithVoid|Proxy
+     */
+    protected $lazyObject;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Callable
+     */
+    protected $initializerCallbackMock;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $this->markTestSkipped('Void return type is only supported in PHP >= 7.1.0.');
+        }
+
+        $this->proxyLoader = $loader      = $this->getMockBuilder(stdClass::class)->setMethods(['load'])->getMock();
+        $this->initializerCallbackMock    = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
+        $this->lazyLoadableObjectMetadata = $metadata = new LazyLoadableObjectWithVoidClassMetadata();
+
+        $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\LazyLoadableObjectWithVoid';
+
+        // creating the proxy class
+        if (!class_exists($proxyClassName, false)) {
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
+            $proxyFileName = $proxyGenerator->getProxyFileName($metadata->getName());
+            $proxyGenerator->generateProxyClass($metadata, $proxyFileName);
+            require_once $proxyFileName;
+        }
+
+        $this->lazyObject = new $proxyClassName($this->getClosure($this->initializerCallbackMock));
+
+        $this->assertFalse($this->lazyObject->__isInitialized());
+    }
+
+    public function testParentVoidMethodIsCalledWithoutParameters()
+    {
+        $this->configureInitializerMock(
+            1,
+            [$this->lazyObject, 'incrementingAndReturningVoid', []],
+            function () {}
+        );
+
+        $this->assertNull($this->lazyObject->incrementingAndReturningVoid());
+        $this->assertSame(1, $this->lazyObject->value);
+    }
+
+    public function testParentVoidMethodIsCalledWithParameters()
+    {
+        $this->configureInitializerMock(
+            1,
+            [$this->lazyObject, 'addingAndReturningVoid', [10]],
+            function () {}
+        );
+
+        $this->assertNull($this->lazyObject->addingAndReturningVoid(10));
+        $this->assertSame(10, $this->lazyObject->value);
+    }
+
+    /**
+     * Converts a given callable into a closure
+     *
+     * @param  callable $callable
+     * @return \Closure
+     */
+    private function getClosure($callable) {
+        return function () use ($callable) {
+            call_user_func_array($callable, func_get_args());
+        };
+    }
+
+    /**
+     * Configures the current initializer callback mock with provided matcher params
+     *
+     * @param int $expectedCallCount the number of invocations to be expected. If a value< 0 is provided, `any` is used
+     * @param array $callParamsMatch an ordered array of parameters to be expected
+     * @param callable $callbackClosure a return callback closure
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|
+     */
+    private function configureInitializerMock(
+        $expectedCallCount = 0,
+        array $callParamsMatch = null,
+        \Closure $callbackClosure = null
+    ) {
+        if (!$expectedCallCount) {
+            $invocationCountMatcher = $this->exactly((int) $expectedCallCount);
+        } else {
+            $invocationCountMatcher = $expectedCallCount < 0 ? $this->any() : $this->exactly($expectedCallCount);
+        }
+
+        $invocationMocker = $this->initializerCallbackMock->expects($invocationCountMatcher)->method('__invoke');
+
+        if (null !== $callParamsMatch) {
+            call_user_func_array([$invocationMocker, 'with'], $callParamsMatch);
+        }
+
+        if ($callbackClosure) {
+            $invocationMocker->will($this->returnCallback($callbackClosure));
+        }
+    }
+
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ScalarTypeHintsClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ScalarTypeHintsClass.php
@@ -22,4 +22,12 @@ class ScalarTypeHintsClass
     public function typeHintsWithVariadic(int ...$foo)
     {
     }
+
+    public function withDefaultValue(int $foo = 123)
+    {
+    }
+
+    public function withDefaultValueNull(int $foo = null)
+    {
+    }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/VoidReturnTypeClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/VoidReturnTypeClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * PHP 7.1 void return type.
+ */
+class VoidReturnTypeClass
+{
+    public function returnsVoid(): void
+    {
+    }
+}


### PR DESCRIPTION
This was supposed to work without any change in the generator, but it's unfortunately not the case. There are multiple problems:
1) generating nullable type with FQCN is broken - generated code results in parse error;
2) reflection with nullable FQCN is broken - unable to generate proxy;
3) it's impossible to distinguish _nullable type with null default value_ and _non-nullable type with null default value_ - may change function signature in the proxy.

Forwarded upstream for more discussion to the PR where the changes were originally discussed and where you can also find more discussion with some other concerns: https://github.com/php/php-src/pull/2068#issuecomment-239983716
In case of no activity there I'll forward it to the bugs tracker soon or eventually php.internals.

(Travis still has old PHP 7.1 version without the changes, they'll appear in beta3.)