### PR TITLE
Add hasEmbeddedClass method to ClassMetadata interface

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -98,6 +98,15 @@ interface ClassMetadata
     public function isCollectionValuedAssociation($fieldName);
 
     /**
+     * Checks if the given field has an embedded class for this class.
+     *
+     * @param string $fieldName
+     *
+     * @return boolean
+     */
+    public function hasEmbeddedClass($fieldName);
+
+    /**
      * A numerically indexed list of field names of this persistent class.
      *
      * This array includes identifier fields if present on this class.


### PR DESCRIPTION
Just like `hasField()` checks `$fieldMappings` and `hasAssociation()` checks `$associationMappings`, the proposed `hasEmbeddedClass()` will check `$embeddedClasses` for the field in question.

Basically the missing variable in this equation:

``` php
$this->assertFieldNotMapped($fieldName) === !($this->hasField($fieldName) && $this->fieldName($fieldName) && $this->hasEmbeddedClass($fieldName))
```
