### PR TITLE
Ensure a leading backslash (and only one) is returned

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1032,6 +1032,6 @@ EOT;
             return ': \\' . $method->getDeclaringClass()->getParentClass()->getName();
         }
 
-        return ': \\' . (string) $returnType;
+        return ': \\' . ltrim((string) $returnType, '\\');
     }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -222,6 +222,7 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $classCode = file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyReturnTypesClass.php');
 
         $this->assertEquals(1, substr_count($classCode, 'function returnsClass(): \stdClass'));
+        $this->assertEquals(1, substr_count($classCode, 'function returnsFQN(): \Doctrine\Tests\Common\Proxy\ReturnTypesClass'));
         $this->assertEquals(1, substr_count($classCode, 'function returnsScalar(): int'));
         $this->assertEquals(1, substr_count($classCode, 'function returnsArray(): array'));
         $this->assertEquals(1, substr_count($classCode, 'function returnsCallable(): callable'));

--- a/tests/Doctrine/Tests/Common/Proxy/ReturnTypesClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ReturnTypesClass.php
@@ -11,6 +11,10 @@ class ReturnTypesClass extends \stdClass
     {
     }
 
+    public function returnsFQN(): \Doctrine\Tests\Common\Proxy\ReturnTypesClass
+    {
+    }
+
     public function returnsScalar(): int
     {
     }


### PR DESCRIPTION
... in the return type template.
Fixes #736 