### PR TITLE
Adding a lost parameter in ObjectRepository

### DIFF
--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -66,11 +66,12 @@ interface ObjectRepository
     /**
      * Finds a single object by a set of criteria.
      *
-     * @param array $criteria The criteria.
+     * @param array      $criteria The criteria.
+     * @param array|null $orderBy
      *
      * @return object|null The object.
      */
-    public function findOneBy(array $criteria);
+    public function findOneBy(array $criteria, array $orderBy = null);
 
     /**
      * Returns the class name of the object managed by the repository.


### PR DESCRIPTION
Based on the documentation EntityRepository I noticed there findOneBy method has two parameters. But when I tried to use it with the second parameter, my IDE PhpStorm reported the mistake that this method has only one parameter. This is due to the fact that it implements interface ObjectRepository without this parameter. Therefore, I decided to add this parameter for better code completion.

Ps. Sory for my bad english