### PR TITLE
Fix parameter/return type validation for interfaces (introduced in #734)

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1063,7 +1063,7 @@ EOT;
             $name = $method->getDeclaringClass()->getParentClass()->getName();
         }
 
-        if ( ! $type->isBuiltin() && ! class_exists($name)) {
+        if ( ! $type->isBuiltin() && ! class_exists($name) && ! interface_exists($name)) {
             if (null !== $parameter) {
                 throw UnexpectedValueException::invalidParameterTypeHint(
                     $method->getDeclaringClass()->getName(),

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -201,7 +201,7 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, substr_count($classCode, 'function singleTypeHint(string $param)'));
         $this->assertEquals(1, substr_count($classCode, 'function multipleTypeHints(int $a, float $b, bool $c, string $d)'));
-        $this->assertEquals(1, substr_count($classCode, 'function combinationOfTypeHintsAndNormal(\stdClass $a, $b, int $c)'));
+        $this->assertEquals(1, substr_count($classCode, 'function combinationOfTypeHintsAndNormal(\stdClass $a, \Countable $b, $c, int $d)'));
         $this->assertEquals(1, substr_count($classCode, 'function typeHintsWithVariadic(int ...$foo)'));
         $this->assertEquals(1, substr_count($classCode, 'function withDefaultValue(int $foo = 123)'));
         $this->assertEquals(1, substr_count($classCode, 'function withDefaultValueNull(int $foo = NULL)'));
@@ -229,6 +229,7 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function returnsCallable(): callable'));
         $this->assertEquals(1, substr_count($classCode, 'function returnsSelf(): \\' . $className));
         $this->assertEquals(1, substr_count($classCode, 'function returnsParent(): \stdClass'));
+        $this->assertEquals(1, substr_count($classCode, 'function returnsInterface(): \Countable'));
     }
 
     public function testClassWithNullableTypeHintsOnProxiedMethods()

--- a/tests/Doctrine/Tests/Common/Proxy/ReturnTypesClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ReturnTypesClass.php
@@ -30,4 +30,8 @@ class ReturnTypesClass extends \stdClass
     public function returnsParent(): parent
     {
     }
+
+    public function returnsInterface() : \Countable
+    {
+    }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ScalarTypeHintsClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ScalarTypeHintsClass.php
@@ -15,7 +15,7 @@ class ScalarTypeHintsClass
     {
     }
 
-    public function combinationOfTypeHintsAndNormal(\stdClass $a, $b, int $c)
+    public function combinationOfTypeHintsAndNormal(\stdClass $a, \Countable $b, $c, int $d)
     {
     }
 


### PR DESCRIPTION
Something that unfortunately got through in #734 after recent refactoring and caused UnexpectedValueException when inteface was used in parameter or return type. (Original piece of code used to catch ReflectionException instead.)
Noticed when testing against code-base with `getFoo() : Collection`.