### PR TITLE
Fix #751 - backport #752 - proxy generation broken on non-optional parameters with default value

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1083,7 +1083,7 @@ EOT;
         }
 
         if ($type->allowsNull()
-            && (null === $parameter || ! $parameter->isOptional() || null !== $parameter->getDefaultValue())
+            && (null === $parameter || ! $parameter->isDefaultValueAvailable() || null !== $parameter->getDefaultValue())
         ) {
             $name = '?' . $name;
         }

--- a/tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
@@ -12,4 +12,8 @@ class NullableNonOptionalHintClass
     public function midSignatureNullableParameter(\stdClass $param = null, $secondParam)
     {
     }
+
+    public function midSignatureNotNullableHintedParameter(string $param = 'foo', $secondParam)
+    {
+    }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test PHP 7.0 compatibility of nullable type hints generation on a non-optional hinted parameter that is nullable
+ *
+ * @see https://github.com/doctrine/common/issues/751
+ */
+class NullableNonOptionalHintClass
+{
+    public function midSignatureNullableParameter(\stdClass $param = null, $secondParam)
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/Php71NullableDefaultedNonOptionalHintClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php71NullableDefaultedNonOptionalHintClass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test PHP 7.1 compatibility of nullable type hints generation on a non-optional hinted parameter that is nullable,
+ * yet has a default parameter
+ *
+ * @see https://github.com/doctrine/common/issues/751
+ */
+class Php71NullableDefaultedNonOptionalHintClass
+{
+    public function midSignatureNullableParameter(?string $param = null, $secondParam)
+    {
+    }
+
+    public function midSignatureNotNullableHintedParameter(?string $param = 'foo', $secondParam)
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -164,10 +164,6 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testClassWithVariadicArgumentOnProxiedMethod()
     {
-        if (PHP_VERSION_ID < 50600) {
-            $this->markTestSkipped('`...` is only supported in PHP >=5.6.0');
-        }
-
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VariadicTypeHintClass', false)) {
             $className = VariadicTypeHintClass::class;
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -183,12 +179,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'parent::addType(...$types)'));
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testClassWithScalarTypeHintsOnProxiedMethods()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->markTestSkipped('Scalar type hints are only supported in PHP >= 7.0.0.');
-        }
-
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ScalarTypeHintsClass', false)) {
             $className = ScalarTypeHintsClass::class;
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -207,12 +202,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function withDefaultValueNull(int $foo = NULL)'));
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testClassWithReturnTypesOnProxiedMethods()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->markTestSkipped('Method return types are only supported in PHP >= 7.0.0.');
-        }
-
         $className = ReturnTypesClass::class;
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\ReturnTypesClass', false)) {
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -232,12 +226,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function returnsInterface(): \Countable'));
     }
 
+    /**
+     * @requires PHP 7.1
+     */
     public function testClassWithNullableTypeHintsOnProxiedMethods()
     {
-        if (PHP_VERSION_ID < 70100) {
-            $this->markTestSkipped('Nullable type hints are only supported in PHP >= 7.1.0.');
-        }
-
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\NullableTypeHintsClass', false)) {
             $className = NullableTypeHintsClass::class;
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -256,12 +249,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function notNullableTypeHintWithDefaultNull(int $param = NULL)'));
     }
 
+    /**
+     * @requires PHP 7.1
+     */
     public function testClassWithNullableReturnTypesOnProxiedMethods()
     {
-        if (PHP_VERSION_ID < 70100) {
-            $this->markTestSkipped('Nullable method return types are only supported in PHP >= 7.1.0.');
-        }
-
         $className = NullableTypeHintsClass::class;
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\NullableTypeHintsClass', false)) {
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -304,12 +296,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testClassWithVoidReturnType()
     {
-        if (PHP_VERSION_ID < 70100) {
-            $this->markTestSkipped('Void method return types are only supported in PHP >= 7.1.0.');
-        }
-
         $className = VoidReturnTypeClass::class;
         if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\VoidReturnTypeClass', false)) {
             $metadata = $this->createClassMetadata($className, ['id']);
@@ -323,12 +314,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function returnsVoid(): void'));
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testClassWithIterableTypeHint()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->markTestSkipped('Method return types are only supported in PHP >= 7.0.0.');
-        }
-
         if (PHP_VERSION_ID < 70100) {
             $this->expectException(UnexpectedValueException::class);
         }
@@ -361,12 +351,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $proxyGenerator->generateProxyClass($metadata);
     }
 
+    /**
+     * @requires PHP 7.0
+     */
     public function testClassWithInvalidReturnTypeOnProxiedMethod()
     {
-        if (PHP_VERSION_ID < 70000) {
-            $this->markTestSkipped('Method return types are only supported in PHP >= 7.0.0.');
-        }
-
         $className = InvalidReturnTypeClass::class;
         $metadata = $this->createClassMetadata($className, ['id']);
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -279,6 +279,8 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group #751
+     *
+     * @requires PHP 7.0
      */
     public function testClassWithNullableOptionalNonLastParameterOnProxiedMethods()
     {
@@ -293,6 +295,11 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->assertContains(
             'public function midSignatureNullableParameter(\stdClass $param = NULL, $secondParam)',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyNullableNonOptionalHintClass.php')
+        );
+
+        $this->assertContains(
+            'public function midSignatureNotNullableHintedParameter(string $param = \'foo\', $secondParam)',
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyNullableNonOptionalHintClass.php')
         );
     }

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -297,7 +297,7 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @requires PHP 7.0
+     * @requires PHP 7.1
      */
     public function testClassWithVoidReturnType()
     {

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -297,6 +297,33 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group #751
+     *
+     * @requires PHP 7.1
+     */
+    public function testClassWithPhp71NullableOptionalNonLastParameterOnProxiedMethods()
+    {
+        $className = Php71NullableDefaultedNonOptionalHintClass::class;
+
+        if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php71NullableDefaultedNonOptionalHintClass', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        $this->assertContains(
+            'public function midSignatureNullableParameter(?string $param = NULL, $secondParam)',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp71NullableDefaultedNonOptionalHintClass.php')
+        );
+
+        $this->assertContains(
+            'public function midSignatureNotNullableHintedParameter(?string $param = \'foo\', $secondParam)',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp71NullableDefaultedNonOptionalHintClass.php')
+        );
+    }
+
+    /**
      * @requires PHP 7.1
      */
     public function testClassWithVoidReturnType()

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -277,6 +277,23 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function returnsNullableSelf(): ?\\' . $className));
     }
 
+    public function testClassWithNullableOptionalNonLastParameterOnProxiedMethods()
+    {
+        $className = NullableNonOptionalHintClass::class;
+
+        if (!class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\NullableNonOptionalHintClass', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        $this->assertContains(
+            'public function midSignatureNullableParameter(\stdClass $param = NULL, $secondParam)',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyNullableNonOptionalHintClass.php')
+        );
+    }
+
     public function testClassWithVoidReturnType()
     {
         if (PHP_VERSION_ID < 70100) {

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -277,6 +277,9 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, substr_count($classCode, 'function returnsNullableSelf(): ?\\' . $className));
     }
 
+    /**
+     * @group #751
+     */
     public function testClassWithNullableOptionalNonLastParameterOnProxiedMethods()
     {
         $className = NullableNonOptionalHintClass::class;

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -313,8 +313,9 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertContains(
-            'public function midSignatureNullableParameter(?string $param = NULL, $secondParam)',
-            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp71NullableDefaultedNonOptionalHintClass.php')
+            'public function midSignatureNullableParameter(string $param = NULL, $secondParam)',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp71NullableDefaultedNonOptionalHintClass.php'),
+            'Signature allows nullable type, although explicit "?" marker isn\'t used in the proxy'
         );
 
         $this->assertContains(


### PR DESCRIPTION
Fixes #751 for 2.6.x. Backport of #752