### PR TITLE
#761 Added support for PHP 7.1 identifier nullable return type

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -37,7 +37,7 @@ class ProxyGenerator
      * Used to match very simple id methods that don't need
      * to be decorated since the identifier is known.
      */
-    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
+    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\?*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
 
     /**
      * The namespace that contains all proxy classes.

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -37,7 +37,7 @@ class ProxyGenerator
      * Used to match very simple id methods that don't need
      * to be decorated since the identifier is known.
      */
-    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\?*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
+    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\??\s*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
 
     /**
      * The namespace that contains all proxy classes.

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehints.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehints.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine;
+use stdClass as A;
+
+/**
+ * Test asset representing a lazy loadable object
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @since  2.4
+ */
+class LazyLoadableObjectWithNullableTypehints
+{
+
+    /** @var \stdClass */
+    private $identifierFieldReturnClassOneLetterNullable;
+
+    /** @var \stdClass */
+    private $identifierFieldReturnClassOneLetterNullableWithSpace;
+
+    public function getIdentifierFieldReturnClassOneLetterNullable(): ?A
+    {
+        return $this->identifierFieldReturnClassOneLetterNullable;
+    }
+
+    public function getIdentifierFieldReturnClassOneLetterNullableWithSpace(): ? A
+    {
+        return $this->identifierFieldReturnClassOneLetterNullableWithSpace;
+    }
+
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
@@ -28,7 +28,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @since  2.4
  */
-class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
+class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetadata
 {
     /**
      * @var ReflectionClass
@@ -39,26 +39,16 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
      * @var array
      */
     protected $identifier = [
-        'identifierFieldNoReturnTypehint' => true,
-        'identifierFieldReturnTypehintScalar' => true,
-        'identifierFieldReturnClassFullyQualified' => true,
-        'identifierFieldReturnClassPartialUse' => true,
-        'identifierFieldReturnClassFullUse' => true,
-        'identifierFieldReturnClassOneWord' => true,
-        'identifierFieldReturnClassOneLetter' => true,
+        'identifierFieldReturnClassOneLetterNullable' => true,
+        'identifierFieldReturnClassOneLetterNullableWithSpace' => true,
     ];
 
     /**
      * @var array
      */
     protected $fields = [
-        'identifierFieldNoReturnTypehint' => true,
-        'identifierFieldReturnTypehintScalar' => true,
-        'identifierFieldReturnClassFullyQualified' => true,
-        'identifierFieldReturnClassPartialUse' => true,
-        'identifierFieldReturnClassFullUse' => true,
-        'identifierFieldReturnClassOneWord' => true,
-        'identifierFieldReturnClassOneLetter' => true,
+        'identifierFieldReturnClassOneLetterNullable' => true,
+        'identifierFieldReturnClassOneLetterNullableWithSpace' => true,
     ];
 
     /**
@@ -83,7 +73,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     public function getReflectionClass()
     {
         if (null === $this->reflectionClass) {
-            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithTypehints');
+            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithNullableTypehints');
         }
 
         return $this->reflectionClass;

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehints.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehints.php
@@ -52,6 +52,9 @@ class LazyLoadableObjectWithTypehints
     /** @var \stdClass */
     private $identifierFieldReturnClassOneLetter;
 
+    /** @var \stdClass */
+    private $identifierFieldReturnClassOneLetterNullable;
+
     /**
      * @return string
      */
@@ -88,6 +91,11 @@ class LazyLoadableObjectWithTypehints
     public function getIdentifierFieldReturnClassOneLetter(): A
     {
         return $this->identifierFieldReturnClassOneLetter;
+    }
+
+    public function getIdentifierFieldReturnClassOneLetterNullable(): ?A
+    {
+        return $this->identifierFieldReturnClassOneLetterNullable;
     }
 
 

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehints.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehints.php
@@ -51,10 +51,6 @@ class LazyLoadableObjectWithTypehints
 
     /** @var \stdClass */
     private $identifierFieldReturnClassOneLetter;
-
-    /** @var \stdClass */
-    private $identifierFieldReturnClassOneLetterNullable;
-
     /**
      * @return string
      */
@@ -91,11 +87,6 @@ class LazyLoadableObjectWithTypehints
     public function getIdentifierFieldReturnClassOneLetter(): A
     {
         return $this->identifierFieldReturnClassOneLetter;
-    }
-
-    public function getIdentifierFieldReturnClassOneLetterNullable(): ?A
-    {
-        return $this->identifierFieldReturnClassOneLetterNullable;
     }
 
 

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
@@ -46,6 +46,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
         'identifierFieldReturnClassFullUse' => true,
         'identifierFieldReturnClassOneWord' => true,
         'identifierFieldReturnClassOneLetter' => true,
+        'identifierFieldReturnClassOneLetterNullable' => true,
     ];
 
     /**
@@ -59,6 +60,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
         'identifierFieldReturnClassFullUse' => true,
         'identifierFieldReturnClassOneWord' => true,
         'identifierFieldReturnClassOneLetter' => true,
+        'identifierFieldReturnClassOneLetterNullable' => true,
     ];
 
     /**

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicNullableTypehintsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicNullableTypehintsTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine\Common\Proxy\ProxyGenerator;
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+/**
+ * Test that identifier getter does not cause lazy loading. These tests make assumptions about the structure of LazyLoadableObjectWithTypehints
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @author Jan Langer <jan.langer@slevomat.cz>
+ */
+class ProxyLogicNullableTypehintsTest extends ProxyLogicTypehintsTest
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            $this->markTestSkipped('Nullable Return type hints are only supported in PHP >= 7.1.0.');
+        }
+
+        $this->identifier = [
+            'identifierFieldReturnClassOneLetterNullable' => new stdClass(),
+            'identifierFieldReturnClassOneLetterNullableWithSpace' => new stdClass(),
+        ];
+
+        $this->proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\LazyLoadableObjectWithNullableTypehints';
+        $this->lazyLoadableObjectMetadata = $this->metadata = new LazyLoadableObjectWithNullableTypehintsClassMetadata();
+
+        $this->setUpProxy();
+    }
+
+    /**
+     * @return array
+     */
+    public function dataNoLazyLoadingForIdentifier()
+    {
+        return [
+            ['identifierFieldReturnClassOneLetterNullable'],
+            ['identifierFieldReturnClassOneLetterNullableWithSpace'],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypehintsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypehintsTest.php
@@ -52,6 +52,16 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
     protected $identifier = [];
 
     /**
+     * @var string
+     */
+    protected $proxyClassName;
+
+    /**
+     * @var ClassMetadata
+     */
+    protected $metadata;
+
+    /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Callable
      */
     protected $initializerCallbackMock;
@@ -72,16 +82,23 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
             'identifierFieldReturnClassFullUse' => new LazyLoadableObjectWithTypehints(),
             'identifierFieldReturnClassOneWord' => new stdClass(),
             'identifierFieldReturnClassOneLetter' => new stdClass(),
-            'identifierFieldReturnClassOneLetterNullable' => new stdClass(),
         ];
 
+        $this->proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\LazyLoadableObjectWithTypehints';
+        $this->lazyLoadableObjectMetadata = $this->metadata = new LazyLoadableObjectWithTypehintsClassMetadata();
+
+        $this->setUpProxy();
+    }
+
+    public function setUpProxy()
+    {
         $this->proxyLoader = $loader      = $this->getMockBuilder(stdClass::class)->setMethods(['load'])->getMock();
         $this->initializerCallbackMock    = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
         $identifier                       = $this->identifier;
-        $this->lazyLoadableObjectMetadata = $metadata = new LazyLoadableObjectWithTypehintsClassMetadata();
+
 
         // emulating what should happen in a proxy factory
-        $cloner = function (LazyLoadableObjectWithTypehints $proxy) use ($loader, $identifier, $metadata) {
+        $cloner = function (LazyLoadableObjectWithTypehints $proxy) use ($loader, $identifier) {
             /* @var $proxy LazyLoadableObjectWithTypehints|Proxy */
             if ($proxy->__isInitialized()) {
                 return;
@@ -95,31 +112,29 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
                 throw new UnexpectedValueException();
             }
 
-            foreach ($metadata->getReflectionClass()->getProperties() as $reflProperty) {
+            foreach ($this->metadata->getReflectionClass()->getProperties() as $reflProperty) {
                 $propertyName = $reflProperty->getName();
 
-                if ($metadata->hasField($propertyName) || $metadata->hasAssociation($propertyName)) {
+                if ($this->metadata->hasField($propertyName) || $this->metadata->hasAssociation($propertyName)) {
                     $reflProperty->setAccessible(true);
                     $reflProperty->setValue($proxy, $reflProperty->getValue($original));
                 }
             }
         };
 
-        $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Doctrine\Tests\Common\Proxy\LazyLoadableObjectWithTypehints';
-
         // creating the proxy class
-        if (!class_exists($proxyClassName, false)) {
+        if (!class_exists($this->proxyClassName, false)) {
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy', true);
-            $proxyFileName = $proxyGenerator->getProxyFileName($metadata->getName());
-            $proxyGenerator->generateProxyClass($metadata, $proxyFileName);
+            $proxyFileName = $proxyGenerator->getProxyFileName($this->metadata->getName());
+            $proxyGenerator->generateProxyClass($this->metadata, $proxyFileName);
             require_once $proxyFileName;
         }
 
-        $this->lazyObject = new $proxyClassName($this->getClosure($this->initializerCallbackMock), $cloner);
+        $this->lazyObject = new $this->proxyClassName($this->getClosure($this->initializerCallbackMock), $cloner);
 
         // setting identifiers in the proxy via reflection
-        foreach ($metadata->getIdentifierFieldNames() as $idField) {
-            $prop = $metadata->getReflectionClass()->getProperty($idField);
+        foreach ($this->metadata->getIdentifierFieldNames() as $idField) {
+            $prop = $this->metadata->getReflectionClass()->getProperty($idField);
             $prop->setAccessible(true);
             $prop->setValue($this->lazyObject, $identifier[$idField]);
         }
@@ -152,7 +167,6 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
             ['identifierFieldReturnClassFullUse'],
             ['identifierFieldReturnClassOneWord'],
             ['identifierFieldReturnClassOneLetter'],
-            ['identifierFieldReturnClassOneLetterNullable'],
         ];
     }
 

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypehintsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypehintsTest.php
@@ -72,6 +72,7 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
             'identifierFieldReturnClassFullUse' => new LazyLoadableObjectWithTypehints(),
             'identifierFieldReturnClassOneWord' => new stdClass(),
             'identifierFieldReturnClassOneLetter' => new stdClass(),
+            'identifierFieldReturnClassOneLetterNullable' => new stdClass(),
         ];
 
         $this->proxyLoader = $loader      = $this->getMockBuilder(stdClass::class)->setMethods(['load'])->getMock();
@@ -151,6 +152,7 @@ class ProxyLogicTypehintsTest extends PHPUnit_Framework_TestCase
             ['identifierFieldReturnClassFullUse'],
             ['identifierFieldReturnClassOneWord'],
             ['identifierFieldReturnClassOneLetter'],
+            ['identifierFieldReturnClassOneLetterNullable'],
         ];
     }
 


### PR DESCRIPTION
The only problem I see now. That doctrine/common does not yet support PHP 7.1 in `composer.json`. So I dont know how to release this because test will fail under <7.1 version

This is fix for #761 