### PR TITLE
[Bugfix] \ReflectionType supported only in PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~5.6|~7.0",
+        "php": "~7.0",
         "doctrine/inflector": "1.*",
         "doctrine/cache": "1.*",
         "doctrine/collections": "1.*",


### PR DESCRIPTION
You use [\ReflectionType](http://php.net/manual/en/class.reflectiontype.php) in [ProxyGenerator::formatType()](https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Proxy/ProxyGenerator.php#L1050).
This class supported only in PHP 7.