### PR TITLE
Specify array content type for ClassMetadataFactory::getAllMetadata

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -33,7 +33,7 @@ interface ClassMetadataFactory
      * Forces the factory to load the metadata of all classes known to the underlying
      * mapping driver.
      *
-     * @return array The ClassMetadata instances of all mapped classes.
+     * @return ClassMetadata[] The ClassMetadata instances of all mapped classes.
      */
     public function getAllMetadata();
 


### PR DESCRIPTION
When the array contains only instances of `ClassMetadata`, then we can specify it on PHPdoc return tag for better IDE completion and documentation.