### PR TITLE
ProxyGenerator: Disallow creating proxies for abstract and final classes

### DIFF
--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -89,4 +89,24 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
 
         return new self(sprintf('Invalid \$notFoundCallback given: must be a callable, "%s" given', $type));
     }
+
+    /**
+     * @param string $className
+     *
+     * @return self
+     */
+    public static function classMustNotBeAbstract($className)
+    {
+        return new self(sprintf('Unable to create a proxy for an abstract class "%s".', $className));
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return self
+     */
+    public static function classMustNotBeFinal($className)
+    {
+        return new self(sprintf('Unable to create a proxy for a final class "%s".', $className));
+    }
 }

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -256,10 +256,13 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class    Metadata for the original class.
      * @param string|bool                                        $fileName Filename (full path) for the generated class. If none is given, eval() is used.
      *
+     * @throws InvalidArgumentException
      * @throws UnexpectedValueException
      */
     public function generateProxyClass(ClassMetadata $class, $fileName = false)
     {
+        $this->verifyClassCanBeProxied($class);
+
         preg_match_all('(<([a-zA-Z]+)>)', $this->proxyClassTemplate, $placeholderMatches);
 
         $placeholderMatches = array_combine($placeholderMatches[0], $placeholderMatches[1]);
@@ -304,6 +307,22 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         file_put_contents($tmpFileName, $proxyCode);
         @chmod($tmpFileName, 0664);
         rename($tmpFileName, $fileName);
+    }
+
+    /**
+     * @param ClassMetadata $class
+     *
+     * @throws InvalidArgumentException
+     */
+    private function verifyClassCanBeProxied(ClassMetadata $class)
+    {
+        if ($class->getReflectionClass()->isFinal()) {
+            throw InvalidArgumentException::classMustNotBeFinal($class->getName());
+        }
+
+        if ($class->getReflectionClass()->isAbstract()) {
+            throw InvalidArgumentException::classMustNotBeAbstract($class->getName());
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+abstract class AbstractClass
+{
+}

--- a/tests/Doctrine/Tests/Common/Proxy/FinalClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/FinalClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+final class FinalClass
+{
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -426,6 +426,24 @@ class ProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertContains("eval()'d code", $reflClass->getFileName());
     }
 
+    public function testAbstractClassThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to create a proxy for an abstract class "' . AbstractClass::class . '".');
+
+        $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+        $proxyGenerator->generateProxyClass($this->createClassMetadata(AbstractClass::class, []));
+    }
+
+    public function testFinalClassThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to create a proxy for a final class "' . FinalClass::class . '".');
+
+        $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+        $proxyGenerator->generateProxyClass($this->createClassMetadata(FinalClass::class, []));
+    }
+
     /**
      * @param       $className
      * @param array $ids


### PR DESCRIPTION
Fixes #770
Related to symfony/symfony#21509

_This could theoretically be a BC break, but I can't imagine any such scenario._