### PR TITLE
Quick-fix to avoid call to deprecated function.

### DIFF
--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -130,7 +130,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
             throw new \InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the entity "%s" in PreUpdateEventArgs.',
                 $field,
-                get_class($this->getEntity())
+                get_class($this->getObject())
             ));
         }
     }


### PR DESCRIPTION
LifecycleEventArgs::getEntity() is deprecated and should be replaced by getObject() to maintain consistency.