### PR TITLE
JIRA is dead, long live the Github issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,4 @@ The Doctrine Common project is a library that provides extensions to core PHP fu
 
 * [Website](http://www.doctrine-project.org)
 * [Documentation](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/)
-* [Issue Tracker](http://www.doctrine-project.org/jira/browse/DCOM)
 * [Downloads](http://github.com/doctrine/common/downloads)


### PR DESCRIPTION
I don't think we still need the issue tracker-bullet point. It's rather obvious that issues should be reported via *Github Issues*