### PR TITLE
Fix #386 - Debug export does not include stdClass properties

### DIFF
--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -144,41 +144,26 @@ final class Debug
 
     /**
      * Fill the $return variable with class attributes
+     * Based on obj2array function from {@see http://php.net/manual/en/function.get-object-vars.php#47075}
      *
      * @param object   $var
-     * @param stdClass $return
+     * @param \stdClass $return
      * @param int      $maxDepth
      *
      * @return mixed
      */
     private static function fillReturnWithClassAttributes($var, \stdClass $return, $maxDepth)
     {
-        $reflClass = ClassUtils::newReflectionObject($var);
-        $parsedAttributes = array();
-        do {
-            $currentClassName = $reflClass->getName();
+        $clone = (array) $var;
 
-            foreach ($reflClass->getProperties() as $reflProperty) {
-                $attributeKey = $reflProperty->isPrivate() ? $currentClassName . '#' : '';
-                $attributeKey .= $reflProperty->getName();
-
-                if (isset($parsedAttributes[$attributeKey])) {
-                    continue;
-                }
-
-                $parsedAttributes[$attributeKey] = true;
-
-                $name =
-                      $reflProperty->getName()
-                    . ($return->__CLASS__ !== $currentClassName || $reflProperty->isPrivate() ? ':' . $currentClassName : '')
-                    . ($reflProperty->isPrivate() ? ':private' : '')
-                    . ($reflProperty->isProtected() ? ':protected' : '')
-                ;
-
-                $reflProperty->setAccessible(true);
-                $return->$name = self::export($reflProperty->getValue($var), $maxDepth - 1);
+        foreach (array_keys($clone) as $key) {
+            $aux = explode("\0", $key);
+            $name = end($aux);
+            if ($aux[0] === '') {
+                $name.= ':' . ($aux[1] === '*' ? 'protected' : $aux[1].':private');
             }
-        } while ($reflClass = $reflClass->getParentClass());
+            $return->$name = self::export($clone[$key], $maxDepth - 1);;
+        }
 
         return $return;
     }

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -17,6 +17,19 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals( "stdClass", $var->__CLASS__ );
     }
 
+    public function testExportObjectWithReference()
+    {
+        $foo = 'bar';
+        $bar = ['foo' => & $foo];
+        $baz = (object) $bar;
+
+        $var = Debug::export($baz, 2);
+        $baz->foo = 'tab';
+
+        $this->assertEquals('bar', $var->foo);
+        $this->assertEquals('tab', $bar['foo']);
+    }
+
     public function testExportArray()
     {
         $array = ['a' => 'b', 'b' => ['c', 'd' => ['e', 'f']]];

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -17,6 +17,15 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals( "stdClass", $var->__CLASS__ );
     }
 
+    public function testExportArray()
+    {
+        $array = ['a' => 'b', 'b' => ['c', 'd' => ['e', 'f']]];
+        $var = Debug::export($array, 2);
+        $expected = $array;
+        $expected['b']['d'] = 'Array(2)';
+        $this->assertEquals($expected, $var);
+    }
+
     public function testExportDateTime()
     {
         $obj = new \DateTime('2010-10-10 10:10:10', new \DateTimeZone('UTC'));


### PR DESCRIPTION
Fixed thanks to pretty interesting comment posted [12 years ago](http://php.net/manual/en/function.get-object-vars.php#47075)

ref: #386