### PR TITLE
[3.0][BC Break]  Require PHP 7.2, added parameter and return types, enable strict types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.1
+  - 7.2
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.2
       env: PHPSTAN=1
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.2",
         "doctrine/inflector": "1.*",
         "doctrine/cache": "1.*",
         "doctrine/collections": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.8.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     }
 }

--- a/lib/Doctrine/Common/CommonException.php
+++ b/lib/Doctrine/Common/CommonException.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/Comparable.php
+++ b/lib/Doctrine/Common/Comparable.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/Comparable.php
+++ b/lib/Doctrine/Common/Comparable.php
@@ -38,9 +38,9 @@ interface Comparable
      * This method should not check for identity using ===, only for semantical equality for example
      * when two different DateTime instances point to the exact same Date + TZ.
      *
-     * @param mixed $other
+     * @param object $other
      *
      * @return int
      */
-    public function compareTo($other);
+    public function compareTo(object $other): int;
 }

--- a/lib/Doctrine/Common/EventArgs.php
+++ b/lib/Doctrine/Common/EventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/EventArgs.php
+++ b/lib/Doctrine/Common/EventArgs.php
@@ -56,7 +56,7 @@ class EventArgs
      *
      * @return EventArgs
      */
-    public static function getEmptyInstance()
+    public static function getEmptyInstance(): self
     {
         if ( ! self::$_emptyEventArgsInstance) {
             self::$_emptyEventArgsInstance = new EventArgs;

--- a/lib/Doctrine/Common/EventManager.php
+++ b/lib/Doctrine/Common/EventManager.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/EventManager.php
+++ b/lib/Doctrine/Common/EventManager.php
@@ -50,7 +50,7 @@ class EventManager
      *
      * @return void
      */
-    public function dispatchEvent($eventName, EventArgs $eventArgs = null)
+    public function dispatchEvent(string $eventName, ?EventArgs $eventArgs = null): void
     {
         if (isset($this->_listeners[$eventName])) {
             $eventArgs = $eventArgs === null ? EventArgs::getEmptyInstance() : $eventArgs;
@@ -68,7 +68,7 @@ class EventManager
      *
      * @return array The event listeners for the specified event, or all event listeners.
      */
-    public function getListeners($event = null)
+    public function getListeners(?string $event = null): array
     {
         return $event ? $this->_listeners[$event] : $this->_listeners;
     }
@@ -80,7 +80,7 @@ class EventManager
      *
      * @return boolean TRUE if the specified event has any listeners, FALSE otherwise.
      */
-    public function hasListeners($event)
+    public function hasListeners(string $event): bool
     {
         return !empty($this->_listeners[$event]);
     }
@@ -93,7 +93,7 @@ class EventManager
      *
      * @return void
      */
-    public function addEventListener($events, $listener)
+    public function addEventListener($events, object $listener): void
     {
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
@@ -113,7 +113,7 @@ class EventManager
      *
      * @return void
      */
-    public function removeEventListener($events, $listener)
+    public function removeEventListener($events, object $listener): void
     {
         // Picks the hash code related to that listener
         $hash = spl_object_hash($listener);
@@ -131,7 +131,7 @@ class EventManager
      *
      * @return void
      */
-    public function addEventSubscriber(EventSubscriber $subscriber)
+    public function addEventSubscriber(EventSubscriber $subscriber): void
     {
         $this->addEventListener($subscriber->getSubscribedEvents(), $subscriber);
     }
@@ -144,7 +144,7 @@ class EventManager
      *
      * @return void
      */
-    public function removeEventSubscriber(EventSubscriber $subscriber)
+    public function removeEventSubscriber(EventSubscriber $subscriber): void
     {
         $this->removeEventListener($subscriber->getSubscribedEvents(), $subscriber);
     }

--- a/lib/Doctrine/Common/EventSubscriber.php
+++ b/lib/Doctrine/Common/EventSubscriber.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/EventSubscriber.php
+++ b/lib/Doctrine/Common/EventSubscriber.php
@@ -38,5 +38,5 @@ interface EventSubscriber
      *
      * @return array
      */
-    public function getSubscribedEvents();
+    public function getSubscribedEvents(): array;
 }

--- a/lib/Doctrine/Common/Lexer.php
+++ b/lib/Doctrine/Common/Lexer.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 use Doctrine\Common\Lexer\AbstractLexer;

--- a/lib/Doctrine/Common/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Common/NotifyPropertyChanged.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/NotifyPropertyChanged.php
+++ b/lib/Doctrine/Common/NotifyPropertyChanged.php
@@ -38,5 +38,5 @@ interface NotifyPropertyChanged
      *
      * @return void
      */
-    public function addPropertyChangedListener(PropertyChangedListener $listener);
+    public function addPropertyChangedListener(PropertyChangedListener $listener): void;
 }

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 /**

--- a/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/AbstractManagerRegistry.php
@@ -70,8 +70,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      * @param string $defaultManager
      * @param string $proxyInterfaceName
      */
-    public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName)
-    {
+    public function __construct(
+        string $name,
+        array $connections,
+        array $managers,
+        string $defaultConnection,
+        string $defaultManager,
+        string $proxyInterfaceName
+    ) {
         $this->name = $name;
         $this->connections = $connections;
         $this->managers = $managers;
@@ -89,7 +95,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      *
      * @return object The instance of the given service.
      */
-    abstract protected function getService($name);
+    abstract protected function getService(string $name): object;
 
     /**
      * Resets the given services.
@@ -100,14 +106,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      *
      * @return void
      */
-    abstract protected function resetService($name);
+    abstract protected function resetService(string $name): void;
 
     /**
      * Gets the name of the registry.
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -115,7 +121,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnection($name = null)
+    public function getConnection(?string $name = null): object
     {
         if (null === $name) {
             $name = $this->defaultConnection;
@@ -131,7 +137,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnectionNames()
+    public function getConnectionNames(): array
     {
         return $this->connections;
     }
@@ -139,7 +145,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getConnections()
+    public function getConnections(): array
     {
         $connections = [];
         foreach ($this->connections as $name => $id) {
@@ -152,7 +158,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getDefaultConnectionName()
+    public function getDefaultConnectionName(): string
     {
         return $this->defaultConnection;
     }
@@ -160,7 +166,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getDefaultManagerName()
+    public function getDefaultManagerName(): string
     {
         return $this->defaultManager;
     }
@@ -170,7 +176,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
      *
      * @throws \InvalidArgumentException
      */
-    public function getManager($name = null)
+    public function getManager(?string $name = null): ObjectManager
     {
         if (null === $name) {
             $name = $this->defaultManager;
@@ -186,7 +192,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getManagerForClass($class)
+    public function getManagerForClass(string $class): ?ObjectManager
     {
         // Check for namespace alias
         if (strpos($class, ':') !== false) {
@@ -211,12 +217,14 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
                 return $manager;
             }
         }
+
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getManagerNames()
+    public function getManagerNames(): array
     {
         return $this->managers;
     }
@@ -224,7 +232,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getManagers()
+    public function getManagers(): array
     {
         $dms = [];
         foreach ($this->managers as $name => $id) {
@@ -237,7 +245,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function getRepository($persistentObjectName, $persistentManagerName = null)
+    public function getRepository(string $persistentObjectName, ?string $persistentManagerName = null): ObjectRepository
     {
         return $this->getManager($persistentManagerName)->getRepository($persistentObjectName);
     }
@@ -245,7 +253,7 @@ abstract class AbstractManagerRegistry implements ManagerRegistry
     /**
      * {@inheritdoc}
      */
-    public function resetManager($name = null)
+    public function resetManager(?string $name = null): ObjectManager
     {
         if (null === $name) {
             $name = $this->defaultManager;

--- a/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 /**

--- a/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ConnectionRegistry.php
@@ -35,28 +35,28 @@ interface ConnectionRegistry
      *
      * @return string The default connection name.
      */
-    public function getDefaultConnectionName();
+    public function getDefaultConnectionName(): string;
 
     /**
      * Gets the named connection.
      *
-     * @param string $name The connection name (null for the default one).
+     * @param string|null $name The connection name (null for the default one).
      *
      * @return object
      */
-    public function getConnection($name = null);
+    public function getConnection(?string $name = null): object;
 
     /**
      * Gets an array of all registered connections.
      *
      * @return array An array of Connection instances.
      */
-    public function getConnections();
+    public function getConnections(): array;
 
     /**
      * Gets all connection names.
      *
      * @return array An array of connection names.
      */
-    public function getConnectionNames();
+    public function getConnectionNames(): array;
 }

--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LifecycleEventArgs.php
@@ -49,7 +49,7 @@ class LifecycleEventArgs extends EventArgs
      * @param object        $object
      * @param ObjectManager $objectManager
      */
-    public function __construct($object, ObjectManager $objectManager)
+    public function __construct(object $object, ObjectManager $objectManager)
     {
         $this->object = $object;
         $this->objectManager = $objectManager;
@@ -62,7 +62,7 @@ class LifecycleEventArgs extends EventArgs
      *
      * @return object
      */
-    public function getEntity()
+    public function getEntity(): object
     {
         return $this->object;
     }
@@ -72,7 +72,7 @@ class LifecycleEventArgs extends EventArgs
      *
      * @return object
      */
-    public function getObject()
+    public function getObject(): object
     {
         return $this->object;
     }
@@ -82,7 +82,7 @@ class LifecycleEventArgs extends EventArgs
      *
      * @return ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/LoadClassMetadataEventArgs.php
@@ -58,7 +58,7 @@ class LoadClassMetadataEventArgs extends EventArgs
      *
      * @return ClassMetadata
      */
-    public function getClassMetadata()
+    public function getClassMetadata(): ClassMetadata
     {
         return $this->classMetadata;
     }
@@ -68,7 +68,7 @@ class LoadClassMetadataEventArgs extends EventArgs
      *
      * @return ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/ManagerEventArgs.php
@@ -52,7 +52,7 @@ class ManagerEventArgs extends EventArgs
      *
      * @return ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }

--- a/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/OnClearEventArgs.php
@@ -48,7 +48,7 @@ class OnClearEventArgs extends EventArgs
      * @param ObjectManager $objectManager The object manager.
      * @param string|null   $entityClass   The optional entity class.
      */
-    public function __construct($objectManager, $entityClass = null)
+    public function __construct(ObjectManager $objectManager, ?string $entityClass = null)
     {
         $this->objectManager = $objectManager;
         $this->entityClass = $entityClass;
@@ -59,7 +59,7 @@ class OnClearEventArgs extends EventArgs
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManager
     {
         return $this->objectManager;
     }
@@ -69,7 +69,7 @@ class OnClearEventArgs extends EventArgs
      *
      * @return string|null
      */
-    public function getEntityClass()
+    public function getEntityClass(): ?string
     {
         return $this->entityClass;
     }
@@ -79,7 +79,7 @@ class OnClearEventArgs extends EventArgs
      *
      * @return bool
      */
-    public function clearsAllEntities()
+    public function clearsAllEntities(): bool
     {
         return ($this->entityClass === null);
     }

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Event;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -43,7 +43,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      * @param ObjectManager $objectManager
      * @param array         $changeSet
      */
-    public function __construct($entity, ObjectManager $objectManager, array &$changeSet)
+    public function __construct(object $entity, ObjectManager $objectManager, array &$changeSet)
     {
         parent::__construct($entity, $objectManager);
 
@@ -55,7 +55,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return array
      */
-    public function getEntityChangeSet()
+    public function getEntityChangeSet(): array
     {
         return $this->entityChangeSet;
     }
@@ -67,7 +67,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return boolean
      */
-    public function hasChangedField($field)
+    public function hasChangedField(string $field): bool
     {
         return isset($this->entityChangeSet[$field]);
     }
@@ -79,7 +79,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return mixed
      */
-    public function getOldValue($field)
+    public function getOldValue(string $field)
     {
         $this->assertValidField($field);
 
@@ -93,7 +93,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return mixed
      */
-    public function getNewValue($field)
+    public function getNewValue(string $field)
     {
         $this->assertValidField($field);
 
@@ -108,7 +108,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @return void
      */
-    public function setNewValue($field, $value)
+    public function setNewValue(string $field, $value): void
     {
         $this->assertValidField($field);
 
@@ -124,7 +124,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      *
      * @throws \InvalidArgumentException
      */
-    private function assertValidField($field)
+    private function assertValidField(string $field): void
     {
         if ( ! isset($this->entityChangeSet[$field])) {
             throw new \InvalidArgumentException(sprintf(

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 /**

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -35,7 +35,7 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return string The default object manager name.
      */
-    public function getDefaultManagerName();
+    public function getDefaultManagerName(): string;
 
     /**
      * Gets a named object manager.
@@ -44,14 +44,14 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    public function getManager($name = null);
+    public function getManager(?string $name = null): ObjectManager;
 
     /**
      * Gets an array of all registered object managers.
      *
      * @return \Doctrine\Common\Persistence\ObjectManager[] An array of ObjectManager instances
      */
-    public function getManagers();
+    public function getManagers(): array;
 
     /**
      * Resets a named object manager.
@@ -70,7 +70,7 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return \Doctrine\Common\Persistence\ObjectManager
      */
-    public function resetManager($name = null);
+    public function resetManager(?string $name = null): ObjectManager;
 
     /**
      * Resolves a registered namespace alias to the full namespace.
@@ -81,14 +81,14 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return string The full namespace.
      */
-    public function getAliasNamespace($alias);
+    public function getAliasNamespace(string $alias): string;
 
     /**
      * Gets all connection names.
      *
      * @return array An array of connection names.
      */
-    public function getManagerNames();
+    public function getManagerNames(): array;
 
     /**
      * Gets the ObjectRepository for a persistent object.
@@ -98,7 +98,7 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return \Doctrine\Common\Persistence\ObjectRepository
      */
-    public function getRepository($persistentObject, $persistentManagerName = null);
+    public function getRepository(string $persistentObject, ?string $persistentManagerName = null): ObjectRepository;
 
     /**
      * Gets the object manager associated with a given class.
@@ -107,5 +107,5 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return \Doctrine\Common\Persistence\ObjectManager|null
      */
-    public function getManagerForClass($class);
+    public function getManagerForClass($class): ?ObjectManager;
 }

--- a/lib/Doctrine/Common/Persistence/ManagerRegistry.php
+++ b/lib/Doctrine/Common/Persistence/ManagerRegistry.php
@@ -107,5 +107,5 @@ interface ManagerRegistry extends ConnectionRegistry
      *
      * @return \Doctrine\Common\Persistence\ObjectManager|null
      */
-    public function getManagerForClass($class): ?ObjectManager;
+    public function getManagerForClass(string $class): ?ObjectManager;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 use Doctrine\Common\Cache\Cache;

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -20,6 +20,7 @@
 namespace Doctrine\Common\Persistence\Mapping;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Util\ClassUtils;
 use ReflectionException;
 
@@ -72,7 +73,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    public function setCacheDriver(Cache $cacheDriver = null)
+    public function setCacheDriver(?Cache $cacheDriver = null): void
     {
         $this->cacheDriver = $cacheDriver;
     }
@@ -82,7 +83,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return \Doctrine\Common\Cache\Cache|null
      */
-    public function getCacheDriver()
+    public function getCacheDriver(): ?Cache
     {
         return $this->cacheDriver;
     }
@@ -92,7 +93,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return ClassMetadata[]
      */
-    public function getLoadedMetadata()
+    public function getLoadedMetadata(): array
     {
         return $this->loadedMetadata;
     }
@@ -103,7 +104,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array The ClassMetadata instances of all mapped classes.
      */
-    public function getAllMetadata()
+    public function getAllMetadata(): array
     {
         if ( ! $this->initialized) {
             $this->initialize();
@@ -124,7 +125,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    abstract protected function initialize();
+    abstract protected function initialize(): void;
 
     /**
      * Gets the fully qualified class-name from the namespace alias.
@@ -134,14 +135,14 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return string
      */
-    abstract protected function getFqcnFromAlias($namespaceAlias, $simpleClassName);
+    abstract protected function getFqcnFromAlias(string $namespaceAlias, string $simpleClassName): string;
 
     /**
      * Returns the mapping driver implementation.
      *
      * @return \Doctrine\Common\Persistence\Mapping\Driver\MappingDriver
      */
-    abstract protected function getDriver();
+    abstract protected function getDriver(): MappingDriver;
 
     /**
      * Wakes up reflection after ClassMetadata gets unserialized from cache.
@@ -151,7 +152,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    abstract protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService);
+    abstract protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService): void;
 
     /**
      * Initializes Reflection after ClassMetadata was constructed.
@@ -161,7 +162,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    abstract protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService);
+    abstract protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService): void;
 
     /**
      * Checks whether the class metadata is an entity.
@@ -172,7 +173,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return boolean
      */
-    abstract protected function isEntity(ClassMetadata $class);
+    abstract protected function isEntity(ClassMetadata $class): bool;
 
     /**
      * Gets the class metadata descriptor for a class.
@@ -184,7 +185,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      * @throws ReflectionException
      * @throws MappingException
      */
-    public function getMetadataFor($className)
+    public function getMetadataFor(string $className): ClassMetadata
     {
         if (isset($this->loadedMetadata[$className])) {
             return $this->loadedMetadata[$className];
@@ -248,7 +249,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return boolean TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
-    public function hasMetadataFor($className)
+    public function hasMetadataFor(string $className): bool
     {
         return isset($this->loadedMetadata[$className]);
     }
@@ -263,7 +264,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    public function setMetadataFor($className, $class)
+    public function setMetadataFor(string $className, ClassMetadata $class): void
     {
         $this->loadedMetadata[$className] = $class;
     }
@@ -275,7 +276,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array
      */
-    protected function getParentClasses($name)
+    protected function getParentClasses(string $name): array
     {
         // Collect parent classes, ignoring transient (not-mapped) classes.
         $parentClasses = [];
@@ -301,7 +302,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return array
      */
-    protected function loadMetadata($name)
+    protected function loadMetadata(string $name): array
     {
         if ( ! $this->initialized) {
             $this->initialize();
@@ -358,7 +359,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata|null
      */
-    protected function onNotFoundMetadata($className)
+    protected function onNotFoundMetadata(string $className): ?ClassMetadata
     {
         return null;
     }
@@ -374,7 +375,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    abstract protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents);
+    abstract protected function doLoadMetadata(ClassMetadata $class, ?ClassMetadata $parent, bool $rootEntityFound, array $nonSuperclassParents): void;
 
     /**
      * Creates a new ClassMetadata instance for the given class name.
@@ -383,12 +384,12 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return ClassMetadata
      */
-    abstract protected function newClassMetadataInstance($className);
+    abstract protected function newClassMetadataInstance(string $className): ClassMetadata;
 
     /**
      * {@inheritDoc}
      */
-    public function isTransient($class)
+    public function isTransient(string $class): bool
     {
         if ( ! $this->initialized) {
             $this->initialize();
@@ -410,7 +411,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return void
      */
-    public function setReflectionService(ReflectionService $reflectionService)
+    public function setReflectionService(ReflectionService $reflectionService): void
     {
         $this->reflectionService = $reflectionService;
     }
@@ -420,7 +421,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      *
      * @return ReflectionService
      */
-    public function getReflectionService()
+    public function getReflectionService(): ReflectionService
     {
         if ($this->reflectionService === null) {
             $this->reflectionService = new RuntimeReflectionService();

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -34,7 +34,7 @@ interface ClassMetadata
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Gets the mapped identifier field name.
@@ -43,14 +43,14 @@ interface ClassMetadata
      *
      * @return array
      */
-    public function getIdentifier();
+    public function getIdentifier(): array;
 
     /**
      * Gets the ReflectionClass instance for this mapped class.
      *
      * @return \ReflectionClass
      */
-    public function getReflectionClass();
+    public function getReflectionClass(): \ReflectionClass;
 
     /**
      * Checks if the given field name is a mapped identifier for this class.
@@ -59,7 +59,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function isIdentifier($fieldName);
+    public function isIdentifier(string $fieldName): bool;
 
     /**
      * Checks if the given field is a mapped property for this class.
@@ -68,7 +68,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function hasField($fieldName);
+    public function hasField(string $fieldName): bool;
 
     /**
      * Checks if the given field is a mapped association for this class.
@@ -77,7 +77,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function hasAssociation($fieldName);
+    public function hasAssociation(string $fieldName): bool;
 
     /**
      * Checks if the given field is a mapped single valued association for this class.
@@ -86,7 +86,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function isSingleValuedAssociation($fieldName);
+    public function isSingleValuedAssociation(string $fieldName): bool;
 
     /**
      * Checks if the given field is a mapped collection valued association for this class.
@@ -95,7 +95,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function isCollectionValuedAssociation($fieldName);
+    public function isCollectionValuedAssociation(string $fieldName): bool;
 
     /**
      * A numerically indexed list of field names of this persistent class.
@@ -104,14 +104,14 @@ interface ClassMetadata
      *
      * @return array
      */
-    public function getFieldNames();
+    public function getFieldNames(): array;
 
     /**
      * Returns an array of identifier field names numerically indexed.
      *
      * @return array
      */
-    public function getIdentifierFieldNames();
+    public function getIdentifierFieldNames(): array;
 
     /**
      * Returns a numerically indexed list of association names of this persistent class.
@@ -120,7 +120,7 @@ interface ClassMetadata
      *
      * @return array
      */
-    public function getAssociationNames();
+    public function getAssociationNames(): array;
 
     /**
      * Returns a type name of this field.
@@ -132,7 +132,7 @@ interface ClassMetadata
      *
      * @return string
      */
-    public function getTypeOfField($fieldName);
+    public function getTypeOfField(string $fieldName): string;
 
     /**
      * Returns the target class name of the given association.
@@ -141,7 +141,7 @@ interface ClassMetadata
      *
      * @return string
      */
-    public function getAssociationTargetClass($assocName);
+    public function getAssociationTargetClass(string $assocName): string;
 
     /**
      * Checks if the association is the inverse side of a bidirectional association.
@@ -150,7 +150,7 @@ interface ClassMetadata
      *
      * @return boolean
      */
-    public function isAssociationInverseSide($assocName);
+    public function isAssociationInverseSide(string $assocName): bool;
 
     /**
      * Returns the target field of the owning side of the association.
@@ -159,7 +159,7 @@ interface ClassMetadata
      *
      * @return string
      */
-    public function getAssociationMappedByTargetField($assocName);
+    public function getAssociationMappedByTargetField(string $assocName): string;
 
     /**
      * Returns the identifier of this object as an array with field name as key.
@@ -170,5 +170,5 @@ interface ClassMetadata
      *
      * @return array
      */
-    public function getIdentifierValues($object);
+    public function getIdentifierValues(object $object): array;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadata.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 /**

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -35,7 +35,7 @@ interface ClassMetadataFactory
      *
      * @return array The ClassMetadata instances of all mapped classes.
      */
-    public function getAllMetadata();
+    public function getAllMetadata(): array;
 
     /**
      * Gets the class metadata descriptor for a class.
@@ -44,7 +44,7 @@ interface ClassMetadataFactory
      *
      * @return ClassMetadata
      */
-    public function getMetadataFor($className);
+    public function getMetadataFor(string $className): ClassMetadata;
 
     /**
      * Checks whether the factory has the metadata for a class loaded already.
@@ -53,7 +53,7 @@ interface ClassMetadataFactory
      *
      * @return boolean TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
-    public function hasMetadataFor($className);
+    public function hasMetadataFor(string $className): bool;
 
     /**
      * Sets the metadata descriptor for a specific class.
@@ -62,7 +62,7 @@ interface ClassMetadataFactory
      *
      * @param ClassMetadata $class
      */
-    public function setMetadataFor($className, $class);
+    public function setMetadataFor(string $className, ClassMetadata $class): void;
 
     /**
      * Returns whether the class with the specified name should have its metadata loaded.
@@ -72,5 +72,5 @@ interface ClassMetadataFactory
      *
      * @return boolean
      */
-    public function isTransient($className);
+    public function isTransient(string $className): bool;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ClassMetadataFactory.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 /**

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -20,6 +20,7 @@
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
@@ -82,7 +83,7 @@ abstract class AnnotationDriver implements MappingDriver
      * @param AnnotationReader  $reader The AnnotationReader to use, duck-typed.
      * @param string|array|null $paths  One or multiple paths where mapping classes can be found.
      */
-    public function __construct($reader, $paths = null)
+    public function __construct(Reader $reader, $paths = null)
     {
         $this->reader = $reader;
         if ($paths) {
@@ -97,7 +98,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return void
      */
-    public function addPaths(array $paths)
+    public function addPaths(array $paths): void
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -107,7 +108,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return array
      */
-    public function getPaths()
+    public function getPaths(): array
     {
         return $this->paths;
     }
@@ -117,7 +118,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @param array $paths
      */
-    public function addExcludePaths(array $paths)
+    public function addExcludePaths(array $paths): void
     {
         $this->excludePaths = array_unique(array_merge($this->excludePaths, $paths));
     }
@@ -127,7 +128,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return array
      */
-    public function getExcludePaths()
+    public function getExcludePaths(): array
     {
         return $this->excludePaths;
     }
@@ -137,7 +138,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return AnnotationReader
      */
-    public function getReader()
+    public function getReader(): AnnotationReader
     {
         return $this->reader;
     }
@@ -147,7 +148,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return string
      */
-    public function getFileExtension()
+    public function getFileExtension(): string
     {
         return $this->fileExtension;
     }
@@ -159,7 +160,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return void
      */
-    public function setFileExtension($fileExtension)
+    public function setFileExtension(string $fileExtension): void
     {
         $this->fileExtension = $fileExtension;
     }
@@ -175,7 +176,7 @@ abstract class AnnotationDriver implements MappingDriver
      *
      * @return boolean
      */
-    public function isTransient($className)
+    public function isTransient(string $className): bool
     {
         $classAnnotations = $this->reader->getClassAnnotations(new \ReflectionClass($className));
 
@@ -190,7 +191,7 @@ abstract class AnnotationDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         if ($this->classNames !== null) {
             return $this->classNames;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -53,7 +53,7 @@ class DefaultFileLocator implements FileLocator
      * @param string|array $paths         One or multiple paths where mapping documents can be found.
      * @param string|null  $fileExtension The file extension of mapping documents, usually prefixed with a dot.
      */
-    public function __construct($paths, $fileExtension = null)
+    public function __construct($paths, ?string $fileExtension = null)
     {
         $this->addPaths((array) $paths);
         $this->fileExtension = $fileExtension;
@@ -66,7 +66,7 @@ class DefaultFileLocator implements FileLocator
      *
      * @return void
      */
-    public function addPaths(array $paths)
+    public function addPaths(array $paths): void
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -76,7 +76,7 @@ class DefaultFileLocator implements FileLocator
      *
      * @return array
      */
-    public function getPaths()
+    public function getPaths(): array
     {
         return $this->paths;
     }
@@ -86,7 +86,7 @@ class DefaultFileLocator implements FileLocator
      *
      * @return string|null
      */
-    public function getFileExtension()
+    public function getFileExtension(): string
     {
         return $this->fileExtension;
     }
@@ -98,7 +98,7 @@ class DefaultFileLocator implements FileLocator
      *
      * @return void
      */
-    public function setFileExtension($fileExtension)
+    public function setFileExtension(?string $fileExtension): void
     {
         $this->fileExtension = $fileExtension;
     }
@@ -106,7 +106,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function findMappingFile($className)
+    public function findMappingFile(string $className): string
     {
         $fileName = str_replace('\\', '.', $className) . $this->fileExtension;
 
@@ -123,7 +123,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames($globalBasename)
+    public function getAllClassNames(?string $globalBasename): array
     {
         $classes = [];
 
@@ -157,7 +157,7 @@ class DefaultFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function fileExists($className)
+    public function fileExists(string $className): bool
     {
         $fileName = str_replace('\\', '.', $className) . $this->fileExtension;
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -61,7 +61,7 @@ abstract class FileDriver implements MappingDriver
      *                                                where mapping documents can be found.
      * @param string|null              $fileExtension
      */
-    public function __construct($locator, $fileExtension = null)
+    public function __construct($locator, ?string $fileExtension = null)
     {
         if ($locator instanceof FileLocator) {
             $this->locator = $locator;
@@ -77,7 +77,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return void
      */
-    public function setGlobalBasename($file)
+    public function setGlobalBasename(string $file): void
     {
         $this->globalBasename = $file;
     }
@@ -87,7 +87,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return string|null
      */
-    public function getGlobalBasename()
+    public function getGlobalBasename(): ?string
     {
         return $this->globalBasename;
     }
@@ -98,11 +98,11 @@ abstract class FileDriver implements MappingDriver
      *
      * @param string $className
      *
-     * @return array The element of schema meta data.
+     * @return string|array The element of schema meta data.
      *
      * @throws MappingException
      */
-    public function getElement($className)
+    public function getElement(string $className)
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -125,7 +125,7 @@ abstract class FileDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function isTransient($className)
+    public function isTransient(string $className): bool
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -141,7 +141,7 @@ abstract class FileDriver implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         if ($this->classCache === null) {
             $this->initialize();
@@ -165,7 +165,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return array
      */
-    abstract protected function loadMappingFile($file);
+    abstract protected function loadMappingFile(string $file): array;
 
     /**
      * Initializes the class cache from all the global files.
@@ -178,7 +178,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         $this->classCache = [];
         if (null !== $this->globalBasename) {
@@ -199,7 +199,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @return FileLocator
      */
-    public function getLocator()
+    public function getLocator(): FileLocator
     {
         return $this->locator;
     }
@@ -209,7 +209,7 @@ abstract class FileDriver implements MappingDriver
      *
      * @param FileLocator $locator
      */
-    public function setLocator(FileLocator $locator)
+    public function setLocator(FileLocator $locator): void
     {
         $this->locator = $locator;
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 /**

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileLocator.php
@@ -37,16 +37,16 @@ interface FileLocator
      *
      * @return string
      */
-    public function findMappingFile($className);
+    public function findMappingFile(string $className): string;
 
     /**
      * Gets all class names that are found with this file locator.
      *
-     * @param string $globalBasename Passed to allow excluding the basename.
+     * @param string|null $globalBasename Passed to allow excluding the basename.
      *
      * @return array
      */
-    public function getAllClassNames($globalBasename);
+    public function getAllClassNames(?string $globalBasename): array;
 
     /**
      * Checks if a file can be found for this class name.
@@ -55,19 +55,19 @@ interface FileLocator
      *
      * @return bool
      */
-    public function fileExists($className);
+    public function fileExists(string $className): bool;
 
     /**
      * Gets all the paths that this file locator looks for mapping files.
      *
      * @return array
      */
-    public function getPaths();
+    public function getPaths(): array;
 
     /**
      * Gets the file extension that mapping files are suffixed with.
      *
      * @return string
      */
-    public function getFileExtension();
+    public function getFileExtension(): string;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriver.php
@@ -37,14 +37,14 @@ interface MappingDriver
      *
      * @return void
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata);
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void;
 
     /**
      * Gets the names of all mapped classes known to this driver.
      *
      * @return array The names of all mapped classes known to this driver.
      */
-    public function getAllClassNames();
+    public function getAllClassNames(): array;
 
     /**
      * Returns whether the class with the specified name should have its metadata loaded.
@@ -54,5 +54,5 @@ interface MappingDriver
      *
      * @return boolean
      */
-    public function isTransient($className);
+    public function isTransient(string $className): bool;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -51,7 +51,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @return MappingDriver|null
      */
-    public function getDefaultDriver()
+    public function getDefaultDriver(): ?MappingDriver
     {
         return $this->defaultDriver;
     }
@@ -63,7 +63,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @return void
      */
-    public function setDefaultDriver(MappingDriver $driver)
+    public function setDefaultDriver(MappingDriver $driver): void
     {
         $this->defaultDriver = $driver;
     }
@@ -76,7 +76,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @return void
      */
-    public function addDriver(MappingDriver $nestedDriver, $namespace)
+    public function addDriver(MappingDriver $nestedDriver, string $namespace): void
     {
         $this->drivers[$namespace] = $nestedDriver;
     }
@@ -86,7 +86,7 @@ class MappingDriverChain implements MappingDriver
      *
      * @return array $drivers
      */
-    public function getDrivers()
+    public function getDrivers(): array
     {
         return $this->drivers;
     }
@@ -94,7 +94,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
         /* @var $driver MappingDriver */
         foreach ($this->drivers as $namespace => $driver) {
@@ -115,7 +115,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         $classNames = [];
         $driverClasses = [];
@@ -147,7 +147,7 @@ class MappingDriverChain implements MappingDriver
     /**
      * {@inheritDoc}
      */
-    public function isTransient($className)
+    public function isTransient(string $className): bool
     {
         /* @var $driver MappingDriver */
         foreach ($this->drivers AS $namespace => $driver) {

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/PHPDriver.php
@@ -50,7 +50,7 @@ class PHPDriver extends FileDriver
     /**
      * {@inheritDoc}
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
         $this->metadata = $metadata;
 
@@ -60,7 +60,7 @@ class PHPDriver extends FileDriver
     /**
      * {@inheritDoc}
      */
-    protected function loadMappingFile($file)
+    protected function loadMappingFile(string $file): array
     {
         $metadata = $this->metadata;
         include $file;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -66,7 +66,7 @@ class StaticPHPDriver implements MappingDriver
      *
      * @return void
      */
-    public function addPaths(array $paths)
+    public function addPaths(array $paths): void
     {
         $this->paths = array_unique(array_merge($this->paths, $paths));
     }
@@ -74,7 +74,7 @@ class StaticPHPDriver implements MappingDriver
     /**
      * {@inheritdoc}
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
         $className::loadMetadata($metadata);
     }
@@ -83,7 +83,7 @@ class StaticPHPDriver implements MappingDriver
      * {@inheritDoc}
      * @todo Same code exists in AnnotationDriver, should we re-use it somehow or not worry about it?
      */
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         if ($this->classNames !== null) {
             return $this->classNames;
@@ -135,7 +135,7 @@ class StaticPHPDriver implements MappingDriver
     /**
      * {@inheritdoc}
      */
-    public function isTransient($className)
+    public function isTransient(string $className): bool
     {
         return ! method_exists($className, 'loadMetadata');
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/StaticPHPDriver.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping\Driver;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -67,7 +67,7 @@ class SymfonyFileLocator implements FileLocator
      * @param string|null $fileExtension
      * @param string      $nsSeparator String which would be used when converting FQCN to filename and vice versa. Should not be empty
      */
-    public function __construct(array $prefixes, $fileExtension = null, $nsSeparator = '.')
+    public function __construct(array $prefixes, ?string $fileExtension = null, string $nsSeparator = '.')
     {
         $this->addNamespacePrefixes($prefixes);
         $this->fileExtension = $fileExtension;
@@ -86,7 +86,7 @@ class SymfonyFileLocator implements FileLocator
      *
      * @return void
      */
-    public function addNamespacePrefixes(array $prefixes)
+    public function addNamespacePrefixes(array $prefixes): void
     {
         $this->prefixes = array_merge($this->prefixes, $prefixes);
         $this->paths = array_merge($this->paths, array_keys($prefixes));
@@ -97,7 +97,7 @@ class SymfonyFileLocator implements FileLocator
      *
      * @return array
      */
-    public function getNamespacePrefixes()
+    public function getNamespacePrefixes(): array
     {
         return $this->prefixes;
     }
@@ -105,7 +105,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getPaths()
+    public function getPaths(): array
     {
         return $this->paths;
     }
@@ -113,7 +113,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getFileExtension()
+    public function getFileExtension(): string
     {
         return $this->fileExtension;
     }
@@ -125,7 +125,7 @@ class SymfonyFileLocator implements FileLocator
      *
      * @return void
      */
-    public function setFileExtension($fileExtension)
+    public function setFileExtension(string $fileExtension): void
     {
         $this->fileExtension = $fileExtension;
     }
@@ -133,7 +133,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function fileExists($className)
+    public function fileExists(string $className): bool
     {
         $defaultFileName = str_replace('\\', $this->nsSeparator, $className).$this->fileExtension;
         foreach ($this->paths as $path) {
@@ -164,7 +164,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function getAllClassNames($globalBasename = null)
+    public function getAllClassNames(?string $globalBasename = null): array
     {
         $classes = [];
 
@@ -210,7 +210,7 @@ class SymfonyFileLocator implements FileLocator
     /**
      * {@inheritDoc}
      */
-    public function findMappingFile($className)
+    public function findMappingFile(string $className): string
     {
         $defaultFileName = str_replace('\\', $this->nsSeparator, $className).$this->fileExtension;
         foreach ($this->paths as $path) {

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -32,7 +32,7 @@ class MappingException extends \Exception
      *
      * @return self
      */
-    public static function classNotFoundInNamespaces($className, $namespaces)
+    public static function classNotFoundInNamespaces(string $className, array $namespaces): self
     {
         return new self("The class '" . $className . "' was not found in the ".
             "chain configured namespaces " . implode(", ", $namespaces));
@@ -41,7 +41,7 @@ class MappingException extends \Exception
     /**
      * @return self
      */
-    public static function pathRequired()
+    public static function pathRequired(): self
     {
         return new self("Specifying the paths to your entities is required ".
             "in the AnnotationDriver to retrieve all class names.");
@@ -52,7 +52,7 @@ class MappingException extends \Exception
      *
      * @return self
      */
-    public static function fileMappingDriversRequireConfiguredDirectoryPath($path = null)
+    public static function fileMappingDriversRequireConfiguredDirectoryPath(?string $path = null): self
     {
         if ( ! empty($path)) {
             $path = '[' . $path . ']';
@@ -70,7 +70,7 @@ class MappingException extends \Exception
      *
      * @return self
      */
-    public static function mappingFileNotFound($entityName, $fileName)
+    public static function mappingFileNotFound(string $entityName, string $fileName): self
     {
         return new self("No mapping file found named '$fileName' for class '$entityName'.");
     }
@@ -81,7 +81,7 @@ class MappingException extends \Exception
      *
      * @return self
      */
-    public static function invalidMappingFile($entityName, $fileName)
+    public static function invalidMappingFile(string $entityName, string $fileName): self
     {
         return new self("Invalid mapping file '$fileName' for class '$entityName'.");
     }
@@ -91,7 +91,7 @@ class MappingException extends \Exception
      *
      * @return self
      */
-    public static function nonExistingClass($className)
+    public static function nonExistingClass(string $className): self
     {
         return new self("Class '$className' does not exist");
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 /**

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -38,7 +38,7 @@ interface ReflectionService
      *
      * @return array
      */
-    public function getParentClasses($class);
+    public function getParentClasses(string $class): array;
 
     /**
      * Returns the shortname of a class.
@@ -47,14 +47,14 @@ interface ReflectionService
      *
      * @return string
      */
-    public function getClassShortName($class);
+    public function getClassShortName(string $class): string;
 
     /**
      * @param string $class
      *
      * @return string
      */
-    public function getClassNamespace($class);
+    public function getClassNamespace(string $class): string;
 
     /**
      * Returns a reflection class instance or null.
@@ -63,7 +63,7 @@ interface ReflectionService
      *
      * @return \ReflectionClass|null
      */
-    public function getClass($class);
+    public function getClass(string $class): ?\ReflectionClass;
 
     /**
      * Returns an accessible property (setAccessible(true)) or null.
@@ -73,7 +73,7 @@ interface ReflectionService
      *
      * @return \ReflectionProperty|null
      */
-    public function getAccessibleProperty($class, $property);
+    public function getAccessibleProperty(string $class, string $property): ?\ReflectionProperty;
 
     /**
      * Checks if the class have a public method with the given name.
@@ -83,5 +83,5 @@ interface ReflectionService
      *
      * @return bool
      */
-    public function hasPublicMethod($class, $method);
+    public function hasPublicMethod($class, $method): bool;
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/ReflectionService.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 /**

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -35,7 +35,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getParentClasses($class)
+    public function getParentClasses(string $class): array
     {
         if ( ! class_exists($class)) {
             throw MappingException::nonExistingClass($class);
@@ -47,7 +47,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassShortName($class)
+    public function getClassShortName(string $class): string
     {
         $reflectionClass = new ReflectionClass($class);
 
@@ -57,7 +57,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassNamespace($class)
+    public function getClassNamespace(string $class): string
     {
         $reflectionClass = new ReflectionClass($class);
 
@@ -67,7 +67,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClass($class)
+    public function getClass(string $class): ?\ReflectionClass
     {
         return new ReflectionClass($class);
     }
@@ -75,7 +75,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getAccessibleProperty($class, $property)
+    public function getAccessibleProperty(string $class, string $property): ?\ReflectionProperty
     {
         $reflectionProperty = new ReflectionProperty($class, $property);
 
@@ -91,7 +91,7 @@ class RuntimeReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function hasPublicMethod($class, $method)
+    public function hasPublicMethod($class, $method): bool
     {
         try {
             $reflectionMethod = new ReflectionMethod($class, $method);

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -29,7 +29,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getParentClasses($class)
+    public function getParentClasses(string $class): array
     {
         return [];
     }
@@ -37,7 +37,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassShortName($className)
+    public function getClassShortName(string $className): string
     {
         if (strpos($className, '\\') !== false) {
             $className = substr($className, strrpos($className, "\\")+1);
@@ -48,7 +48,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClassNamespace($className)
+    public function getClassNamespace(string $className): string
     {
         $namespace = '';
         if (strpos($className, '\\') !== false) {
@@ -60,7 +60,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getClass($class)
+    public function getClass(string $class): ?\ReflectionClass
     {
         return null;
     }
@@ -68,7 +68,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function getAccessibleProperty($class, $property)
+    public function getAccessibleProperty(string $class, string $property): ?\ReflectionProperty
     {
         return null;
     }
@@ -76,7 +76,7 @@ class StaticReflectionService implements ReflectionService
     /**
      * {@inheritDoc}
      */
-    public function hasPublicMethod($class, $method)
+    public function hasPublicMethod($class, $method): bool
     {
         return true;
     }

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence\Mapping;
 
 /**

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/ObjectManager.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManager.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\Common\Persistence;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+
 /**
  * Contract for a Doctrine persistence layer ObjectManager class to implement.
  *
@@ -39,7 +42,7 @@ interface ObjectManager
      *
      * @return object The found object.
      */
-    public function find($className, $id);
+    public function find(string $className, $id): object;
 
     /**
      * Tells the ObjectManager to make an instance managed and persistent.
@@ -53,7 +56,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function persist($object);
+    public function persist(object $object): void;
 
     /**
      * Removes an object instance.
@@ -64,7 +67,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function remove($object);
+    public function remove(object $object): void;
 
     /**
      * Merges the state of a detached object into the persistence context
@@ -75,7 +78,7 @@ interface ObjectManager
      *
      * @return object
      */
-    public function merge($object);
+    public function merge(object $object): object;
 
     /**
      * Clears the ObjectManager. All objects that are currently managed
@@ -85,7 +88,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function clear($objectName = null);
+    public function clear(?string $objectName = null): void;
 
     /**
      * Detaches an object from the ObjectManager, causing a managed object to
@@ -98,7 +101,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function detach($object);
+    public function detach(object $object): void;
 
     /**
      * Refreshes the persistent state of an object from the database,
@@ -108,7 +111,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function refresh($object);
+    public function refresh(object $object): void;
 
     /**
      * Flushes all changes to objects that have been queued up to now to the database.
@@ -117,7 +120,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function flush();
+    public function flush(): void;
 
     /**
      * Gets the repository for a class.
@@ -126,7 +129,7 @@ interface ObjectManager
      *
      * @return \Doctrine\Common\Persistence\ObjectRepository
      */
-    public function getRepository($className);
+    public function getRepository(string $className): ObjectRepository;
 
     /**
      * Returns the ClassMetadata descriptor for a class.
@@ -138,14 +141,14 @@ interface ObjectManager
      *
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata
      */
-    public function getClassMetadata($className);
+    public function getClassMetadata(string $className): ClassMetadata;
 
     /**
      * Gets the metadata factory used to gather the metadata of classes.
      *
      * @return \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory
      */
-    public function getMetadataFactory();
+    public function getMetadataFactory(): ClassMetadataFactory;
 
     /**
      * Helper method to initialize a lazy loading proxy or persistent collection.
@@ -156,7 +159,7 @@ interface ObjectManager
      *
      * @return void
      */
-    public function initializeObject($obj);
+    public function initializeObject(object $obj): void;
 
     /**
      * Checks if the object is part of the current UnitOfWork and therefore managed.
@@ -165,5 +168,5 @@ interface ObjectManager
      *
      * @return bool
      */
-    public function contains($object);
+    public function contains(object $object): bool;
 }

--- a/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerAware.php
@@ -47,5 +47,5 @@ interface ObjectManagerAware
      *
      * @return void
      */
-    public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata);
+    public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata): void;
 }

--- a/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
+++ b/lib/Doctrine/Common/Persistence/ObjectManagerDecorator.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\Common\Persistence;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+
 /**
  * Base class to simplify ObjectManager decorators
  *
@@ -37,7 +40,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function find($className, $id)
+    public function find(string $className, $id): object
     {
         return $this->wrapped->find($className, $id);
     }
@@ -45,7 +48,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function persist($object)
+    public function persist(object $object): void
     {
         $this->wrapped->persist($object);
     }
@@ -53,7 +56,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function remove($object)
+    public function remove(object $object): void
     {
         $this->wrapped->remove($object);
     }
@@ -61,7 +64,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function merge($object)
+    public function merge(object $object): object
     {
         return $this->wrapped->merge($object);
     }
@@ -69,7 +72,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function clear($objectName = null)
+    public function clear(?string $objectName = null): void
     {
         $this->wrapped->clear($objectName);
     }
@@ -77,7 +80,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function detach($object)
+    public function detach(object $object): void
     {
         $this->wrapped->detach($object);
     }
@@ -85,7 +88,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function refresh($object)
+    public function refresh(object $object): void
     {
         $this->wrapped->refresh($object);
     }
@@ -93,7 +96,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function flush()
+    public function flush(): void
     {
         $this->wrapped->flush();
     }
@@ -101,7 +104,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function getRepository($className)
+    public function getRepository(string $className): ObjectRepository
     {
         return $this->wrapped->getRepository($className);
     }
@@ -109,7 +112,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function getClassMetadata($className)
+    public function getClassMetadata(string $className): ClassMetadata
     {
         return $this->wrapped->getClassMetadata($className);
     }
@@ -117,7 +120,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function getMetadataFactory()
+    public function getMetadataFactory(): ClassMetadataFactory
     {
         return $this->wrapped->getMetadataFactory();
     }
@@ -125,7 +128,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function initializeObject($obj)
+    public function initializeObject(object $obj): void
     {
         $this->wrapped->initializeObject($obj);
     }
@@ -133,7 +136,7 @@ abstract class ObjectManagerDecorator implements ObjectManager
     /**
      * {@inheritdoc}
      */
-    public function contains($object)
+    public function contains(object $object): bool
     {
         return $this->wrapped->contains($object);
     }

--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -36,14 +36,14 @@ interface ObjectRepository
      *
      * @return object|null The object.
      */
-    public function find($id);
+    public function find($id): ?object;
 
     /**
      * Finds all objects in the repository.
      *
      * @return array The objects.
      */
-    public function findAll();
+    public function findAll(): array;
 
     /**
      * Finds objects by a set of criteria.
@@ -61,7 +61,7 @@ interface ObjectRepository
      *
      * @throws \UnexpectedValueException
      */
-    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null);
+    public function findBy(array $criteria, array $orderBy = null, ?int $limit = null, ?int $offset = null): array;
 
     /**
      * Finds a single object by a set of criteria.
@@ -70,12 +70,12 @@ interface ObjectRepository
      *
      * @return object|null The object.
      */
-    public function findOneBy(array $criteria);
+    public function findOneBy(array $criteria): array;
 
     /**
      * Returns the class name of the object managed by the repository.
      *
      * @return string
      */
-    public function getClassName();
+    public function getClassName(): string;
 }

--- a/lib/Doctrine/Common/Persistence/ObjectRepository.php
+++ b/lib/Doctrine/Common/Persistence/ObjectRepository.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 /**

--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -73,7 +73,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @return void
      */
-    static public function setObjectManager(ObjectManager $objectManager = null)
+    static public function setObjectManager(?ObjectManager $objectManager = null): void
     {
         self::$objectManager = $objectManager;
     }
@@ -81,7 +81,7 @@ abstract class PersistentObject implements ObjectManagerAware
     /**
      * @return ObjectManager|null
      */
-    static public function getObjectManager()
+    static public function getObjectManager(): ?ObjectManager
     {
         return self::$objectManager;
     }
@@ -96,7 +96,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @throws \RuntimeException
      */
-    public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata)
+    public function injectObjectManager(ObjectManager $objectManager, ClassMetadata $classMetadata): void
     {
         if ($objectManager !== self::$objectManager) {
             throw new \RuntimeException("Trying to use PersistentObject with different ObjectManager instances. " .
@@ -117,7 +117,7 @@ abstract class PersistentObject implements ObjectManagerAware
      * @throws \BadMethodCallException   When no persistent field exists by that name.
      * @throws \InvalidArgumentException When the wrong target object type is passed to an association.
      */
-    private function set($field, $args)
+    private function set(string $field, array $args): void
     {
         $this->initializeDoctrine();
 
@@ -144,7 +144,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @throws \BadMethodCallException When no persistent field exists by that name.
      */
-    private function get($field)
+    private function get(string $field)
     {
         $this->initializeDoctrine();
 
@@ -158,13 +158,13 @@ abstract class PersistentObject implements ObjectManagerAware
     /**
      * If this is an inverse side association, completes the owning side.
      *
-     * @param string        $field
-     * @param ClassMetadata $targetClass
-     * @param object        $targetObject
+     * @param string      $field
+     * @param string      $targetClass
+     * @param object|null $targetObject
      *
      * @return void
      */
-    private function completeOwningSide($field, $targetClass, $targetObject)
+    private function completeOwningSide(string $field, string $targetClass, ?object $targetObject): void
     {
         // add this object on the owning side as well, for obvious infinite recursion
         // reasons this is only done when called on the inverse side.
@@ -188,7 +188,7 @@ abstract class PersistentObject implements ObjectManagerAware
      * @throws \BadMethodCallException
      * @throws \InvalidArgumentException
      */
-    private function add($field, $args)
+    private function add(string $field, array $args): void
     {
         $this->initializeDoctrine();
 
@@ -214,7 +214,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @throws \RuntimeException
      */
-    private function initializeDoctrine()
+    private function initializeDoctrine(): void
     {
         if ($this->cm !== null) {
             return;
@@ -237,7 +237,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @throws \BadMethodCallException
      */
-    public function __call($method, $args)
+    public function __call(string $method, array $args)
     {
         $command = substr($method, 0, 3);
         $field = lcfirst(substr($method, 3));

--- a/lib/Doctrine/Common/Persistence/Proxy.php
+++ b/lib/Doctrine/Common/Persistence/Proxy.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Persistence;
 
 /**

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -41,5 +41,5 @@ interface PropertyChangedListener
      *
      * @return void
      */
-    function propertyChanged($sender, $propertyName, $oldValue, $newValue);
+    function propertyChanged(object $sender, string $propertyName, $oldValue, $newValue): void;
 }

--- a/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 /**

--- a/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ClassFinderInterface.php
@@ -33,5 +33,5 @@ interface ClassFinderInterface
      *
      * @return string|null The name of the class or NULL if not found.
      */
-    public function findFile($class);
+    public function findFile(string $class): ?string;
 }

--- a/lib/Doctrine/Common/Reflection/Psr0FindFile.php
+++ b/lib/Doctrine/Common/Reflection/Psr0FindFile.php
@@ -37,7 +37,7 @@ class Psr0FindFile implements ClassFinderInterface
      * @param array $prefixes An array of prefixes. Each key is a PHP namespace and each value is
      *                        a list of directories.
      */
-    public function __construct($prefixes)
+    public function __construct(array $prefixes)
     {
         $this->prefixes = $prefixes;
     }
@@ -45,7 +45,7 @@ class Psr0FindFile implements ClassFinderInterface
     /**
      * {@inheritDoc}
      */
-    public function findFile($class)
+    public function findFile(string $class): ?string
     {
         $lastNsPos = strrpos($class, '\\');
         if ('\\' == $class[0]) {

--- a/lib/Doctrine/Common/Reflection/Psr0FindFile.php
+++ b/lib/Doctrine/Common/Reflection/Psr0FindFile.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 /**

--- a/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 interface ReflectionProviderInterface

--- a/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
+++ b/lib/Doctrine/Common/Reflection/ReflectionProviderInterface.php
@@ -26,7 +26,7 @@ interface ReflectionProviderInterface
      *
      * @return \ReflectionClass
      */
-    public function getReflectionClass();
+    public function getReflectionClass(): \ReflectionClass;
 
     /**
      * Gets the ReflectionMethod equivalent for this class.
@@ -35,7 +35,7 @@ interface ReflectionProviderInterface
      *
      * @return \ReflectionMethod
      */
-    public function getReflectionMethod($name);
+    public function getReflectionMethod(string $name): \ReflectionMethod;
 
     /**
      * Gets the ReflectionProperty equivalent for this class.
@@ -44,5 +44,5 @@ interface ReflectionProviderInterface
      *
      * @return \ReflectionProperty
      */
-    public function getReflectionProperty($name);
+    public function getReflectionProperty(string $name): \ReflectionProperty;
 }

--- a/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 use Doctrine\Common\Proxy\Proxy;

--- a/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
@@ -60,7 +60,7 @@ class RuntimePublicReflectionProperty extends ReflectionProperty
      * is a {@see \Doctrine\Common\Proxy\Proxy}.
      * @link https://bugs.php.net/bug.php?id=63463
      */
-    public function setValue($object, $value = null)
+    public function setValue($object, $value = null): void
     {
         if ( ! ($object instanceof Proxy && ! $object->__isInitialized())) {
             parent::setValue($object, $value);

--- a/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 use ReflectionClass;

--- a/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionClass.php
@@ -42,7 +42,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->staticReflectionParser->getClassName();
     }
@@ -50,7 +50,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getDocComment()
+    public function getDocComment(): string
     {
         return $this->staticReflectionParser->getDocComment();
     }
@@ -58,7 +58,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): string
     {
         return $this->staticReflectionParser->getNamespaceName();
     }
@@ -66,7 +66,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * @return array
      */
-    public function getUseStatements()
+    public function getUseStatements(): array
     {
         return $this->staticReflectionParser->getUseStatements();
     }
@@ -74,7 +74,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getMethod($name)
+    public function getMethod($name): \ReflectionMethod
     {
         return $this->staticReflectionParser->getReflectionMethod($name);
     }
@@ -82,7 +82,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getProperty($name)
+    public function getProperty($name): \ReflectionProperty
     {
         return $this->staticReflectionParser->getReflectionProperty($name);
     }
@@ -90,7 +90,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public static function export($argument, $return = false)
+    public static function export($argument, $return = false): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -98,7 +98,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getConstant($name)
+    public function getConstant($name): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -106,7 +106,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getConstants()
+    public function getConstants(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -114,7 +114,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getConstructor()
+    public function getConstructor(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -122,7 +122,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getDefaultProperties()
+    public function getDefaultProperties(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -130,7 +130,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getEndLine()
+    public function getEndLine(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -138,7 +138,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getExtension()
+    public function getExtension(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -146,7 +146,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getExtensionName()
+    public function getExtensionName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -154,7 +154,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getFileName()
+    public function getFileName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -162,7 +162,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getInterfaceNames()
+    public function getInterfaceNames(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -170,7 +170,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getInterfaces()
+    public function getInterfaces(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -178,7 +178,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getMethods($filter = null)
+    public function getMethods($filter = null): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -186,7 +186,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getModifiers()
+    public function getModifiers(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -194,7 +194,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getParentClass()
+    public function getParentClass(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -202,7 +202,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getProperties($filter = null)
+    public function getProperties($filter = null): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -210,7 +210,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getShortName()
+    public function getShortName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -218,7 +218,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getStartLine()
+    public function getStartLine(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -226,7 +226,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getStaticProperties()
+    public function getStaticProperties(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -234,7 +234,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getStaticPropertyValue($name, $default = '')
+    public function getStaticPropertyValue($name, $default = ''): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -242,7 +242,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getTraitAliases()
+    public function getTraitAliases(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -250,7 +250,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getTraitNames()
+    public function getTraitNames(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -258,7 +258,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function getTraits()
+    public function getTraits(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -266,7 +266,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function hasConstant($name)
+    public function hasConstant($name): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -274,7 +274,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function hasMethod($name)
+    public function hasMethod($name): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -282,7 +282,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function hasProperty($name)
+    public function hasProperty($name): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -290,7 +290,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function implementsInterface($interface)
+    public function implementsInterface($interface): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -298,7 +298,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function inNamespace()
+    public function inNamespace(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -306,7 +306,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isAbstract()
+    public function isAbstract(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -314,7 +314,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isCloneable()
+    public function isCloneable(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -322,7 +322,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isFinal()
+    public function isFinal(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -330,7 +330,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isInstance($object)
+    public function isInstance($object): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -338,7 +338,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isInstantiable()
+    public function isInstantiable(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -346,7 +346,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isInterface()
+    public function isInterface(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -354,7 +354,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isInternal()
+    public function isInternal(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -362,7 +362,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isIterateable()
+    public function isIterateable(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -370,7 +370,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isSubclassOf($class)
+    public function isSubclassOf($class): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -378,7 +378,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isTrait()
+    public function isTrait(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -386,7 +386,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isUserDefined()
+    public function isUserDefined(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -394,7 +394,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function newInstance($args)
+    public function newInstance($args): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -402,7 +402,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function newInstanceArgs(array $args = [])
+    public function newInstanceArgs(array $args = []): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -410,7 +410,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function newInstanceWithoutConstructor()
+    public function newInstanceWithoutConstructor(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -418,7 +418,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function setStaticPropertyValue($name, $value)
+    public function setStaticPropertyValue($name, $value): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -426,7 +426,7 @@ class StaticReflectionClass extends ReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function __toString()
+    public function __toString(): void
     {
         throw new ReflectionException('Method not implemented');
     }

--- a/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 use ReflectionException;

--- a/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionMethod.php
@@ -42,7 +42,7 @@ class StaticReflectionMethod extends ReflectionMethod
      * @param StaticReflectionParser $staticReflectionParser
      * @param string                 $methodName
      */
-    public function __construct(StaticReflectionParser $staticReflectionParser, $methodName)
+    public function __construct(StaticReflectionParser $staticReflectionParser, string $methodName)
     {
         $this->staticReflectionParser = $staticReflectionParser;
         $this->methodName = $methodName;
@@ -51,7 +51,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->methodName;
     }
@@ -59,7 +59,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * @return StaticReflectionParser
      */
-    protected function getStaticReflectionParser()
+    protected function getStaticReflectionParser(): StaticReflectionParser
     {
         return $this->staticReflectionParser->getStaticReflectionParserForDeclaringClass('method', $this->methodName);
     }
@@ -67,7 +67,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getDeclaringClass()
+    public function getDeclaringClass(): \ReflectionClass
     {
         return $this->getStaticReflectionParser()->getReflectionClass();
     }
@@ -75,7 +75,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): string
     {
         return $this->getStaticReflectionParser()->getNamespaceName();
     }
@@ -83,7 +83,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getDocComment()
+    public function getDocComment(): string
     {
         return $this->getStaticReflectionParser()->getDocComment('method', $this->methodName);
     }
@@ -91,7 +91,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * @return array
      */
-    public function getUseStatements()
+    public function getUseStatements(): array
     {
         return $this->getStaticReflectionParser()->getUseStatements();
     }
@@ -99,7 +99,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public static function export($class, $name, $return = false)
+    public static function export($class, $name, $return = false): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -107,7 +107,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getClosure($object)
+    public function getClosure($object): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -115,7 +115,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getModifiers()
+    public function getModifiers(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -123,7 +123,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getPrototype()
+    public function getPrototype(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -131,7 +131,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function invoke($object, $parameter = null)
+    public function invoke($object, $parameter = null): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -139,7 +139,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function invokeArgs($object, array $args)
+    public function invokeArgs($object, array $args): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -147,7 +147,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isAbstract()
+    public function isAbstract(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -155,7 +155,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isConstructor()
+    public function isConstructor(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -163,7 +163,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isDestructor()
+    public function isDestructor(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -171,7 +171,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isFinal()
+    public function isFinal(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -179,7 +179,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isPrivate()
+    public function isPrivate(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -187,7 +187,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isProtected()
+    public function isProtected(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -195,7 +195,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isPublic()
+    public function isPublic(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -203,7 +203,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isStatic()
+    public function isStatic(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -211,7 +211,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function setAccessible($accessible)
+    public function setAccessible($accessible): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -219,7 +219,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function __toString()
+    public function __toString(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -227,7 +227,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getClosureThis()
+    public function getClosureThis(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -235,7 +235,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getEndLine()
+    public function getEndLine(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -243,7 +243,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getExtension()
+    public function getExtension(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -251,7 +251,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getExtensionName()
+    public function getExtensionName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -259,7 +259,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getFileName()
+    public function getFileName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -267,7 +267,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getNumberOfParameters()
+    public function getNumberOfParameters(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -275,7 +275,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getNumberOfRequiredParameters()
+    public function getNumberOfRequiredParameters(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -283,7 +283,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getParameters()
+    public function getParameters(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -291,7 +291,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getShortName()
+    public function getShortName(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -299,7 +299,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getStartLine()
+    public function getStartLine(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -307,7 +307,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function getStaticVariables()
+    public function getStaticVariables(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -315,7 +315,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function inNamespace()
+    public function inNamespace(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -323,7 +323,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isClosure()
+    public function isClosure(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -331,7 +331,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isDeprecated()
+    public function isDeprecated(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -339,7 +339,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isInternal()
+    public function isInternal(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -347,7 +347,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function isUserDefined()
+    public function isUserDefined(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -355,7 +355,7 @@ class StaticReflectionMethod extends ReflectionMethod
     /**
      * {@inheritDoc}
      */
-    public function returnsReference()
+    public function returnsReference(): void
     {
         throw new ReflectionException('Method not implemented');
     }

--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -111,7 +111,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
      * @param boolean              $classAnnotationOptimize Only retrieve the class docComment.
      *                                                      Presumes there is only one statement per line.
      */
-    public function __construct($className, $finder, $classAnnotationOptimize = false)
+    public function __construct(string $className, ClassFinderInterface $finder, bool $classAnnotationOptimize = false)
     {
         $this->className = ltrim($className, '\\');
         $lastNsPos = strrpos($this->className, '\\');
@@ -130,7 +130,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * @return void
      */
-    protected function parse()
+    protected function parse(): void
     {
         if ($this->parsed || !$fileName = $this->finder->findFile($this->className)) {
             return;
@@ -212,7 +212,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * @return StaticReflectionParser
      */
-    protected function getParentStaticReflectionParser()
+    protected function getParentStaticReflectionParser(): StaticReflectionParser
     {
         if (empty($this->parentStaticReflectionParser)) {
             $this->parentStaticReflectionParser = new static($this->parentClassName, $this->finder);
@@ -224,7 +224,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -232,7 +232,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * @return string
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): string
     {
         return $this->namespace;
     }
@@ -240,7 +240,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         return new StaticReflectionClass($this);
     }
@@ -248,7 +248,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getReflectionMethod($methodName)
+    public function getReflectionMethod(string $methodName): \ReflectionMethod
     {
         return new StaticReflectionMethod($this, $methodName);
     }
@@ -256,7 +256,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getReflectionProperty($propertyName)
+    public function getReflectionProperty(string $propertyName): \ReflectionProperty
     {
         return new StaticReflectionProperty($this, $propertyName);
     }
@@ -266,7 +266,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
      *
      * @return array
      */
-    public function getUseStatements()
+    public function getUseStatements(): array
     {
         $this->parse();
 
@@ -281,7 +281,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
      *
      * @return string The doc comment, empty string if none.
      */
-    public function getDocComment($type = 'class', $name = '')
+    public function getDocComment(string $type = 'class', string $name = ''): string
     {
         $this->parse();
 
@@ -298,7 +298,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
      *
      * @throws ReflectionException
      */
-    public function getStaticReflectionParserForDeclaringClass($type, $name)
+    public function getStaticReflectionParserForDeclaringClass(string $type, string $name): StaticReflectionParser
     {
         $this->parse();
         if (isset($this->docComment[$type][$name])) {

--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 use Doctrine\Common\Annotations\TokenParser;

--- a/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Reflection;
 
 use ReflectionException;

--- a/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionProperty.php
@@ -42,7 +42,7 @@ class StaticReflectionProperty extends ReflectionProperty
      * @param StaticReflectionParser $staticReflectionParser
      * @param string|null            $propertyName
      */
-    public function __construct(StaticReflectionParser $staticReflectionParser, $propertyName)
+    public function __construct(StaticReflectionParser $staticReflectionParser, string $propertyName)
     {
         $this->staticReflectionParser = $staticReflectionParser;
         $this->propertyName = $propertyName;
@@ -51,7 +51,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->propertyName;
     }
@@ -59,7 +59,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * @return StaticReflectionParser
      */
-    protected function getStaticReflectionParser()
+    protected function getStaticReflectionParser(): StaticReflectionParser
     {
         return $this->staticReflectionParser->getStaticReflectionParserForDeclaringClass('property', $this->propertyName);
     }
@@ -67,7 +67,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function getDeclaringClass()
+    public function getDeclaringClass(): \ReflectionClass
     {
         return $this->getStaticReflectionParser()->getReflectionClass();
     }
@@ -75,7 +75,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function getDocComment()
+    public function getDocComment(): string
     {
         return $this->getStaticReflectionParser()->getDocComment('property', $this->propertyName);
     }
@@ -83,7 +83,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * @return array
      */
-    public function getUseStatements()
+    public function getUseStatements(): array
     {
         return $this->getStaticReflectionParser()->getUseStatements();
     }
@@ -91,7 +91,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public static function export($class, $name, $return = false)
+    public static function export($class, $name, $return = false): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -99,7 +99,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function getModifiers()
+    public function getModifiers(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -107,7 +107,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function getValue($object = null)
+    public function getValue($object = null): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -115,7 +115,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function isDefault()
+    public function isDefault(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -123,7 +123,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function isPrivate()
+    public function isPrivate(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -131,7 +131,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function isProtected()
+    public function isProtected(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -139,7 +139,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function isPublic()
+    public function isPublic(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -147,7 +147,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function isStatic()
+    public function isStatic(): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -155,7 +155,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function setAccessible($accessible)
+    public function setAccessible($accessible): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -163,7 +163,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function setValue($object, $value = null)
+    public function setValue($object, $value = null): void
     {
         throw new ReflectionException('Method not implemented');
     }
@@ -171,7 +171,7 @@ class StaticReflectionProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
-    public function __toString()
+    public function __toString(): void
     {
         throw new ReflectionException('Method not implemented');
     }

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Persistence\Proxy;

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -37,7 +37,7 @@ class ClassUtils
      *
      * @return string
      */
-    public static function getRealClass($class)
+    public static function getRealClass(string $class): string
     {
         if (false === $pos = strrpos($class, '\\'.Proxy::MARKER.'\\')) {
             return $class;
@@ -53,7 +53,7 @@ class ClassUtils
      *
      * @return string
      */
-    public static function getClass($object)
+    public static function getClass(object $object): string
     {
         return self::getRealClass(get_class($object));
     }
@@ -65,7 +65,7 @@ class ClassUtils
      *
      * @return string
      */
-    public static function getParentClass($className)
+    public static function getParentClass(string $className): string
     {
         return get_parent_class( self::getRealClass( $className ) );
     }
@@ -77,7 +77,7 @@ class ClassUtils
      *
      * @return \ReflectionClass
      */
-    public static function newReflectionClass($class)
+    public static function newReflectionClass(string $class): \ReflectionClass
     {
         return new \ReflectionClass( self::getRealClass( $class ) );
     }
@@ -89,7 +89,7 @@ class ClassUtils
      *
      * @return \ReflectionClass
      */
-    public static function newReflectionObject($object)
+    public static function newReflectionObject(object $object): \ReflectionClass
     {
         return self::newReflectionClass( self::getClass( $object ) );
     }
@@ -102,7 +102,7 @@ class ClassUtils
      *
      * @return string
      */
-    public static function generateProxyClassName($className, $proxyNamespace)
+    public static function generateProxyClassName(string $className, string $proxyNamespace): string
     {
         return rtrim($proxyNamespace, '\\') . '\\'.Proxy::MARKER.'\\' . ltrim($className, '\\');
     }

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -53,7 +53,7 @@ final class Debug
      *
      * @return string
      */
-    public static function dump($var, $maxDepth = 2, $stripTags = true, $echo = true)
+    public static function dump($var, int $maxDepth = 2, bool $stripTags = true, bool $echo = true): string
     {
         $html = ini_get('html_errors');
 
@@ -91,7 +91,7 @@ final class Debug
      *
      * @return mixed
      */
-    public static function export($var, $maxDepth)
+    public static function export($var, int $maxDepth)
     {
         $return = null;
         $isObj = is_object($var);
@@ -152,7 +152,7 @@ final class Debug
      *
      * @return mixed
      */
-    private static function fillReturnWithClassAttributes($var, \stdClass $return, $maxDepth)
+    private static function fillReturnWithClassAttributes(object $var, \stdClass $return, int $maxDepth)
     {
         $clone = (array) $var;
 
@@ -175,7 +175,7 @@ final class Debug
      *
      * @return string
      */
-    public static function toString($obj)
+    public static function toString(object $obj): string
     {
         return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_hash($obj);
     }

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Collections\Collection;
@@ -58,7 +60,7 @@ final class Debug
         $html = ini_get('html_errors');
 
         if ($html !== true) {
-            ini_set('html_errors', true);
+            ini_set('html_errors', '1');
         }
 
         if (extension_loaded('xdebug')) {
@@ -157,7 +159,7 @@ final class Debug
         $clone = (array) $var;
 
         foreach (array_keys($clone) as $key) {
-            $aux = explode("\0", $key);
+            $aux = explode("\0", (string) $key);
             $name = end($aux);
             if ($aux[0] === '') {
                 $name.= ':' . ($aux[1] === '*' ? 'protected' : $aux[1].':private');

--- a/lib/Doctrine/Common/Util/Inflector.php
+++ b/lib/Doctrine/Common/Util/Inflector.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Inflector\Inflector as BaseInflector;

--- a/lib/Doctrine/Common/Version.php
+++ b/lib/Doctrine/Common/Version.php
@@ -43,7 +43,7 @@ class Version
      *
      * @return int -1 if older, 0 if it is the same, 1 if version passed as argument is newer.
      */
-    public static function compare($version)
+    public static function compare(string $version): int
     {
         $currentVersion = str_replace(' ', '', strtolower(self::VERSION));
         $version = str_replace(' ', '', $version);

--- a/lib/Doctrine/Common/Version.php
+++ b/lib/Doctrine/Common/Version.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Common;
 
 /**

--- a/lib/Doctrine/Common/Version.php
+++ b/lib/Doctrine/Common/Version.php
@@ -34,7 +34,7 @@ class Version
     /**
      * Current Doctrine Version.
      */
-    const VERSION = '2.7.0-DEV';
+    const VERSION = '3.0.0-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,3 +18,5 @@ parameters:
         - '#Access to an undefined property Doctrine\\Common\\Proxy\\Proxy::\$publicField#'
         - '#Access to an undefined property Doctrine\\Tests\\Common\\Proxy\\MagicGetByRefClass::\$nonExisting#'
         - '#does not accept [\\a-zA-Z0-9_|]*PHPUnit_Framework_MockObject_MockObject#'
+        - '#Return typehint of method .+ has invalid type object#'
+        - '#Parameter \$\S+ of method .+ has invalid typehint type object#'

--- a/tests/Doctrine/Tests/Common/EventManagerTest.php
+++ b/tests/Doctrine/Tests/Common/EventManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common;
 
 use Doctrine\Common\EventManager;

--- a/tests/Doctrine/Tests/Common/EventManagerTest.php
+++ b/tests/Doctrine/Tests/Common/EventManagerTest.php
@@ -20,21 +20,21 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
     private $_eventManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_eventManager = new EventManager;
         $this->_preFooInvoked = false;
         $this->_postFooInvoked = false;
     }
 
-    public function testInitialState()
+    public function testInitialState(): void
     {
         $this->assertEquals([], $this->_eventManager->getListeners());
         $this->assertFalse($this->_eventManager->hasListeners(self::preFoo));
         $this->assertFalse($this->_eventManager->hasListeners(self::postFoo));
     }
 
-    public function testAddEventListener()
+    public function testAddEventListener(): void
     {
         $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
         $this->assertTrue($this->_eventManager->hasListeners(self::preFoo));
@@ -44,7 +44,7 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertEquals(2, count($this->_eventManager->getListeners()));
     }
 
-    public function testDispatchEvent()
+    public function testDispatchEvent(): void
     {
         $this->_eventManager->addEventListener(['preFoo', 'postFoo'], $this);
         $this->_eventManager->dispatchEvent(self::preFoo);
@@ -52,7 +52,7 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($this->_postFooInvoked);
     }
 
-    public function testRemoveEventListener()
+    public function testRemoveEventListener(): void
     {
         $this->_eventManager->addEventListener(['preBar'], $this);
         $this->assertTrue($this->_eventManager->hasListeners(self::preBar));
@@ -60,7 +60,7 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertFalse($this->_eventManager->hasListeners(self::preBar));
     }
 
-    public function testAddEventSubscriber()
+    public function testAddEventSubscriber(): void
     {
         $eventSubscriber = new TestEventSubscriber();
         $this->_eventManager->addEventSubscriber($eventSubscriber);
@@ -70,12 +70,12 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
     /* Listener methods */
 
-    public function preFoo(EventArgs $e)
+    public function preFoo(EventArgs $e): void
     {
         $this->_preFooInvoked = true;
     }
 
-    public function postFoo(EventArgs $e)
+    public function postFoo(EventArgs $e): void
     {
         $this->_postFooInvoked = true;
     }

--- a/tests/Doctrine/Tests/Common/EventManagerTest.php
+++ b/tests/Doctrine/Tests/Common/EventManagerTest.php
@@ -81,7 +81,7 @@ class EventManagerTest extends \Doctrine\Tests\DoctrineTestCase
 
 class TestEventSubscriber implements \Doctrine\Common\EventSubscriber
 {
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return ['preFoo', 'postFoo'];
     }

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -104,7 +104,7 @@ class TestManagerRegistry extends AbstractManagerRegistry
         parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);
     }
 
-    protected function getService($name)
+    protected function getService(string $name): object
     {
         if (!isset($this->services[$name])) {
             $this->services[$name] = call_user_func($this->managerFactory);
@@ -113,12 +113,12 @@ class TestManagerRegistry extends AbstractManagerRegistry
         return $this->services[$name];
     }
 
-    protected function resetService($name)
+    protected function resetService(string $name): void
     {
         unset($this->services[$name]);
     }
 
-    public function getAliasNamespace($alias)
+    public function getAliasNamespace(string $alias): string
     {
         return __NAMESPACE__;
     }

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence;
 
 use Doctrine\Common\Persistence\AbstractManagerRegistry;

--- a/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ManagerRegistryTest.php
@@ -27,7 +27,7 @@ class ManagerRegistryTest extends DoctrineTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->mr = new TestManagerRegistry(
             'ORM',
@@ -40,17 +40,17 @@ class ManagerRegistryTest extends DoctrineTestCase
         );
     }
 
-    public function testGetManagerForClass()
+    public function testGetManagerForClass(): void
     {
         $this->mr->getManagerForClass(TestObject::class);
     }
 
-    public function testGetManagerForProxyInterface()
+    public function testGetManagerForProxyInterface(): void
     {
         $this->assertNull($this->mr->getManagerForClass(ObjectManagerAware::class));
     }
 
-    public function testGetManagerForInvalidClass()
+    public function testGetManagerForInvalidClass(): void
     {
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage('Class Doctrine\Tests\Common\Persistence\TestObjectInexistent does not exist');
@@ -58,12 +58,12 @@ class ManagerRegistryTest extends DoctrineTestCase
         $this->mr->getManagerForClass('prefix:TestObjectInexistent');
     }
 
-    public function testGetManagerForAliasedClass()
+    public function testGetManagerForAliasedClass(): void
     {
         $this->mr->getManagerForClass('prefix:TestObject');
     }
 
-    public function testGetManagerForInvalidAliasedClass()
+    public function testGetManagerForInvalidAliasedClass(): void
     {
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage('Class Doctrine\Tests\Common\Persistence\TestObject:Foo does not exist');
@@ -71,7 +71,7 @@ class ManagerRegistryTest extends DoctrineTestCase
         $this->mr->getManagerForClass('prefix:TestObject:Foo');
     }
 
-    public function testResetManager()
+    public function testResetManager(): void
     {
         $manager = $this->mr->getManager();
         $newManager = $this->mr->resetManager();
@@ -80,7 +80,7 @@ class ManagerRegistryTest extends DoctrineTestCase
         $this->assertNotSame($manager, $newManager);
     }
 
-    private function getManagerFactory()
+    private function getManagerFactory(): callable
     {
         return function () {
             $mock = $this->createMock(ObjectManager::class);
@@ -99,8 +99,15 @@ class TestManagerRegistry extends AbstractManagerRegistry
 
     private $managerFactory;
 
-    public function __construct($name, array $connections, array $managers, $defaultConnection, $defaultManager, $proxyInterfaceName, callable $managerFactory)
-    {
+    public function __construct(
+        string $name,
+        array $connections,
+        array $managers,
+        string $defaultConnection,
+        string $defaultManager,
+        string $proxyInterfaceName,
+        callable $managerFactory
+    ) {
         $this->managerFactory = $managerFactory;
 
         parent::__construct($name, $connections, $managers, $defaultConnection, $defaultManager, $proxyInterfaceName);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
@@ -12,7 +12,7 @@ use Doctrine\TestClass;
 
 class AnnotationDriverTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetAllClassNames()
+    public function testGetAllClassNames(): void
     {
         $reader = new AnnotationReader();
         $driver = new SimpleAnnotationDriver($reader, [__DIR__ . '/_files/annotation']);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
@@ -25,7 +25,7 @@ class SimpleAnnotationDriver extends AnnotationDriver
 {
     protected $entityAnnotationClasses = [Entity::class => true];
 
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/AnnotationDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -23,14 +23,14 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
      */
     private $cmf;
 
-    public function setUp()
+    public function setUp(): void
     {
         $driver = $this->createMock(MappingDriver::class);
         $metadata = $this->createMock(ClassMetadata::class);
         $this->cmf = new TestClassMetadataFactory($driver, $metadata);
     }
 
-    public function testGetCacheDriver()
+    public function testGetCacheDriver(): void
     {
         $this->assertNull($this->cmf->getCacheDriver());
         $cache = new ArrayCache();
@@ -38,7 +38,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertSame($cache, $this->cmf->getCacheDriver());
     }
 
-    public function testGetMetadataFor()
+    public function testGetMetadataFor(): void
     {
         $metadata = $this->cmf->getMetadataFor('stdClass');
 
@@ -46,13 +46,13 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertTrue($this->cmf->hasMetadataFor('stdClass'));
     }
 
-    public function testGetMetadataForAbsentClass()
+    public function testGetMetadataForAbsentClass(): void
     {
         $this->expectException(MappingException::class);
         $this->cmf->getMetadataFor(__NAMESPACE__ . '\AbsentClass');
     }
 
-    public function testGetParentMetadata()
+    public function testGetParentMetadata(): void
     {
         $metadata = $this->cmf->getMetadataFor(ChildEntity::class);
 
@@ -61,7 +61,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertTrue($this->cmf->hasMetadataFor(RootEntity::class));
     }
 
-    public function testGetCachedMetadata()
+    public function testGetCachedMetadata(): void
     {
         $metadata = $this->createMock(ClassMetadata::class);
         $cache = new ArrayCache();
@@ -72,7 +72,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertSame($metadata, $this->cmf->getMetadataFor(ChildEntity::class));
     }
 
-    public function testCacheGetMetadataFor()
+    public function testCacheGetMetadataFor(): void
     {
         $cache = new ArrayCache();
         $this->cmf->setCacheDriver($cache);
@@ -82,7 +82,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertSame($loadedMetadata, $cache->fetch(ChildEntity::class. '$CLASSMETADATA'));
     }
 
-    public function testGetAliasedMetadata()
+    public function testGetAliasedMetadata(): void
     {
         $this->cmf->getMetadataFor('prefix:ChildEntity');
 
@@ -93,7 +93,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     /**
      * @group DCOM-270
      */
-    public function testGetInvalidAliasedMetadata()
+    public function testGetInvalidAliasedMetadata(): void
     {
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage(
@@ -106,12 +106,12 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     /**
      * @group DCOM-270
      */
-    public function testClassIsTransient()
+    public function testClassIsTransient(): void
     {
         $this->assertTrue($this->cmf->isTransient('prefix:ChildEntity:Foo'));
     }
 
-    public function testWillFallbackOnNotLoadedMetadata()
+    public function testWillFallbackOnNotLoadedMetadata(): void
     {
         $classMetadata = $this->createMock(ClassMetadata::class);
 
@@ -124,7 +124,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
         $this->assertSame($classMetadata, $this->cmf->getMetadataFor('Foo'));
     }
 
-    public function testWillFailOnFallbackFailureWithNotLoadedMetadata()
+    public function testWillFailOnFallbackFailureWithNotLoadedMetadata(): void
     {
         $this->cmf->fallbackCallback = function () {
             return null;
@@ -140,7 +140,7 @@ class ClassMetadataFactoryTest extends DoctrineTestCase
     /**
      * @group 717
      */
-    public function testWillIgnoreCacheEntriesThatAreNotMetadataInstances()
+    public function testWillIgnoreCacheEntriesThatAreNotMetadataInstances(): void
     {
         /* @var $cacheDriver Cache|\PHPUnit_Framework_MockObject_MockObject */
         $cacheDriver = $this->createMock(Cache::class);
@@ -171,7 +171,7 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
     /** @var callable|null */
     public $fallbackCallback;
 
-    public function __construct($driver, $metadata)
+    public function __construct(MappingDriver $driver, ClassMetadata $metadata)
     {
         $this->driver = $driver;
         $this->metadata = $metadata;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Cache\Cache;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/ClassMetadataFactoryTest.php
@@ -175,44 +175,44 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
         $this->metadata = $metadata;
     }
 
-    protected function doLoadMetadata($class, $parent, $rootEntityFound, array $nonSuperclassParents)
+    protected function doLoadMetadata(ClassMetadata $class, ?ClassMetadata $parent, bool $rootEntityFound, array $nonSuperclassParents): void
     {
 
     }
 
-    protected function getFqcnFromAlias($namespaceAlias, $simpleClassName)
+    protected function getFqcnFromAlias(string $namespaceAlias, string $simpleClassName): string
     {
         return __NAMESPACE__ . '\\' . $simpleClassName;
     }
 
-    protected function initialize()
+    protected function initialize(): void
     {
 
     }
 
-    protected function newClassMetadataInstance($className)
+    protected function newClassMetadataInstance(string $className): ClassMetadata
     {
         return $this->metadata;
     }
 
-    protected function getDriver()
+    protected function getDriver(): MappingDriver
     {
         return $this->driver;
     }
-    protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService)
+    protected function wakeupReflection(ClassMetadata $class, ReflectionService $reflService): void
     {
     }
 
-    protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService)
+    protected function initializeReflection(ClassMetadata $class, ReflectionService $reflService): void
     {
     }
 
-    protected function isEntity(ClassMetadata $class)
+    protected function isEntity(ClassMetadata $class): bool
     {
         return true;
     }
 
-    protected function onNotFoundMetadata($className)
+    protected function onNotFoundMetadata(string $className): ?ClassMetadata
     {
         if (! $fallback = $this->fallbackCallback) {
             return null;
@@ -221,7 +221,7 @@ class TestClassMetadataFactory extends AbstractClassMetadataFactory
         return $fallback();
     }
 
-    public function isTransient($class)
+    public function isTransient(string $class): bool
     {
         return true;
     }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 
 class DefaultFileLocatorTest extends DoctrineTestCase
 {
-    public function testGetPaths()
+    public function testGetPaths(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -21,7 +21,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals([$path], $locator->getPaths());
     }
 
-    public function testGetFileExtension()
+    public function testGetFileExtension(): void
     {
         $locator = new DefaultFileLocator([], ".yml");
         $this->assertEquals(".yml", $locator->getFileExtension());
@@ -29,7 +29,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals(".xml", $locator->getFileExtension());
     }
 
-    public function testUniquePaths()
+    public function testUniquePaths(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -37,7 +37,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals([$path], $locator->getPaths());
     }
 
-    public function testFindMappingFile()
+    public function testFindMappingFile(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -46,7 +46,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals(__DIR__ . '/_files' . DIRECTORY_SEPARATOR . 'stdClass.yml', $locator->findMappingFile('stdClass'));
     }
 
-    public function testFindMappingFileNotFound()
+    public function testFindMappingFileNotFound(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -57,7 +57,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $locator->findMappingFile('stdClass2');
     }
 
-    public function testGetAllClassNames()
+    public function testGetAllClassNames(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -77,7 +77,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals($expectedGlobalClasses, $globalClasses);
     }
 
-    public function testGetAllClassNamesNonMatchingFileExtension()
+    public function testGetAllClassNamesNonMatchingFileExtension(): void
     {
         $path = __DIR__ . "/_files";
 
@@ -85,7 +85,7 @@ class DefaultFileLocatorTest extends DoctrineTestCase
         $this->assertEquals([], $locator->getAllClassNames("global"));
     }
 
-    public function testFileExists()
+    public function testFileExists(): void
     {
         $path = __DIR__ . "/_files";
 

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DefaultFileLocatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DriverChainTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\DoctrineTestCase;
 
 class DriverChainTest extends DoctrineTestCase
 {
-    public function testDelegateToMatchingNamespaceDriver()
+    public function testDelegateToMatchingNamespaceDriver(): void
     {
         $className = DriverChainEntity::class;
         /* @var $classMetadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
@@ -46,7 +46,7 @@ class DriverChainTest extends DoctrineTestCase
         $this->assertTrue( $chain->isTransient($className) );
     }
 
-    public function testLoadMetadata_NoDelegatorFound_ThrowsMappingException()
+    public function testLoadMetadata_NoDelegatorFound_ThrowsMappingException(): void
     {
         $className = DriverChainEntity::class;
         /* @var $classMetadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
@@ -58,7 +58,7 @@ class DriverChainTest extends DoctrineTestCase
         $chain->loadMetadataForClass($className, $classMetadata);
     }
 
-    public function testGatherAllClassNames()
+    public function testGatherAllClassNames(): void
     {
         $chain = new MappingDriverChain();
 
@@ -87,7 +87,7 @@ class DriverChainTest extends DoctrineTestCase
     /**
      * @group DDC-706
      */
-    public function testIsTransient()
+    public function testIsTransient(): void
     {
         /* @var $driver1 MappingDriver|\PHPUnit_Framework_MockObject_MockObject */
         $driver1 = $this->createMock(MappingDriver::class);
@@ -100,7 +100,7 @@ class DriverChainTest extends DoctrineTestCase
     /**
      * @group DDC-1412
      */
-    public function testDefaultDriver()
+    public function testDefaultDriver(): void
     {
         $companyDriver      = $this->createMock(MappingDriver::class);
         $defaultDriver      = $this->createMock(MappingDriver::class);
@@ -133,7 +133,7 @@ class DriverChainTest extends DoctrineTestCase
         $this->assertFalse($chain->isTransient($managerClassName));
     }
 
-    public function testDefaultDriverGetAllClassNames()
+    public function testDefaultDriverGetAllClassNames(): void
     {
         /* @var $companyDriver MappingDriver|\PHPUnit_Framework_MockObject_MockObject */
         $companyDriver = $this->createMock(MappingDriver::class);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/DriverChainTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/DriverChainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\Driver\FileLocator;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -147,7 +147,7 @@ class FileDriverTest extends DoctrineTestCase
 
 class TestFileDriver extends FileDriver
 {
-    protected function loadMappingFile($file)
+    protected function loadMappingFile(string $file): array
     {
         if (strpos($file, "global.yml") !== false) {
             return ['stdGlobal' => 'stdGlobal', 'stdGlobal2' => 'stdGlobal2'];
@@ -155,7 +155,7 @@ class TestFileDriver extends FileDriver
         return ['stdClass' => 'stdClass'];
     }
 
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass(string $className, ClassMetadata $metadata): void
     {
 
     }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 class FileDriverTest extends DoctrineTestCase
 {
-    public function testGlobalBasename()
+    public function testGlobalBasename(): void
     {
         $driver = new TestFileDriver([]);
 
@@ -21,7 +21,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals("global", $driver->getGlobalBasename());
     }
 
-    public function testGetElementFromGlobalFile()
+    public function testGetElementFromGlobalFile(): void
     {
         $driver = new TestFileDriver($this->newLocator());
         $driver->setGlobalBasename("global");
@@ -31,7 +31,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals('stdGlobal', $element);
     }
 
-    public function testGetElementFromFile()
+    public function testGetElementFromFile(): void
     {
         $locator = $this->newLocator();
         $locator->expects($this->once())
@@ -44,7 +44,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals('stdClass', $driver->getElement('stdClass'));
     }
 
-    public function testGetElementUpdatesClassCache()
+    public function testGetElementUpdatesClassCache(): void
     {
         $locator = $this->newLocator();
 
@@ -63,7 +63,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals('stdClass', $driver->getElement('stdClass'));
     }
 
-    public function testGetAllClassNamesGlobalBasename()
+    public function testGetAllClassNamesGlobalBasename(): void
     {
         $driver = new TestFileDriver($this->newLocator());
         $driver->setGlobalBasename("global");
@@ -73,7 +73,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals(['stdGlobal', 'stdGlobal2'], $classNames);
     }
 
-    public function testGetAllClassNamesFromMappingFile()
+    public function testGetAllClassNamesFromMappingFile(): void
     {
         $locator = $this->newLocator();
         $locator->expects($this->any())
@@ -87,7 +87,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals(['stdClass'], $classNames);
     }
 
-    public function testGetAllClassNamesBothSources()
+    public function testGetAllClassNamesBothSources(): void
     {
         $locator = $this->newLocator();
         $locator->expects($this->any())
@@ -102,7 +102,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertEquals(['stdGlobal', 'stdGlobal2', 'stdClass'], $classNames);
     }
 
-    public function testIsNotTransient()
+    public function testIsNotTransient(): void
     {
         $locator = $this->newLocator();
         $locator->expects($this->once())
@@ -118,7 +118,7 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertFalse($driver->isTransient('stdGlobal2'));
     }
 
-    public function testIsTransient()
+    public function testIsTransient(): void
     {
         $locator = $this->newLocator();
         $locator->expects($this->once())
@@ -131,14 +131,14 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertTrue($driver->isTransient('stdClass2'));
     }
 
-    public function testNonLocatorFallback()
+    public function testNonLocatorFallback(): void
     {
         $driver = new TestFileDriver(__DIR__ . '/_files', '.yml');
         $this->assertTrue($driver->isTransient('stdClass2'));
         $this->assertFalse($driver->isTransient('stdClass'));
     }
 
-    private function newLocator()
+    private function newLocator(): FileLocator
     {
         $locator = $this->createMock(FileLocator::class);
         $locator->expects($this->any())->method('getFileExtension')->will($this->returnValue('.yml'));

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/FileDriverTest.php
@@ -138,6 +138,9 @@ class FileDriverTest extends DoctrineTestCase
         $this->assertFalse($driver->isTransient('stdClass'));
     }
 
+    /**
+     * @return FileLocator|\PHPUnit_Framework_MockObject_MockObject
+     */
     private function newLocator(): FileLocator
     {
         $locator = $this->createMock(FileLocator::class);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\PHPDriver;
 
 class PHPDriverTest extends DoctrineTestCase
 {
-    public function testLoadMetadata()
+    public function testLoadMetadata(): void
     {
         /* @var $metadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
         $metadata = $this->createMock(ClassMetadata::class);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/PHPDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -37,46 +37,46 @@ class RuntimeReflectionServiceTest extends \PHPUnit_Framework_TestCase
 
     public $unusedPublicProperty;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->reflectionService = new RuntimeReflectionService();
     }
 
-    public function testShortname()
+    public function testShortname(): void
     {
         $this->assertEquals("RuntimeReflectionServiceTest", $this->reflectionService->getClassShortName(__CLASS__));
     }
 
-    public function testClassNamespaceName()
+    public function testClassNamespaceName(): void
     {
         $this->assertEquals('Doctrine\Tests\Common\Persistence\Mapping', $this->reflectionService->getClassNamespace(__CLASS__));
     }
 
-    public function testGetParentClasses()
+    public function testGetParentClasses(): void
     {
         $classes = $this->reflectionService->getParentClasses(__CLASS__);
         $this->assertTrue(count($classes) >= 1, "The test class ".__CLASS__." should have at least one parent.");
     }
 
-    public function testGetParentClassesForAbsentClass()
+    public function testGetParentClassesForAbsentClass(): void
     {
         $this->expectException(MappingException::class);
         $this->reflectionService->getParentClasses(__NAMESPACE__ . '\AbsentClass');
     }
 
-    public function testGetReflectionClass()
+    public function testGetReflectionClass(): void
     {
         $class = $this->reflectionService->getClass(__CLASS__);
         $this->assertInstanceOf("ReflectionClass", $class);
     }
 
-    public function testGetMethods()
+    public function testGetMethods(): void
     {
         $this->assertTrue($this->reflectionService->hasPublicMethod(__CLASS__, "testGetMethods"));
         $this->assertFalse($this->reflectionService->hasPublicMethod(__CLASS__, "testGetMethods2"));
     }
 
-    public function testGetAccessibleProperty()
+    public function testGetAccessibleProperty(): void
     {
         $reflProp = $this->reflectionService->getAccessibleProperty(__CLASS__, "reflectionService");
         $this->assertInstanceOf(\ReflectionProperty::class, $reflProp);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/RuntimeReflectionServiceTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
 
 class StaticPHPDriverTest extends DoctrineTestCase
 {
-    public function testLoadMetadata()
+    public function testLoadMetadata(): void
     {
         /* @var $metadata ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
         $metadata = $this->createMock(ClassMetadata::class);
@@ -20,7 +20,7 @@ class StaticPHPDriverTest extends DoctrineTestCase
         $driver->loadMetadataForClass(TestEntity::class, $metadata);
     }
 
-    public function testGetAllClassNames()
+    public function testGetAllClassNames(): void
     {
         $driver = new StaticPHPDriver([__DIR__]);
         $classNames = $driver->getAllClassNames();
@@ -31,7 +31,7 @@ class StaticPHPDriverTest extends DoctrineTestCase
 
 class TestEntity
 {
-    static public function loadMetadata($metadata)
+    static public function loadMetadata(ClassMetadata $metadata): void
     {
         $metadata->getFieldNames();
     }

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticPHPDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
@@ -33,41 +33,41 @@ class StaticReflectionServiceTest extends \PHPUnit_Framework_TestCase
      */
     private $reflectionService;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->reflectionService = new StaticReflectionService();
     }
 
-    public function testShortname()
+    public function testShortname(): void
     {
         $this->assertEquals("StaticReflectionServiceTest", $this->reflectionService->getClassShortName(__CLASS__));
     }
 
-    public function testClassNamespaceName()
+    public function testClassNamespaceName(): void
     {
         $this->assertEquals('', $this->reflectionService->getClassNamespace(\stdClass::class));
         $this->assertEquals(__NAMESPACE__, $this->reflectionService->getClassNamespace(__CLASS__));
     }
 
-    public function testGetParentClasses()
+    public function testGetParentClasses(): void
     {
         $classes = $this->reflectionService->getParentClasses(__CLASS__);
         $this->assertTrue(count($classes) == 0, "The test class ".__CLASS__." should have no parents according to static reflection.");
     }
 
-    public function testGetReflectionClass()
+    public function testGetReflectionClass(): void
     {
         $class = $this->reflectionService->getClass(__CLASS__);
         $this->assertNull($class);
     }
 
-    public function testGetMethods()
+    public function testGetMethods(): void
     {
         $this->assertTrue($this->reflectionService->hasPublicMethod(__CLASS__, "testGetMethods"));
         $this->assertTrue($this->reflectionService->hasPublicMethod(__CLASS__, "testGetMethods2"));
     }
 
-    public function testGetAccessibleProperty()
+    public function testGetAccessibleProperty(): void
     {
         $reflProp = $this->reflectionService->getAccessibleProperty(__CLASS__, "reflectionService");
         $this->assertNull($reflProp);

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/StaticReflectionServiceTest.php
@@ -17,6 +17,8 @@
  * <http://www.doctrine-project.org>.
  */
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\StaticReflectionService;

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -80,7 +80,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
 
-        new SymfonyFileLocator([$path => $prefix], ".yml", null);
+        new SymfonyFileLocator([$path => $prefix], ".yml", "");
     }
 
     public function customNamespaceSeparatorProvider()

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\SymfonyFileLocator;
 
 class SymfonyFileLocatorTest extends DoctrineTestCase
 {
-    public function testGetPaths()
+    public function testGetPaths(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -22,7 +22,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertEquals([$path], $locator->getPaths());
     }
 
-    public function testGetPrefixes()
+    public function testGetPrefixes(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -31,7 +31,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertEquals([$path => $prefix], $locator->getNamespacePrefixes());
     }
 
-    public function testGetFileExtension()
+    public function testGetFileExtension(): void
     {
         $locator = new SymfonyFileLocator([], ".yml");
         $this->assertEquals(".yml", $locator->getFileExtension());
@@ -39,7 +39,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertEquals(".xml", $locator->getFileExtension());
     }
 
-    public function testFileExists()
+    public function testFileExists(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -52,7 +52,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertFalse($locator->fileExists("Foo\global2"));
     }
 
-    public function testGetAllClassNames()
+    public function testGetAllClassNames(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -77,7 +77,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Namespace separator should not be empty
      */
-    public function testInvalidCustomNamespaceSeparator()
+    public function testInvalidCustomNamespaceSeparator(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -85,7 +85,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         new SymfonyFileLocator([$path => $prefix], ".yml", "");
     }
 
-    public function customNamespaceSeparatorProvider()
+    public function customNamespaceSeparatorProvider(): array
     {
         return [
             'directory separator' => [DIRECTORY_SEPARATOR, "/_custom_ns/dir"],
@@ -101,7 +101,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
      *
      * @throws MappingException
      */
-    public function testGetClassNamesWithCustomNsSeparator($separator, $dir)
+    public function testGetClassNamesWithCustomNsSeparator(string $separator, string $dir): void
     {
         $path = __DIR__ . $dir;
         $prefix = "Foo";
@@ -113,7 +113,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertEquals(["Foo\\stdClass", "Foo\\sub\\subClass", "Foo\\sub\\subsub\\subSubClass"], $classes);
     }
 
-    public function customNamespaceLookupQueryProvider()
+    public function customNamespaceLookupQueryProvider(): array
     {
         return [
             'directory separator'  => [
@@ -144,7 +144,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
      *
      * @throws MappingException
      */
-    public function testFindMappingFileWithCustomNsSeparator($separator, $dir, $files)
+    public function testFindMappingFileWithCustomNsSeparator(string $separator, string $dir, array $files): void
     {
         $path   = __DIR__ . $dir;
         $prefix = "Foo";
@@ -158,7 +158,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
     }
 
 
-    public function testFindMappingFile()
+    public function testFindMappingFile(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -168,7 +168,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $this->assertEquals(__DIR__ . "/_files/stdClass.yml", $locator->findMappingFile("Foo\\stdClass"));
     }
 
-    public function testFindMappingFileNotFound()
+    public function testFindMappingFileNotFound(): void
     {
         $path = __DIR__ . "/_files";
         $prefix = "Foo";
@@ -180,7 +180,7 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         $locator->findMappingFile("Foo\\stdClass2");
     }
 
-    public function testFindMappingFileLeastSpecificNamespaceFirst()
+    public function testFindMappingFileLeastSpecificNamespaceFirst(): void
     {
         // Low -> High
         $prefixes = array();
@@ -195,7 +195,8 @@ class SymfonyFileLocatorTest extends DoctrineTestCase
         );
     }
 
-    public function testFindMappingFileMostSpecificNamespaceFirst() {
+    public function testFindMappingFileMostSpecificNamespaceFirst(): void
+    {
         $prefixes = array();
         $prefixes[__DIR__ . "/_match_ns/Bar"] = "Foo\\Bar";
         $prefixes[__DIR__ . "/_match_ns"] = "Foo";

--- a/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/Mapping/SymfonyFileLocatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;

--- a/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
@@ -23,13 +23,13 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     private $wrapped;
     private $decorated;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->wrapped   = $this->createMock(ObjectManager::class);
         $this->decorated = new NullObjectManagerDecorator($this->wrapped);
     }
 
-    public function getMethodParameters()
+    public function getMethodParameters(): array
     {
         $class = new \ReflectionClass(ObjectManager::class);
 
@@ -51,7 +51,7 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getMethodParameters
      */
-    public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters, $returnedValue)
+    public function testAllMethodCallsAreDelegatedToTheWrappedInstance(string $method, array $parameters, $returnedValue): void
     {
         $stub = $this->wrapped
             ->expects($this->once())

--- a/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
@@ -30,26 +30,16 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     public function getMethodParameters()
     {
         $class = new \ReflectionClass(ObjectManager::class);
-        $voidMethods = [
-            'persist',
-            'remove',
-            'clear',
-            'detach',
-            'refresh',
-            'flush',
-            'initializeObject',
-        ];
 
         $methods = [];
         foreach ($class->getMethods() as $method) {
-            $isVoidMethod = in_array($method->getName(), $voidMethods, true);
             if ($method->getNumberOfRequiredParameters() === 0) {
-               $methods[] = [$method->getName(), [], $isVoidMethod];
+               $methods[] = [$method->getName(), [], $this->getDummyReturnType($method)];
             } elseif ($method->getNumberOfRequiredParameters() > 0) {
-                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: [], $isVoidMethod];
+                $methods[] = [$method->getName(), $this->buildDummyParameters($method, true), $this->getDummyReturnType($method)];
             }
             if ($method->getNumberOfParameters() != $method->getNumberOfRequiredParameters()) {
-                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: [], $isVoidMethod];
+                $methods[] = [$method->getName(), $this->buildDummyParameters($method), $this->getDummyReturnType($method)];
             }
         }
 
@@ -59,9 +49,8 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getMethodParameters
      */
-    public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters, $isVoidMethod)
+    public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters, $returnedValue)
     {
-        $returnedValue = $isVoidMethod ? null : 'INNER VALUE FROM ' . $method;
         $stub = $this->wrapped
             ->expects($this->once())
             ->method($method)
@@ -70,5 +59,68 @@ class ObjectManagerDecoratorTest extends \PHPUnit_Framework_TestCase
         call_user_func_array([$stub, 'with'], $parameters);
 
         $this->assertSame($returnedValue, call_user_func_array([$this->decorated, $method], $parameters));
+    }
+
+    private function buildDummyParameters(\ReflectionMethod $method, bool $requiredOnly = false): array
+    {
+        if ($method->getNumberOfParameters() === 0) {
+            return [];
+        }
+
+        $dummies = [];
+        for (
+            $i = 0, $count = $requiredOnly ? $method->getNumberOfRequiredParameters() : $method->getNumberOfParameters();
+            $i < $count;
+            $i++
+        ) {
+            $dummies[] = $this->getDummyValueForParameter($method->getParameters()[$i]);
+        }
+
+        return $dummies;
+    }
+
+    private function getDummyValueForParameter(\ReflectionParameter $parameter)
+    {
+        if ($parameter->getType() === null) {
+            // mixed
+            return 'untyped';
+        }
+
+        return $this->getDummyValueForType($parameter->getType());
+    }
+
+    private function getDummyReturnType(\ReflectionMethod $method)
+    {
+        if (! $method->hasReturnType()) {
+            return 'untyped';
+        }
+
+        return $this->getDummyValueForType($method->getReturnType());
+    }
+
+    private function getDummyValueForType(\ReflectionType $type)
+    {
+        if ($type->allowsNull()) {
+            return null;
+        }
+
+        switch ((string) $type) {
+            case 'object':
+                return new \stdClass();
+            case 'string':
+                return'php';
+            case 'bool':
+                return true;
+            case 'int':
+                return 42;
+            case 'float':
+                return 4.2;
+            case 'array':
+                return [];
+            case 'void':
+                return null;
+            default:
+                return $this->createMock((string) $type);
+        }
     }
 }

--- a/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/ObjectManagerDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence;
 
 use Doctrine\Common\Persistence\ObjectManagerDecorator;

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Persistence;
 
 use BadMethodCallException;

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -157,84 +157,84 @@ class TestObject extends PersistentObject
 class TestObjectMetadata implements ClassMetadata
 {
 
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField(string $assocName): string
     {
         $assoc = ['children' => 'parent'];
         return $assoc[$assocName];
     }
 
-    public function getAssociationNames()
+    public function getAssociationNames(): array
     {
         return ['parent', 'children'];
     }
 
-    public function getAssociationTargetClass($assocName)
+    public function getAssociationTargetClass(string $assocName): string
     {
         return __NAMESPACE__ . '\TestObject';
     }
 
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return ['id', 'name'];
     }
 
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return ['id'];
     }
 
-    public function getName()
+    public function getName(): string
     {
         return __NAMESPACE__ . '\TestObject';
     }
 
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         return new \ReflectionClass($this->getName());
     }
 
-    public function getTypeOfField($fieldName)
+    public function getTypeOfField(string $fieldName): string
     {
         $types = ['id' => 'integer', 'name' => 'string'];
         return $types[$fieldName];
     }
 
-    public function hasAssociation($fieldName)
+    public function hasAssociation(string $fieldName): bool
     {
         return in_array($fieldName, ['parent', 'children']);
     }
 
-    public function hasField($fieldName)
+    public function hasField(string $fieldName): bool
     {
         return in_array($fieldName, ['id', 'name']);
     }
 
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide(string $assocName): bool
     {
         return ($assocName === 'children');
     }
 
-    public function isCollectionValuedAssociation($fieldName)
+    public function isCollectionValuedAssociation(string $fieldName): bool
     {
         return ($fieldName === 'children');
     }
 
-    public function isIdentifier($fieldName)
+    public function isIdentifier(string $fieldName): bool
     {
         return $fieldName === 'id';
     }
 
-    public function isSingleValuedAssociation($fieldName)
+    public function isSingleValuedAssociation(string $fieldName): bool
     {
         return $fieldName === 'parent';
     }
 
-    public function getIdentifierValues($entity)
+    public function getIdentifierValues(object $object): array
     {
 
     }
 
-    public function getIdentifierFieldNames()
+    public function getIdentifierFieldNames(): array
     {
 
     }

--- a/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/Common/Persistence/PersistentObjectTest.php
@@ -21,7 +21,7 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
     private $om;
     private $object;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cm = new TestObjectMetadata;
         $this->om = $this->createMock(ObjectManager::class);
@@ -32,65 +32,65 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
         $this->object->injectObjectManager($this->om, $this->cm);
     }
 
-    public function testGetObjectManager()
+    public function testGetObjectManager(): void
     {
         $this->assertSame($this->om, PersistentObject::getObjectManager());
     }
 
-    public function testNonMatchingObjectManager()
+    public function testNonMatchingObjectManager(): void
     {
         $this->expectException(RuntimeException::class);
         $om = $this->createMock(ObjectManager::class);
         $this->object->injectObjectManager($om, $this->cm);
     }
 
-    public function testGetField()
+    public function testGetField(): void
     {
         $this->assertEquals('beberlei', $this->object->getName());
     }
 
-    public function testSetField()
+    public function testSetField(): void
     {
         $this->object->setName("test");
         $this->assertEquals("test", $this->object->getName());
     }
 
-    public function testGetIdentifier()
+    public function testGetIdentifier(): void
     {
         $this->assertEquals(1, $this->object->getId());
     }
 
-    public function testSetIdentifier()
+    public function testSetIdentifier(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->object->setId(2);
     }
 
-    public function testSetUnknownField()
+    public function testSetUnknownField(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->object->setUnknown("test");
     }
 
-    public function testGetUnknownField()
+    public function testGetUnknownField(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->object->getUnknown();
     }
 
-    public function testGetToOneAssociation()
+    public function testGetToOneAssociation(): void
     {
         $this->assertNull($this->object->getParent());
     }
 
-    public function testSetToOneAssociation()
+    public function testSetToOneAssociation(): void
     {
         $parent = new TestObject();
         $this->object->setParent($parent);
         $this->assertSame($parent, $this->object->getParent($parent));
     }
 
-    public function testSetInvalidToOneAssociation()
+    public function testSetInvalidToOneAssociation(): void
     {
         $parent = new \stdClass();
 
@@ -98,7 +98,7 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
         $this->object->setParent($parent);
     }
 
-    public function testSetToOneAssociationNull()
+    public function testSetToOneAssociationNull(): void
     {
         $parent = new TestObject();
         $this->object->setParent($parent);
@@ -106,7 +106,7 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertNull($this->object->getParent());
     }
 
-    public function testAddToManyAssociation()
+    public function testAddToManyAssociation(): void
     {
         $child = new TestObject();
         $this->object->addChildren($child);
@@ -120,13 +120,13 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
         $this->assertEquals(2, count($this->object->getChildren()));
     }
 
-    public function testAddInvalidToManyAssociation()
+    public function testAddInvalidToManyAssociation(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->object->addChildren(new \stdClass());
     }
 
-    public function testNoObjectManagerSet()
+    public function testNoObjectManagerSet(): void
     {
         PersistentObject::setObjectManager(null);
         $child = new TestObject();
@@ -135,13 +135,13 @@ class PersistentObjectTest extends \Doctrine\Tests\DoctrineTestCase
         $child->setName("test");
     }
 
-    public function testInvalidMethod()
+    public function testInvalidMethod(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->object->asdf();
     }
 
-    public function testAddInvalidCollection()
+    public function testAddInvalidCollection(): void
     {
         $this->expectException(BadMethodCallException::class);
         $this->object->addAsdf(new \stdClass());
@@ -241,12 +241,12 @@ class TestObjectMetadata implements ClassMetadata
 
     }
 
-    public function initializeReflection(ReflectionService $reflService)
+    public function initializeReflection(ReflectionService $reflService): void
     {
 
     }
 
-    public function wakeupReflection(ReflectionService $reflService)
+    public function wakeupReflection(ReflectionService $reflService): void
     {
 
     }

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
@@ -64,7 +64,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getReflectionClass()->getName();
     }
@@ -72,7 +72,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return array_keys($this->identifier);
     }
@@ -80,7 +80,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         if (null === $this->reflectionClass) {
             $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObject');
@@ -92,7 +92,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isIdentifier($fieldName)
+    public function isIdentifier(string $fieldName): bool
     {
         return isset($this->identifier[$fieldName]);
     }
@@ -100,7 +100,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasField($fieldName)
+    public function hasField(string $fieldName): bool
     {
         return isset($this->fields[$fieldName]);
     }
@@ -108,7 +108,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasAssociation($fieldName)
+    public function hasAssociation(string $fieldName): bool
     {
         return isset($this->associations[$fieldName]);
     }
@@ -116,7 +116,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isSingleValuedAssociation($fieldName)
+    public function isSingleValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -124,7 +124,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isCollectionValuedAssociation($fieldName)
+    public function isCollectionValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -132,7 +132,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return array_keys($this->fields);
     }
@@ -140,7 +140,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierFieldNames()
+    public function getIdentifierFieldNames(): array
     {
         return $this->getIdentifier();
     }
@@ -148,7 +148,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationNames()
+    public function getAssociationNames(): array
     {
         return array_keys($this->associations);
     }
@@ -156,7 +156,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getTypeOfField($fieldName)
+    public function getTypeOfField(string $fieldName): string
     {
         return 'string';
     }
@@ -164,7 +164,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationTargetClass($assocName)
+    public function getAssociationTargetClass(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -172,7 +172,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide(string $assocName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -180,7 +180,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -188,7 +188,7 @@ class LazyLoadableObjectClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierValues($object)
+    public function getIdentifierValues(object $object): array
     {
         throw new \BadMethodCallException('not implemented');
     }

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
@@ -54,7 +54,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getReflectionClass()->getName();
     }
@@ -62,7 +62,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return array_keys($this->identifier);
     }
@@ -70,7 +70,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         if (null === $this->reflectionClass) {
             $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithNullableTypehints');
@@ -82,7 +82,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function isIdentifier($fieldName)
+    public function isIdentifier(string $fieldName): bool
     {
         return isset($this->identifier[$fieldName]);
     }
@@ -90,7 +90,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function hasField($fieldName)
+    public function hasField(string $fieldName): bool
     {
         return isset($this->fields[$fieldName]);
     }
@@ -98,7 +98,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function hasAssociation($fieldName)
+    public function hasAssociation(string $fieldName): bool
     {
         return false;
     }
@@ -106,7 +106,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function isSingleValuedAssociation($fieldName)
+    public function isSingleValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -114,7 +114,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function isCollectionValuedAssociation($fieldName)
+    public function isCollectionValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -122,7 +122,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return array_keys($this->fields);
     }
@@ -130,7 +130,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierFieldNames()
+    public function getIdentifierFieldNames(): array
     {
         return $this->getIdentifier();
     }
@@ -138,7 +138,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getAssociationNames()
+    public function getAssociationNames(): array
     {
         return [];
     }
@@ -146,7 +146,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getTypeOfField($fieldName)
+    public function getTypeOfField(string $fieldName): string
     {
         return 'string';
     }
@@ -154,7 +154,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getAssociationTargetClass($assocName)
+    public function getAssociationTargetClass(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -162,7 +162,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide(string $assocName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -170,7 +170,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -178,7 +178,7 @@ class LazyLoadableObjectWithNullableTypehintsClassMetadata implements ClassMetad
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierValues($object)
+    public function getIdentifierValues(object $object): array
     {
         throw new \BadMethodCallException('not implemented');
     }

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
@@ -64,7 +64,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getReflectionClass()->getName();
     }
@@ -72,7 +72,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return array_keys($this->identifier);
     }
@@ -80,7 +80,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         if (null === $this->reflectionClass) {
             $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithTypehints');
@@ -92,7 +92,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isIdentifier($fieldName)
+    public function isIdentifier(string $fieldName): bool
     {
         return isset($this->identifier[$fieldName]);
     }
@@ -100,7 +100,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasField($fieldName)
+    public function hasField(string $fieldName): bool
     {
         return isset($this->fields[$fieldName]);
     }
@@ -108,7 +108,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasAssociation($fieldName)
+    public function hasAssociation(string $fieldName): bool
     {
         return false;
     }
@@ -116,7 +116,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isSingleValuedAssociation($fieldName)
+    public function isSingleValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -124,7 +124,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isCollectionValuedAssociation($fieldName)
+    public function isCollectionValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -132,7 +132,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return array_keys($this->fields);
     }
@@ -140,7 +140,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierFieldNames()
+    public function getIdentifierFieldNames(): array
     {
         return $this->getIdentifier();
     }
@@ -148,7 +148,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationNames()
+    public function getAssociationNames(): array
     {
         return [];
     }
@@ -156,7 +156,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getTypeOfField($fieldName)
+    public function getTypeOfField(string $fieldName): string
     {
         return 'string';
     }
@@ -164,7 +164,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationTargetClass($assocName)
+    public function getAssociationTargetClass(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -172,7 +172,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide(string $assocName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -180,7 +180,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -188,7 +188,7 @@ class LazyLoadableObjectWithTypehintsClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierValues($object)
+    public function getIdentifierValues(object $object): array
     {
         throw new \BadMethodCallException('not implemented');
     }

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
@@ -37,7 +37,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getReflectionClass()->getName();
     }
@@ -45,7 +45,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): array
     {
         return [];
     }
@@ -53,7 +53,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getReflectionClass()
+    public function getReflectionClass(): \ReflectionClass
     {
         if (null === $this->reflectionClass) {
             $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithVoid');
@@ -65,7 +65,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isIdentifier($fieldName)
+    public function isIdentifier(string $fieldName): bool
     {
         return false;
     }
@@ -73,7 +73,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasField($fieldName)
+    public function hasField(string $fieldName): bool
     {
         return false;
     }
@@ -81,7 +81,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function hasAssociation($fieldName)
+    public function hasAssociation(string $fieldName): bool
     {
         return false;
     }
@@ -89,7 +89,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isSingleValuedAssociation($fieldName)
+    public function isSingleValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -97,7 +97,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isCollectionValuedAssociation($fieldName)
+    public function isCollectionValuedAssociation(string $fieldName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -105,7 +105,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return [];
     }
@@ -113,7 +113,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierFieldNames()
+    public function getIdentifierFieldNames(): array
     {
         return $this->getIdentifier();
     }
@@ -121,7 +121,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationNames()
+    public function getAssociationNames(): array
     {
         return [];
     }
@@ -129,7 +129,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getTypeOfField($fieldName)
+    public function getTypeOfField(string $fieldName): string
     {
         return 'integer';
     }
@@ -137,7 +137,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationTargetClass($assocName)
+    public function getAssociationTargetClass(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -145,7 +145,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function isAssociationInverseSide($assocName)
+    public function isAssociationInverseSide(string $assocName): bool
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -153,7 +153,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getAssociationMappedByTargetField($assocName)
+    public function getAssociationMappedByTargetField(string $assocName): string
     {
         throw new \BadMethodCallException('not implemented');
     }
@@ -161,7 +161,7 @@ class LazyLoadableObjectWithVoidClassMetadata implements ClassMetadata
     /**
      * {@inheritDoc}
      */
-    public function getIdentifierValues($object)
+    public function getIdentifierValues(object $object): array
     {
         throw new \BadMethodCallException('not implemented');
     }

--- a/tests/Doctrine/Tests/Common/Reflection/DeeperNamespaceParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/DeeperNamespaceParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 class DeeperNamespaceParent extends Dummies\NoParent

--- a/tests/Doctrine/Tests/Common/Reflection/Dummies/NoParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/Dummies/NoParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection\Dummies;
 
 class NoParent

--- a/tests/Doctrine/Tests/Common/Reflection/ExampleAnnotationClass.php
+++ b/tests/Doctrine/Tests/Common/Reflection/ExampleAnnotationClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 use Doctrine\Common\Annotations\Annotation;

--- a/tests/Doctrine/Tests/Common/Reflection/FullyClassifiedParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/FullyClassifiedParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 class FullyClassifiedParent extends \Doctrine\Tests\Common\Reflection\NoParent

--- a/tests/Doctrine/Tests/Common/Reflection/NoParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/NoParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 class NoParent

--- a/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 use PHPUnit_Framework_TestCase;

--- a/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/RuntimePublicReflectionPropertyTest.php
@@ -10,7 +10,7 @@ use Doctrine\Common\Proxy\Proxy;
 
 class RuntimePublicReflectionPropertyTest extends PHPUnit_Framework_TestCase
 {
-    public function testGetValueOnProxyPublicProperty()
+    public function testGetValueOnProxyPublicProperty(): void
     {
         $getCheckMock = $this->getMockBuilder('stdClass')->setMethods(['callGet'])->getMock();
         $getCheckMock->expects($this->never())->method('callGet');
@@ -31,7 +31,7 @@ class RuntimePublicReflectionPropertyTest extends PHPUnit_Framework_TestCase
         $this->assertNull($reflProperty->getValue($mockProxy));
     }
 
-    public function testSetValueOnProxyPublicProperty()
+    public function testSetValueOnProxyPublicProperty(): void
     {
         $setCheckMock = $this->getMockBuilder('stdClass')->setMethods(['neverCallSet'])->getMock();
         $setCheckMock->expects($this->never())->method('neverCallSet');

--- a/tests/Doctrine/Tests/Common/Reflection/SameNamespaceParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/SameNamespaceParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 class SameNamespaceParent extends NoParent

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -22,7 +22,7 @@ class StaticReflectionParserTest extends DoctrineTestCase
      *
      * @return void
      */
-    public function testParentClass($classAnnotationOptimize, $parsedClassName, $expectedClassName)
+    public function testParentClass(bool $classAnnotationOptimize, string $parsedClassName, string $expectedClassName): void
     {
         // If classed annotation optimization is enabled the properties tested
         // below cannot be found.
@@ -43,7 +43,7 @@ class StaticReflectionParserTest extends DoctrineTestCase
     /**
      * @return array
      */
-    public function parentClassData()
+    public function parentClassData(): array
     {
         $data = [];
         $noParentClassName = NoParent::class;
@@ -71,7 +71,8 @@ class StaticReflectionParserTest extends DoctrineTestCase
     /**
      * @dataProvider classAnnotationOptimize
      */
-    public function testClassAnnotationOptimizedParsing($classAnnotationOptimize) {
+    public function testClassAnnotationOptimizedParsing(bool $classAnnotationOptimize): void
+    {
         $testsRoot = substr(__DIR__, 0, -strlen(__NAMESPACE__) - 1);
         $paths = [
           'Doctrine\\Tests' => [$testsRoot],

--- a/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
+++ b/tests/Doctrine/Tests/Common/Reflection/StaticReflectionParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 use Doctrine\Tests\Common\Reflection\NoParent;

--- a/tests/Doctrine/Tests/Common/Reflection/UseParent.php
+++ b/tests/Doctrine/Tests/Common/Reflection/UseParent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Reflection;
 
 use Doctrine\Tests\Common\Reflection\Dummies\NoParent as Test;

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Util
 {
     use Doctrine\Tests\DoctrineTestCase;

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -9,7 +9,7 @@ namespace Doctrine\Tests\Common\Util
 
     class ClassUtilsTest extends DoctrineTestCase
     {
-        static public function dataGetClass()
+        static public function dataGetClass(): array
         {
             return [
                 [\stdClass::class, \stdClass::class],
@@ -23,7 +23,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testGetRealClass($className, $expectedClassName)
+        public function testGetRealClass(string $className, string $expectedClassName): void
         {
             $this->assertEquals($expectedClassName, ClassUtils::getRealClass($className));
         }
@@ -31,19 +31,19 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testGetClass( $className, $expectedClassName )
+        public function testGetClass(string $className, string $expectedClassName): void
         {
             $object = new $className();
             $this->assertEquals($expectedClassName, ClassUtils::getClass($object));
         }
 
-        public function testGetParentClass()
+        public function testGetParentClass(): void
         {
             $parentClass = ClassUtils::getParentClass( 'MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject' );
             $this->assertEquals('stdClass', $parentClass);
         }
 
-        public function testGenerateProxyClassName()
+        public function testGenerateProxyClassName(): void
         {
             $this->assertEquals( 'Proxies\__CG__\stdClass', ClassUtils::generateProxyClassName( 'stdClass', 'Proxies' ) );
         }
@@ -51,7 +51,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testNewReflectionClass( $className, $expectedClassName )
+        public function testNewReflectionClass(string $className, string $expectedClassName): void
         {
             $reflClass = ClassUtils::newReflectionClass( $className );
             $this->assertEquals( $expectedClassName, $reflClass->getName() );
@@ -60,7 +60,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testNewReflectionObject( $className, $expectedClassName )
+        public function testNewReflectionObject(string $className, string $expectedClassName): void
         {
             $object = new $className;
             $reflClass = ClassUtils::newReflectionObject( $object );

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Util\Debug;
 
 class DebugTest extends DoctrineTestCase
 {
-    public function testExportObject( )
+    public function testExportObject(): void
     {
         $obj = new \stdClass;
         $obj->foo = "bar";
@@ -19,7 +19,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals( "stdClass", $var->__CLASS__ );
     }
 
-    public function testExportObjectWithReference()
+    public function testExportObjectWithReference(): void
     {
         $foo = 'bar';
         $bar = ['foo' => & $foo];
@@ -32,7 +32,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals('tab', $bar['foo']);
     }
 
-    public function testExportArray()
+    public function testExportArray(): void
     {
         $array = ['a' => 'b', 'b' => ['c', 'd' => ['e', 'f']]];
         $var = Debug::export($array, 2);
@@ -41,7 +41,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals($expected, $var);
     }
 
-    public function testExportDateTime()
+    public function testExportDateTime(): void
     {
         $obj = new \DateTime('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
@@ -50,7 +50,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date);
     }
 
-    public function testExportDateTimeImmutable()
+    public function testExportDateTimeImmutable(): void
     {
         $obj = new \DateTimeImmutable('2010-10-10 10:10:10', new \DateTimeZone('UTC'));
 
@@ -59,7 +59,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals('2010-10-10T10:10:10+00:00', $var->date);
     }
 
-    public function testExportDateTimeZone()
+    public function testExportDateTimeZone(): void
     {
         $obj = new \DateTimeImmutable('2010-10-10 12:34:56', new \DateTimeZone('Europe/Rome'));
 
@@ -68,7 +68,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertEquals('2010-10-10T12:34:56+02:00', $var->date);
     }
 
-    public function testExportArrayTraversable()
+    public function testExportArrayTraversable(): void
     {
         $obj = new \ArrayObject(['foobar']);
 
@@ -81,7 +81,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertContains('foobar', $var->__STORAGE__);
     }
 
-    public function testReturnsOutput()
+    public function testReturnsOutput(): void
     {
         ob_start();
 
@@ -93,7 +93,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertSame($outputValue, $dump);
     }
 
-    public function testDisablesOutput()
+    public function testDisablesOutput(): void
     {
         ob_start();
 
@@ -109,7 +109,7 @@ class DebugTest extends DoctrineTestCase
     /**
      * @dataProvider provideAttributesCases
      */
-    public function testExportParentAttributes(TestAsset\ParentClass $class, array $expected)
+    public function testExportParentAttributes(TestAsset\ParentClass $class, array $expected): void
     {
         $print_r_class = print_r($class, true);
         $print_r_expected = print_r($expected, true);
@@ -126,7 +126,7 @@ class DebugTest extends DoctrineTestCase
         $this->assertSame($expected, $var);
     }
 
-    public function provideAttributesCases()
+    public function provideAttributesCases(): array
     {
         return array(
             'different-attributes' => array(

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Util;
 
 use Doctrine\Tests\DoctrineTestCase;

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ChildClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ChildClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Util\TestAsset;
 
 final class ChildClass extends ParentClass

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ChildWithSameAttributesClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ChildWithSameAttributesClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Util\TestAsset;
 
 final class ChildWithSameAttributesClass extends ParentClass

--- a/tests/Doctrine/Tests/Common/Util/TestAsset/ParentClass.php
+++ b/tests/Doctrine/Tests/Common/Util/TestAsset/ParentClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\Util\TestAsset;
 
 abstract class ParentClass

--- a/tests/Doctrine/Tests/DoctrineTestCase.php
+++ b/tests/Doctrine/Tests/DoctrineTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 /**

--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -2,6 +2,8 @@
 /*
  * This file bootstraps the test environment.
  */
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 error_reporting(E_ALL | E_STRICT);


### PR DESCRIPTION
* Migrated Doctrine\Common to PHP 7.2 - initial step for https://github.com/doctrine/doctrine2/issues/6529
* Added parameter types
* Added return types
* Enabled strict types

Requires at least PHP 7.2.0alpha3 (due to `object` type being used).

Excluded from migration:
- ClassLoader - deprecated, to be removed in 3.0
- Proxy - to be phased out for 3.0

Possible TODOs:
* [x] also add types for tests
* [ ] deprecate some mixed/union parameters in API
* [ ] document API changes
* [x] Fix PHPStan - blocked by https://github.com/phpstan/phpstan/issues/367

Tests are green. 💚
Travis is failing because it doesn't provide PHP 7.2 version yet - tracked in https://github.com/travis-ci/travis-ci/issues/7989.

```
$ php7.2-local vendor/bin/phpunit -v
PHPUnit 5.7.21 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.0alpha3
Configuration: /www/doctrine/common/phpunit.xml.dist

...............................................................  63 / 246 ( 25%)
............................................................... 126 / 246 ( 51%)
............................................................... 189 / 246 ( 76%)
.........................................................       246 / 246 (100%)

Time: 129 ms, Memory: 8.00MB
```

Currently targets master, but should definitely go into develop branch (which doesn't exist yet - create one so we can retarget the PR 😎 ).

cc @Ocramius @lcobucci 