### PR TITLE
[WIP] Add coding standard checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,14 @@ matrix:
   include:
     - php: 7.1
       env: PHPSTAN=1
+           CODING_STANDARD=1
 
 before_script:
   - composer --prefer-source install
   - if [[ $PHPSTAN = 1 ]]; then composer require --dev phpstan/phpstan:^0.7; fi
+  - if [[ $CODING_STANDARD = 1 ]]; then composer require --dev symplify/easy-coding-standard:^2.2; fi
 
 script:
   - ./vendor/bin/phpunit
   - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -c phpstan.neon -l 3 lib tests; fi
+  - if [[ $CODING_STANDARD = 1 ]]; then vendor/bin/ecs check lib; fi

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -1,0 +1,10 @@
+# this will be placed in doctrine/coding-stanard, easy-accessible for anyone
+includes:
+    # PSR-2 rules: https://github.com/doctrine/coding-standard/blob/fe7696ba040327075c7bf1693c5d88bd64995090/ruleset.xml#L6
+    - vendor/symplify/easy-coding-standard/config/psr2-checkers.neon
+
+checkers:
+    # can be used instead of
+    # https://github.com/doctrine/coding-standard/blob/master/Sniffs/Strings/ConcatenationSpacingSniff.php
+    PhpCsFixer\Fixer\Operator\ConcatSpaceFixer:
+        spacing: one

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -183,7 +183,7 @@ class ClassLoader
             return false;
         }
 
-        require ($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
+        require($this->includePath !== null ? $this->includePath . DIRECTORY_SEPARATOR : '')
                . str_replace($this->namespaceSeparator, DIRECTORY_SEPARATOR, $className)
                . $this->fileExtension;
 
@@ -200,7 +200,7 @@ class ClassLoader
      */
     public function canLoadClass($className)
     {
-        if ($this->namespace !== null && strpos($className, $this->namespace.$this->namespaceSeparator) !== 0) {
+        if ($this->namespace !== null && strpos($className, $this->namespace . $this->namespaceSeparator) !== 0) {
             return false;
         }
 
@@ -250,7 +250,7 @@ class ClassLoader
      */
     public static function getClassLoader($className)
     {
-         foreach (spl_autoload_functions() as $loader) {
+        foreach (spl_autoload_functions() as $loader) {
             if (is_array($loader)
                 && ($classLoader = reset($loader))
                 && $classLoader instanceof ClassLoader

--- a/lib/Doctrine/Common/EventArgs.php
+++ b/lib/Doctrine/Common/EventArgs.php
@@ -58,7 +58,7 @@ class EventArgs
      */
     public static function getEmptyInstance()
     {
-        if ( ! self::$_emptyEventArgsInstance) {
+        if (! self::$_emptyEventArgsInstance) {
             self::$_emptyEventArgsInstance = new EventArgs;
         }
 

--- a/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/Common/Persistence/Event/PreUpdateEventArgs.php
@@ -126,7 +126,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      */
     private function assertValidField($field)
     {
-        if ( ! isset($this->entityChangeSet[$field])) {
+        if (! isset($this->entityChangeSet[$field])) {
             throw new \InvalidArgumentException(sprintf(
                 'Field "%s" is not a valid field of the entity "%s" in PreUpdateEventArgs.',
                 $field,

--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -105,7 +105,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function getAllMetadata()
     {
-        if ( ! $this->initialized) {
+        if (! $this->initialized) {
             $this->initialize();
         }
 
@@ -280,7 +280,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
         // Collect parent classes, ignoring transient (not-mapped) classes.
         $parentClasses = [];
         foreach (array_reverse($this->getReflectionService()->getParentClasses($name)) as $parentClass) {
-            if ( ! $this->getDriver()->isTransient($parentClass)) {
+            if (! $this->getDriver()->isTransient($parentClass)) {
                 $parentClasses[] = $parentClass;
             }
         }
@@ -303,7 +303,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     protected function loadMetadata($name)
     {
-        if ( ! $this->initialized) {
+        if (! $this->initialized) {
             $this->initialize();
         }
 
@@ -390,7 +390,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public function isTransient($class)
     {
-        if ( ! $this->initialized) {
+        if (! $this->initialized) {
             $this->initialize();
         }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php
@@ -204,7 +204,7 @@ abstract class AnnotationDriver implements MappingDriver
         $includedFiles = [];
 
         foreach ($this->paths as $path) {
-            if ( ! is_dir($path)) {
+            if (! is_dir($path)) {
                 throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
             }
 
@@ -220,7 +220,7 @@ abstract class AnnotationDriver implements MappingDriver
             foreach ($iterator as $file) {
                 $sourceFile = $file[0];
 
-                if ( ! preg_match('(^phar:)i', $sourceFile)) {
+                if (! preg_match('(^phar:)i', $sourceFile)) {
                     $sourceFile = realpath($sourceFile);
                 }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/DefaultFileLocator.php
@@ -129,7 +129,7 @@ class DefaultFileLocator implements FileLocator
 
         if ($this->paths) {
             foreach ($this->paths as $path) {
-                if ( ! is_dir($path)) {
+                if (! is_dir($path)) {
                     throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
                 }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/FileDriver.php
@@ -183,7 +183,7 @@ abstract class FileDriver implements MappingDriver
         $this->classCache = [];
         if (null !== $this->globalBasename) {
             foreach ($this->locator->getPaths() as $path) {
-                $file = $path.'/'.$this->globalBasename.$this->locator->getFileExtension();
+                $file = $path . '/' . $this->globalBasename . $this->locator->getFileExtension();
                 if (is_file($file)) {
                     $this->classCache = array_merge(
                         $this->classCache,

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/MappingDriverChain.php
@@ -121,14 +121,14 @@ class MappingDriverChain implements MappingDriver
         $driverClasses = [];
 
         /* @var $driver MappingDriver */
-        foreach ($this->drivers AS $namespace => $driver) {
+        foreach ($this->drivers as $namespace => $driver) {
             $oid = spl_object_hash($driver);
 
             if (!isset($driverClasses[$oid])) {
                 $driverClasses[$oid] = $driver->getAllClassNames();
             }
 
-            foreach ($driverClasses[$oid] AS $className) {
+            foreach ($driverClasses[$oid] as $className) {
                 if (strpos($className, $namespace) === 0) {
                     $classNames[$className] = true;
                 }
@@ -150,7 +150,7 @@ class MappingDriverChain implements MappingDriver
     public function isTransient($className)
     {
         /* @var $driver MappingDriver */
-        foreach ($this->drivers AS $namespace => $driver) {
+        foreach ($this->drivers as $namespace => $driver) {
             if (strpos($className, $namespace) === 0) {
                 return $driver->isTransient($className);
             }

--- a/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/Driver/SymfonyFileLocator.php
@@ -135,11 +135,11 @@ class SymfonyFileLocator implements FileLocator
      */
     public function fileExists($className)
     {
-        $defaultFileName = str_replace('\\', $this->nsSeparator, $className).$this->fileExtension;
+        $defaultFileName = str_replace('\\', $this->nsSeparator, $className) . $this->fileExtension;
         foreach ($this->paths as $path) {
             if (!isset($this->prefixes[$path])) {
                 // global namespace class
-                if (is_file($path.DIRECTORY_SEPARATOR.$defaultFileName)) {
+                if (is_file($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
                     return true;
                 }
 
@@ -148,11 +148,11 @@ class SymfonyFileLocator implements FileLocator
 
             $prefix = $this->prefixes[$path];
 
-            if (0 !== strpos($className, $prefix.'\\')) {
+            if (0 !== strpos($className, $prefix . '\\')) {
                 continue;
             }
 
-            $filename = $path.'/'.strtr(substr($className, strlen($prefix)+1), '\\', $this->nsSeparator).$this->fileExtension;
+            $filename = $path . '/' . strtr(substr($className, strlen($prefix)+1), '\\', $this->nsSeparator) . $this->fileExtension;
             if (is_file($filename)) {
                 return true;
             }
@@ -196,7 +196,7 @@ class SymfonyFileLocator implements FileLocator
                             '\\'
                         );
 
-                        $classes[] = $this->prefixes[$path] . str_replace(DIRECTORY_SEPARATOR, '\\', $nsSuffix) . '\\' .str_replace($this->nsSeparator, '\\', $fileName);
+                        $classes[] = $this->prefixes[$path] . str_replace(DIRECTORY_SEPARATOR, '\\', $nsSuffix) . '\\' . str_replace($this->nsSeparator, '\\', $fileName);
                     } else {
                         $classes[] = str_replace($this->nsSeparator, '\\', $fileName);
                     }
@@ -212,11 +212,11 @@ class SymfonyFileLocator implements FileLocator
      */
     public function findMappingFile($className)
     {
-        $defaultFileName = str_replace('\\', $this->nsSeparator, $className).$this->fileExtension;
+        $defaultFileName = str_replace('\\', $this->nsSeparator, $className) . $this->fileExtension;
         foreach ($this->paths as $path) {
             if (!isset($this->prefixes[$path])) {
-                if (is_file($path.DIRECTORY_SEPARATOR.$defaultFileName)) {
-                    return $path.DIRECTORY_SEPARATOR.$defaultFileName;
+                if (is_file($path . DIRECTORY_SEPARATOR . $defaultFileName)) {
+                    return $path . DIRECTORY_SEPARATOR . $defaultFileName;
                 }
 
                 continue;
@@ -224,16 +224,16 @@ class SymfonyFileLocator implements FileLocator
 
             $prefix = $this->prefixes[$path];
 
-            if (0 !== strpos($className, $prefix.'\\')) {
+            if (0 !== strpos($className, $prefix . '\\')) {
                 continue;
             }
 
-            $filename = $path.'/'.strtr(substr($className, strlen($prefix)+1), '\\', $this->nsSeparator ).$this->fileExtension;
+            $filename = $path . '/' . strtr(substr($className, strlen($prefix)+1), '\\', $this->nsSeparator) . $this->fileExtension;
             if (is_file($filename)) {
                 return $filename;
             }
         }
 
-        throw MappingException::mappingFileNotFound($className, substr($className, strrpos($className, '\\') + 1).$this->fileExtension);
+        throw MappingException::mappingFileNotFound($className, substr($className, strrpos($className, '\\') + 1) . $this->fileExtension);
     }
 }

--- a/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/MappingException.php
@@ -34,7 +34,7 @@ class MappingException extends \Exception
      */
     public static function classNotFoundInNamespaces($className, $namespaces)
     {
-        return new self("The class '" . $className . "' was not found in the ".
+        return new self("The class '" . $className . "' was not found in the " .
             "chain configured namespaces " . implode(", ", $namespaces));
     }
 
@@ -43,7 +43,7 @@ class MappingException extends \Exception
      */
     public static function pathRequired()
     {
-        return new self("Specifying the paths to your entities is required ".
+        return new self("Specifying the paths to your entities is required " .
             "in the AnnotationDriver to retrieve all class names.");
     }
 
@@ -54,7 +54,7 @@ class MappingException extends \Exception
      */
     public static function fileMappingDriversRequireConfiguredDirectoryPath($path = null)
     {
-        if ( ! empty($path)) {
+        if (! empty($path)) {
             $path = '[' . $path . ']';
         }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php
@@ -37,7 +37,7 @@ class RuntimeReflectionService implements ReflectionService
      */
     public function getParentClasses($class)
     {
-        if ( ! class_exists($class)) {
+        if (! class_exists($class)) {
             throw MappingException::nonExistingClass($class);
         }
 

--- a/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/StaticReflectionService.php
@@ -52,7 +52,7 @@ class StaticReflectionService implements ReflectionService
     {
         $namespace = '';
         if (strpos($className, '\\') !== false) {
-            $namespace = strrev(substr( strrev($className), strpos(strrev($className), '\\')+1 ));
+            $namespace = strrev(substr(strrev($className), strpos(strrev($className), '\\')+1));
         }
         return $namespace;
     }

--- a/lib/Doctrine/Common/Persistence/PersistentObject.php
+++ b/lib/Doctrine/Common/Persistence/PersistentObject.php
@@ -73,7 +73,7 @@ abstract class PersistentObject implements ObjectManagerAware
      *
      * @return void
      */
-    static public function setObjectManager(ObjectManager $objectManager = null)
+    public static function setObjectManager(ObjectManager $objectManager = null)
     {
         self::$objectManager = $objectManager;
     }
@@ -81,7 +81,7 @@ abstract class PersistentObject implements ObjectManagerAware
     /**
      * @return ObjectManager|null
      */
-    static public function getObjectManager()
+    public static function getObjectManager()
     {
         return self::$objectManager;
     }
@@ -121,15 +121,15 @@ abstract class PersistentObject implements ObjectManagerAware
     {
         if ($this->cm->hasField($field) && !$this->cm->isIdentifier($field)) {
             $this->$field = $args[0];
-        } else if ($this->cm->hasAssociation($field) && $this->cm->isSingleValuedAssociation($field)) {
+        } elseif ($this->cm->hasAssociation($field) && $this->cm->isSingleValuedAssociation($field)) {
             $targetClass = $this->cm->getAssociationTargetClass($field);
             if (!($args[0] instanceof $targetClass) && $args[0] !== null) {
-                throw new \InvalidArgumentException("Expected persistent object of type '".$targetClass."'");
+                throw new \InvalidArgumentException("Expected persistent object of type '" . $targetClass . "'");
             }
             $this->$field = $args[0];
             $this->completeOwningSide($field, $targetClass, $args[0]);
         } else {
-            throw new \BadMethodCallException("no field with name '".$field."' exists on '".$this->cm->getName()."'");
+            throw new \BadMethodCallException("no field with name '" . $field . "' exists on '" . $this->cm->getName() . "'");
         }
     }
 
@@ -144,11 +144,11 @@ abstract class PersistentObject implements ObjectManagerAware
      */
     private function get($field)
     {
-        if ( $this->cm->hasField($field) || $this->cm->hasAssociation($field) ) {
+        if ($this->cm->hasField($field) || $this->cm->hasAssociation($field)) {
             return $this->$field;
         }
 
-        throw new \BadMethodCallException("no field with name '".$field."' exists on '".$this->cm->getName()."'");
+        throw new \BadMethodCallException("no field with name '" . $field . "' exists on '" . $this->cm->getName() . "'");
     }
 
     /**
@@ -168,7 +168,7 @@ abstract class PersistentObject implements ObjectManagerAware
             $mappedByField = $this->cm->getAssociationMappedByTargetField($field);
             $targetMetadata = self::$objectManager->getClassMetadata($targetClass);
 
-            $setter = ($targetMetadata->isCollectionValuedAssociation($mappedByField) ? "add" : "set").$mappedByField;
+            $setter = ($targetMetadata->isCollectionValuedAssociation($mappedByField) ? "add" : "set") . $mappedByField;
             $targetObject->$setter($this);
         }
     }
@@ -189,7 +189,7 @@ abstract class PersistentObject implements ObjectManagerAware
         if ($this->cm->hasAssociation($field) && $this->cm->isCollectionValuedAssociation($field)) {
             $targetClass = $this->cm->getAssociationTargetClass($field);
             if (!($args[0] instanceof $targetClass)) {
-                throw new \InvalidArgumentException("Expected persistent object of type '".$targetClass."'");
+                throw new \InvalidArgumentException("Expected persistent object of type '" . $targetClass . "'");
             }
             if (!($this->$field instanceof Collection)) {
                 $this->$field = new ArrayCollection($this->$field ?: []);
@@ -197,7 +197,7 @@ abstract class PersistentObject implements ObjectManagerAware
             $this->$field->add($args[0]);
             $this->completeOwningSide($field, $targetClass, $args[0]);
         } else {
-            throw new \BadMethodCallException("There is no method add".$field."() on ".$this->cm->getName());
+            throw new \BadMethodCallException("There is no method add" . $field . "() on " . $this->cm->getName());
         }
     }
 
@@ -239,12 +239,12 @@ abstract class PersistentObject implements ObjectManagerAware
         $field = lcfirst(substr($method, 3));
         if ($command == "set") {
             $this->set($field, $args);
-        } else if ($command == "get") {
+        } elseif ($command == "get") {
             return $this->get($field);
-        } else if ($command == "add") {
+        } elseif ($command == "add") {
             $this->add($field, $args);
         } else {
-            throw new \BadMethodCallException("There is no method ".$method." on ".$this->cm->getName());
+            throw new \BadMethodCallException("There is no method " . $method . " on " . $this->cm->getName());
         }
     }
 }

--- a/lib/Doctrine/Common/PropertyChangedListener.php
+++ b/lib/Doctrine/Common/PropertyChangedListener.php
@@ -41,5 +41,5 @@ interface PropertyChangedListener
      *
      * @return void
      */
-    function propertyChanged($sender, $propertyName, $oldValue, $newValue);
+    public function propertyChanged($sender, $propertyName, $oldValue, $newValue);
 }

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -201,7 +201,7 @@ abstract class AbstractProxyFactory
         $this->definitions[$className] = $this->createProxyDefinition($className);
         $proxyClassName                = $this->definitions[$className]->proxyClassName;
 
-        if ( ! class_exists($proxyClassName, false)) {
+        if (! class_exists($proxyClassName, false)) {
             $fileName  = $this->proxyGenerator->getProxyFileName($className);
 
             switch ($this->autoGenerate) {
@@ -210,7 +210,7 @@ abstract class AbstractProxyFactory
                     break;
 
                 case self::AUTOGENERATE_FILE_NOT_EXISTS:
-                    if ( ! file_exists($fileName)) {
+                    if (! file_exists($fileName)) {
                         $this->proxyGenerator->generateProxyClass($classMetadata, $fileName);
                     }
                     require $fileName;

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -73,7 +73,7 @@ class Autoloader
     {
         $proxyNamespace = ltrim($proxyNamespace, '\\');
 
-        if ( ! (null === $notFoundCallback || is_callable($notFoundCallback))) {
+        if (! (null === $notFoundCallback || is_callable($notFoundCallback))) {
             throw InvalidArgumentException::invalidClassNotFoundCallback($notFoundCallback);
         }
 

--- a/lib/Doctrine/Common/Proxy/ProxyDefinition.php
+++ b/lib/Doctrine/Common/Proxy/ProxyDefinition.php
@@ -67,4 +67,3 @@ class ProxyDefinition
         $this->cloner           = $cloner;
     }
 }
-

--- a/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
+++ b/lib/Doctrine/Common/Reflection/RuntimePublicReflectionProperty.php
@@ -62,7 +62,7 @@ class RuntimePublicReflectionProperty extends ReflectionProperty
      */
     public function setValue($object, $value = null)
     {
-        if ( ! ($object instanceof Proxy && ! $object->__isInitialized())) {
+        if (! ($object instanceof Proxy && ! $object->__isInitialized())) {
             parent::setValue($object, $value);
 
             return;

--- a/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
+++ b/lib/Doctrine/Common/Reflection/StaticReflectionParser.php
@@ -175,6 +175,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
                         continue 2;
                     }
                     // No break.
+                    // no break
                 case T_FUNCTION:
                     // The next string after function is the name, but
                     // there can be & before the function name so find the
@@ -202,7 +203,7 @@ class StaticReflectionParser implements ReflectionProviderInterface
                             if ($alias == $prefix) {
                                 $this->parentClassName = '\\' . $use . $postfix;
                                 $fullySpecified = true;
-                          }
+                            }
                         }
                     }
                     if (!$fullySpecified) {

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -39,7 +39,7 @@ class ClassUtils
      */
     public static function getRealClass($class)
     {
-        if (false === $pos = strrpos($class, '\\'.Proxy::MARKER.'\\')) {
+        if (false === $pos = strrpos($class, '\\' . Proxy::MARKER . '\\')) {
             return $class;
         }
 
@@ -67,7 +67,7 @@ class ClassUtils
      */
     public static function getParentClass($className)
     {
-        return get_parent_class( self::getRealClass( $className ) );
+        return get_parent_class(self::getRealClass($className));
     }
 
     /**
@@ -79,7 +79,7 @@ class ClassUtils
      */
     public static function newReflectionClass($class)
     {
-        return new \ReflectionClass( self::getRealClass( $class ) );
+        return new \ReflectionClass(self::getRealClass($class));
     }
 
     /**
@@ -91,7 +91,7 @@ class ClassUtils
      */
     public static function newReflectionObject($object)
     {
-        return self::newReflectionClass( self::getClass( $object ) );
+        return self::newReflectionClass(self::getClass($object));
     }
 
     /**
@@ -104,6 +104,6 @@ class ClassUtils
      */
     public static function generateProxyClassName($className, $proxyNamespace)
     {
-        return rtrim($proxyNamespace, '\\') . '\\'.Proxy::MARKER.'\\' . ltrim($className, '\\');
+        return rtrim($proxyNamespace, '\\') . '\\' . Proxy::MARKER . '\\' . ltrim($className, '\\');
     }
 }

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -163,7 +163,6 @@ final class Debug
                 $name.= ':' . ($aux[1] === '*' ? 'protected' : $aux[1] . ':private');
             }
             $return->$name = self::export($clone[$key], $maxDepth - 1);
-            ;
         }
 
         return $return;

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -160,9 +160,10 @@ final class Debug
             $aux = explode("\0", $key);
             $name = end($aux);
             if ($aux[0] === '') {
-                $name.= ':' . ($aux[1] === '*' ? 'protected' : $aux[1].':private');
+                $name.= ':' . ($aux[1] === '*' ? 'protected' : $aux[1] . ':private');
             }
-            $return->$name = self::export($clone[$key], $maxDepth - 1);;
+            $return->$name = self::export($clone[$key], $maxDepth - 1);
+            ;
         }
 
         return $return;


### PR DESCRIPTION
After bumping [min version to PHP 7.1 in Doctrine Project](http://www.doctrine-project.org/2017/07/25/php-7.1-requirement-and-composer.html) and successful setup of [coding standard for Nette](https://github.com/nette/coding-standard) to all its repositories, I'd like to help setup Doctrine Coding Standard that would help you to maintain code and review PRs.

[Doctrine\CodingStandard](https://github.com/doctrine/coding-standard) seems inactive and not used in projects and I want to change that.

In final version, all it will require for this repository add this line to `travis.yml`:

```yaml
vendor/bin/ecs check libs src --config vendor/doctrine/coding-standard/basic-standard.neon
```

**In this PR we only prepare rules setup and after you agree on them, I will send PR to Doctrine\CodingStandard that would be basically only repository to deal with coding standard changes, like [Nette\CodingStandard](http://github.com/nette/coding-standard).**


What do you think?


### Questions

1. ` ! ` does not comply with default PSR2 checkers from PHP-CS-Fixer and it changes it to `!`. I don't know a checker that would do that now, but it coud be done with custom fixer, yet it requires maintenance overhead that could make lead to ignoring the checker class later when bugs appear - do you really find it important?

2. What extra rules over PSR2 would you like include to?