### PR TITLE
doctrine/cache 1.7.1 does not support php 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~5.6|~7.0",
         "doctrine/inflector": "1.*",
-        "doctrine/cache": "1.*",
+        "doctrine/cache": "1.6.*",
         "doctrine/collections": "1.*",
         "doctrine/lexer": "1.*",
         "doctrine/annotations": "1.*"


### PR DESCRIPTION
soctrine/cache increases the minimum supported PHP version to 7.1.0, This means that it is not possible for doctrine/common to require doctrine/cache 1.*

This must change in 1.6.*