### PR TITLE
Fix AbstractClassMetadataFactory

### DIFF
--- a/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php
@@ -217,8 +217,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
                     foreach ($this->loadMetadata($realClassName) as $loadedClassName) {
                         $this->cacheDriver->save(
                             $loadedClassName . $this->cacheSalt,
-                            $this->loadedMetadata[$loadedClassName],
-                            null
+                            $this->loadedMetadata[$loadedClassName]
                         );
                     }
                 }


### PR DESCRIPTION
The `$lifeTime` parameter of `Cache::save()` [should always be integer](https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/Cache.php#L49), not null.

https://github.com/Kdyby/DoctrineCache/pull/18