### PR TITLE
Provide forward-compat replace for doctrine/{event-manager,persistence,reflection}

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,16 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7"
     },
+    "replace": {
+        "doctrine/event-manager": "1.0.*",
+        "doctrine/persistence": "1.0.*",
+        "doctrine/reflection": "1.0.*"
+    },
+    "conflict": {
+        "doctrine/event-manager": ">=1.1.0@dev",
+        "doctrine/persistence": ">=1.1.0@dev",
+        "doctrine/reflection": ">=1.1.0@dev"
+    },
     "autoload": {
         "psr-4": {
             "Doctrine\\Common\\": "lib/Doctrine/Common"


### PR DESCRIPTION
This should allow us to depend on `doctrine/event-manager` package while still using `doctrine/common` 2.8.x (thus not requiring immediate release of 2.9, which should be done once we solve `doctrine/persistence`).
This is targetting 2.8 only, not applicable in 2.9.x-dev (#842 will be done instead).
Once `doctrine/common` 2.9.0 is out, real dependency kicks in.

@Ocramius Does this make sense as forward compatible polyfill? doctrine/event-manager is identical.