### PR TITLE
doctrine/common deprecations (soft)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "phpunit/phpunit": "^6.3",
         "doctrine/coding-standard": "^1.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "symfony/phpunit-bridge": "^4.0.5"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -1,6 +1,11 @@
 <?php
 namespace Doctrine\Common;
 
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
+@trigger_error(ClassLoader::class . ' is deprecated.', E_USER_DEPRECATED);
+
 /**
  * A <tt>ClassLoader</tt> is an autoloader for class files that can be
  * installed on the SPL autoload stack. It is a class loader that either loads only classes

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -13,7 +13,7 @@ namespace Doctrine\Common;
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
  *
- * @deprecated the ClassLoader is deprecated and will be removed in version 3.0 of doctrine/common.
+ * @deprecated The ClassLoader is deprecated and will be removed in version 3.0 of doctrine/common.
  */
 class ClassLoader
 {

--- a/lib/Doctrine/Common/CommonException.php
+++ b/lib/Doctrine/Common/CommonException.php
@@ -5,6 +5,8 @@ namespace Doctrine\Common;
  * Base exception class for package Doctrine\Common.
  *
  * @author heinrich
+ *
+ * @deprecated The doctrine/common package is deprecated, please use specific packages and their exceptions instead.
  */
 class CommonException extends \Exception
 {

--- a/lib/Doctrine/Common/Lexer.php
+++ b/lib/Doctrine/Common/Lexer.php
@@ -2,6 +2,10 @@
 namespace Doctrine\Common;
 
 use Doctrine\Common\Lexer\AbstractLexer;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
+@trigger_error(Lexer::class . ' is deprecated.', E_USER_DEPRECATED);
 
 /**
  * Base class for writing simple lexers, i.e. for creating small DSLs.

--- a/lib/Doctrine/Common/Lexer.php
+++ b/lib/Doctrine/Common/Lexer.php
@@ -13,6 +13,8 @@ use Doctrine\Common\Lexer\AbstractLexer;
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated Use Doctrine\Common\Lexer\AbstractLexer from doctrine/lexer package instead.
  */
 abstract class Lexer extends AbstractLexer
 {

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -11,6 +11,8 @@ use Doctrine\Common\Util\ClassUtils;
  * Abstract factory for proxy objects.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 abstract class AbstractProxyFactory
 {

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -7,6 +7,10 @@ use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
  * Special Autoloader for Proxy classes, which are not PSR-0 compliant.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @internal
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class Autoloader
 {

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -10,6 +10,8 @@ use InvalidArgumentException as BaseInvalidArgumentException;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class InvalidArgumentException extends BaseInvalidArgumentException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
@@ -8,6 +8,8 @@ use OutOfBoundsException as BaseOutOfBoundsException;
  *
  * @link   www.doctrine-project.org
  * @author Fredrik Wendel <fredrik_w@users.sourceforge.net>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class OutOfBoundsException extends BaseOutOfBoundsException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
@@ -7,6 +7,8 @@ namespace Doctrine\Common\Proxy\Exception;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 interface ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -9,6 +9,8 @@ use UnexpectedValueException as BaseUnexpectedValueException;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class UnexpectedValueException extends BaseUnexpectedValueException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -10,6 +10,8 @@ use Doctrine\Common\Persistence\Proxy as BaseProxy;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Marco Pivetta  <ocramius@gmail.com>
  * @since  2.4
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 interface Proxy extends BaseProxy
 {

--- a/lib/Doctrine/Common/Proxy/ProxyDefinition.php
+++ b/lib/Doctrine/Common/Proxy/ProxyDefinition.php
@@ -5,6 +5,8 @@ namespace Doctrine\Common\Proxy;
  * Definition structure how to create a proxy.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class ProxyDefinition
 {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -12,6 +12,8 @@ use Doctrine\Common\Util\ClassUtils;
  *
  * @author Marco Pivetta <ocramius@gmail.com>
  * @since  2.4
+ *
+ * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class ProxyGenerator
 {

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -9,6 +9,8 @@ use Doctrine\Common\Persistence\Proxy;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Johannes Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated The ClassUtils class is deprecated.
  */
 class ClassUtils
 {

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -13,6 +13,8 @@ use Doctrine\Common\Persistence\Proxy;
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
  * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
+ *
+ * @deprecated The Debug class is deprecated, please use symfony/var-dumper instead.
  */
 final class Debug
 {

--- a/lib/Doctrine/Common/Util/Inflector.php
+++ b/lib/Doctrine/Common/Util/Inflector.php
@@ -7,6 +7,8 @@ use Doctrine\Common\Inflector\Inflector as BaseInflector;
  * Doctrine inflector has static methods for inflecting text.
  *
  * Kept for backwards compatibility reasons, was moved to its own component.
+ *
+ * @deprecated The Inflector class is deprecated, use Doctrine\Common\Inflector\Inflector from doctrine/inflector package instead,
  */
 class Inflector extends BaseInflector
 {

--- a/lib/Doctrine/Common/Util/Inflector.php
+++ b/lib/Doctrine/Common/Util/Inflector.php
@@ -2,6 +2,10 @@
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Inflector\Inflector as BaseInflector;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
+@trigger_error(Inflector::class . ' is deprecated.', E_USER_DEPRECATED);
 
 /**
  * Doctrine inflector has static methods for inflecting text.

--- a/lib/Doctrine/Common/Version.php
+++ b/lib/Doctrine/Common/Version.php
@@ -10,6 +10,8 @@ namespace Doctrine\Common;
  * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Jonathan Wage <jonwage@gmail.com>
  * @author Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated The Version class is deprecated, please refrain from checking the version of doctrine/common.
  */
 class Version
 {

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\Common;
 
 use Doctrine\Common\ClassLoader;
 
+/**
+ * @group legacy
+ */
 class ClassLoaderTest extends \Doctrine\Tests\DoctrineTestCase
 {
     public function testClassLoader()


### PR DESCRIPTION
~_Note: Also includes commits from #844 - review only https://github.com/doctrine/common/pull/845/commits/1860aa60215b2aef3deb136de02d40783a113476 until merged._~

Deprecations for the rest of doctrine/common:
* whole Proxy namespace in favor of ocramius/proxy-manager
* Util\Debug in favor of symfony/var-dumper
* Util\ClassUtils without replacement (mostly an internal helper)
* Util\Inflector in favor of doctrine/inflector
* Lexer in favor of doctrine/lexer