### PR TITLE
Revert adding silent deprecations for legacy ClassLoader, Inflector and Lexer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.3",
         "doctrine/coding-standard": "^1.0",
-        "squizlabs/php_codesniffer": "^3.0",
-        "symfony/phpunit-bridge": "^4.0.5"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -1,11 +1,6 @@
 <?php
 namespace Doctrine\Common;
 
-use function trigger_error;
-use const E_USER_DEPRECATED;
-
-@trigger_error(ClassLoader::class . ' is deprecated.', E_USER_DEPRECATED);
-
 /**
  * A <tt>ClassLoader</tt> is an autoloader for class files that can be
  * installed on the SPL autoload stack. It is a class loader that either loads only classes

--- a/lib/Doctrine/Common/Lexer.php
+++ b/lib/Doctrine/Common/Lexer.php
@@ -2,10 +2,6 @@
 namespace Doctrine\Common;
 
 use Doctrine\Common\Lexer\AbstractLexer;
-use function trigger_error;
-use const E_USER_DEPRECATED;
-
-@trigger_error(Lexer::class . ' is deprecated.', E_USER_DEPRECATED);
 
 /**
  * Base class for writing simple lexers, i.e. for creating small DSLs.

--- a/lib/Doctrine/Common/Util/Inflector.php
+++ b/lib/Doctrine/Common/Util/Inflector.php
@@ -2,10 +2,6 @@
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Inflector\Inflector as BaseInflector;
-use function trigger_error;
-use const E_USER_DEPRECATED;
-
-@trigger_error(Inflector::class . ' is deprecated.', E_USER_DEPRECATED);
 
 /**
  * Doctrine inflector has static methods for inflecting text.

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -4,9 +4,6 @@ namespace Doctrine\Tests\Common;
 
 use Doctrine\Common\ClassLoader;
 
-/**
- * @group legacy
- */
 class ClassLoaderTest extends \Doctrine\Tests\DoctrineTestCase
 {
     public function testClassLoader()


### PR DESCRIPTION
Reverts 39bc3964c485340b4cceba25e344a7e0d5f1ee4a in 2.9.

In #845 we added silent deprecations using the `@trigger_error(..., E_USER_DEPRECATED)` pattern (suggested in https://github.com/doctrine/common/pull/845#issuecomment-397631398).
This concept was originally created in a good faith to let users opt-in for deprecations only when they are interested in seeing them and aware it could happen (thus expecting deprecations may appear) and show none by default (for everyone else who doesn't opt-in).
Unfortunately Symfony had started misusing this concept and [has turned it to opt-out](https://github.com/symfony/symfony/issues/27936#issuecomment-404935867), just like if these were non-silent deprecations without `@` (messages logged, printed out and tests error out with exit code 1). In the end this means users are now seeing silenced deprecations unexpectedly without ever opting-in (in tests, debug toolbar etc.) and it breaks their test suite / CI.

Causes issues like: https://github.com/doctrine/doctrine2/issues/7306
Further (out-of-scope discussion): https://github.com/symfony/symfony/issues/27936

Proposal: Revert now for 2.9, release as 2.9.1. Then reevaluate usefulness of the concept of silent deprecations for future use.