### PR TITLE
[DDC-2556] Fix generating non-loading proxy methods when the identifier field is defined in a trait

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -856,7 +856,7 @@ EOT;
         );
 
         if ($cheapCheck) {
-            $code = file($method->getDeclaringClass()->getFileName());
+            $code = file($method->getFileName());
             $code = trim(implode(' ', array_slice($code, $startLine - 1, $endLine - $startLine + 1)));
 
             $pattern = sprintf(self::PATTERN_MATCH_ID_METHOD, $method->getName(), $identifier);

--- a/tests/Doctrine/Tests/Common/Proxy/IdentifierFieldTrait.php
+++ b/tests/Doctrine/Tests/Common/Proxy/IdentifierFieldTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+trait IdentifierFieldTrait
+{
+
+    /**
+     * @var int
+     */
+    private $identifierFieldInTrait;
+
+    /**
+     * @return int
+     */
+    public function getIdentifierFieldInTrait(): int
+    {
+        return $this->identifierFieldInTrait;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTrait.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset representing an object that has fields with respective getters defined in a separate trait
+ */
+class LazyLoadableObjectWithTrait
+{
+
+    use IdentifierFieldTrait;
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTraitClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTraitClassMetadata.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use ReflectionClass;
+
+/**
+ * Class metadata test asset for @see LazyLoadableObjectWithTrait
+ */
+class LazyLoadableObjectWithTraitClassMetadata implements ClassMetadata
+{
+    /**
+     * @var ReflectionClass
+     */
+    protected $reflectionClass;
+
+    /**
+     * @var array
+     */
+    protected $identifier = [
+        'identifierFieldInTrait' => true,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $fields = [
+        'identifierFieldInTrait' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if (null === $this->reflectionClass) {
+            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithTrait');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
@@ -78,6 +78,13 @@ class ProxyLogicIdentifierGetterTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
+        $methods = array_merge(
+            $methods,
+            [
+                [new LazyLoadableObjectWithTraitClassMetadata(), 'identifierFieldInTrait', 123],
+            ]
+        );
+
         return array_merge(
             $methods,
             [

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
@@ -57,40 +57,18 @@ class ProxyLogicIdentifierGetterTest extends \PHPUnit\Framework\TestCase
      */
     public function methodsForWhichLazyLoadingShouldBeDisabled()
     {
-        $methods = [
+        return [
             [new LazyLoadableObjectClassMetadata(), 'protectedIdentifierField', 'foo'],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldNoReturnTypehint', 'noTypeHint'],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnTypehintScalar', 'scalarValue'],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassFullyQualified', new LazyLoadableObjectWithTypehints()],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassPartialUse', new LazyLoadableObjectWithTypehints()],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassFullUse', new LazyLoadableObjectWithTypehints()],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassOneWord', new stdClass()],
+            [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetter', new stdClass()],
+            [new LazyLoadableObjectWithTraitClassMetadata(), 'identifierFieldInTrait', 123],
+            [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullable', new stdClass()],
+            [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullableWithSpace', new stdClass()],
         ];
-
-        if ( ! class_exists(\ReflectionType::class, false)) {
-            return $methods;
-        }
-
-        $methods = array_merge(
-            $methods,
-            [
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldNoReturnTypehint', 'noTypeHint'],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnTypehintScalar', 'scalarValue'],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassFullyQualified', new LazyLoadableObjectWithTypehints()],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassPartialUse', new LazyLoadableObjectWithTypehints()],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassFullUse', new LazyLoadableObjectWithTypehints()],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassOneWord', new stdClass()],
-                [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetter', new stdClass()],
-            ]
-        );
-
-        $methods = array_merge(
-            $methods,
-            [
-                [new LazyLoadableObjectWithTraitClassMetadata(), 'identifierFieldInTrait', 123],
-            ]
-        );
-
-        return array_merge(
-            $methods,
-            [
-                [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullable', new stdClass()],
-                [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullableWithSpace', new stdClass()],
-            ]
-        );
     }
 }


### PR DESCRIPTION
I stumbled upon this issue today while dealing with a nasty performance issue. After some digging around in the various bug trackers I found https://github.com/doctrine/doctrine2/issues/3282 which illustrates the issue, however it doesn't make it clear what the root cause is.

The problem is that the code that gets checked against the regular expression when determining if a getter is "a short identifier getter" is not the right code. With this patch the actual method in the trait gets checked, not the various use statements in the class that uses said trait.

In my particular case, the lines that got considered where these:

```
use XXX\ContentApi\Domain\Traits\HasLikes;
use XXX\ContentApi\Domain\Traits\Identifiable;
use XXX\ContentApi\Infrastructure\Traits\AutoIncrements;
use XXX\ContentApi\Infrastructure\Traits\Timestamps;
```

Here, the line numbers are correct, but the file is wrong, which ultimately causes the check to fail.
