### PR TITLE
Fix proxies with return types in magic methods

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1,10 +1,10 @@
 <?php
 namespace Doctrine\Common\Proxy;
 
-use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use function array_map;
 use function method_exists;
 
@@ -433,14 +433,24 @@ EOT;
         $hasParentGet         = false;
         $returnReference      = '';
         $inheritDoc           = '';
+        $name                 = '$name';
+        $parametersString     = '$name';
+        $returnTypeHint       = null;
 
         if ($reflectionClass->hasMethod('__get')) {
-            $hasParentGet = true;
-            $inheritDoc   = '{@inheritDoc}';
+            $hasParentGet     = true;
+            $inheritDoc       = '{@inheritDoc}';
+            $methodReflection = $reflectionClass->getMethod('__get');
 
-            if ($reflectionClass->getMethod('__get')->returnsReference()) {
+            if ($methodReflection->returnsReference()) {
                 $returnReference = '& ';
             }
+
+            $methodParameters = $methodReflection->getParameters();
+            $name             = '$' . $methodParameters[0]->getName();
+
+            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $returnTypeHint   = $this->getMethodReturnType($methodReflection);
         }
 
         if (empty($lazyPublicProperties) && ! $hasParentGet) {
@@ -450,19 +460,28 @@ EOT;
         $magicGet = <<<EOT
     /**
      * $inheritDoc
-     * @param string \$name
+     * @param string $name
      */
-    public function {$returnReference}__get(\$name)
+    public function {$returnReference}__get($parametersString)$returnTypeHint
     {
 
 EOT;
 
         if ( ! empty($lazyPublicProperties)) {
-            $magicGet .= <<<'EOT'
-        if (\array_key_exists($name, self::$lazyPropertiesNames)) {
-            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
+            $magicGet .= sprintf(<<<'EOT'
+        if (\array_key_exists(%s, self::$lazyPropertiesNames)) {
+            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [%s]);
+EOT
+                , $name, $name);
 
-            return $this->$name;
+            if ($returnTypeHint === ': void') {
+                $magicGet .= "\n            return;";
+            } else {
+                $magicGet .= "\n            return \$this->$name;";
+            }
+
+            $magicGet .= <<<'EOT'
+
         }
 
 
@@ -470,22 +489,34 @@ EOT;
         }
 
         if ($hasParentGet) {
-            $magicGet .= <<<'EOT'
-        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
+            $magicGet .= sprintf(<<<'EOT'
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [%s]);
+EOT
+                , $name);
 
-        return parent::__get($name);
+            if ($returnTypeHint === ': void') {
+                $magicGet .= sprintf(<<<'EOT'
 
-EOT;
+        parent::__get(%s);
+        return;
+EOT
+                    , $name);
+            } else {
+                $magicGet .= sprintf(<<<'EOT'
+
+        return parent::__get(%s);
+EOT
+                    , $name);
+            }
         } else {
-            $magicGet .= <<<'EOT'
-        trigger_error(sprintf('Undefined property: %s::$%s', __CLASS__, $name), E_USER_NOTICE);
+            $magicGet .= sprintf(<<<EOT
+        trigger_error(sprintf('Undefined property: %%s::$%%s', __CLASS__, %s), E_USER_NOTICE);
 
-EOT;
+EOT
+                , $name);
         }
 
-        $magicGet .= "    }";
-
-        return $magicGet;
+        return $magicGet . "\n    }";
     }
 
     /**
@@ -499,22 +530,31 @@ EOT;
     {
         $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $hasParentSet         = $class->getReflectionClass()->hasMethod('__set');
+        $parametersString     = '$name, $value';
+        $returnTypeHint       = null;
+
+        if ($hasParentSet) {
+            $methodReflection = $class->getReflectionClass()->getMethod('__set');
+            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $returnTypeHint   = $this->getMethodReturnType($methodReflection);
+        }
 
         if (empty($lazyPublicProperties) && ! $hasParentSet) {
             return '';
         }
 
         $inheritDoc = $hasParentSet ? '{@inheritDoc}' : '';
-        $magicSet   = <<<EOT
+        $magicSet   = sprintf(<<<'EOT'
     /**
-     * $inheritDoc
-     * @param string \$name
-     * @param mixed  \$value
+     * %s
+     * @param string $name
+     * @param mixed  $value
      */
-    public function __set(\$name, \$value)
+    public function __set(%s)%s
     {
 
-EOT;
+EOT
+            , $inheritDoc, $parametersString, $returnTypeHint);
 
         if ( ! empty($lazyPublicProperties)) {
             $magicSet .= <<<'EOT'
@@ -540,9 +580,7 @@ EOT;
             $magicSet .= "        \$this->\$name = \$value;";
         }
 
-        $magicSet .= "\n    }";
-
-        return $magicSet;
+        return $magicSet . "\n    }";
     }
 
     /**
@@ -556,6 +594,14 @@ EOT;
     {
         $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $hasParentIsset       = $class->getReflectionClass()->hasMethod('__isset');
+        $parametersString     = '$name';
+        $returnTypeHint       = null;
+
+        if ($hasParentIsset) {
+            $methodReflection = $class->getReflectionClass()->getMethod('__isset');
+            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $returnTypeHint   = $this->getMethodReturnType($methodReflection);
+        }
 
         if (empty($lazyPublicProperties) && ! $hasParentIsset) {
             return '';
@@ -568,7 +614,7 @@ EOT;
      * @param  string \$name
      * @return boolean
      */
-    public function __isset(\$name)
+    public function __isset($parametersString)$returnTypeHint
     {
 
 EOT;
@@ -590,7 +636,6 @@ EOT;
         $this->__initializer__ && $this->__initializer__->__invoke($this, '__isset', [$name]);
 
         return parent::__isset($name);
-
 EOT;
         } else {
             $magicIsset .= "        return false;";

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,6 +37,9 @@ parameters:
         -
             message: '#^Property Doctrine\\Tests\\Common\\Proxy\\ProxyLogicVoidReturnTypeTest::\$initializerCallbackMock \(callable&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject&stdClass\.$#'
             path: '%currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
+        -
+            message: '#^Method Doctrine\\Tests\\Common\\Proxy\\MagicIssetClassWithInteger::__isset\(\) should return bool but returns int\.$#'
+            path: '%currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php'
 
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithScalarType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithScalarType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ * @author Jan Barasek <jan@barasek.com>
+ */
+class MagicGetClassWithScalarType
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @param string $name
+     *
+     * @return string
+     * @throws \BadMethodCallException
+     */
+    public function __get(string $name): string
+    {
+        if ($name === 'test') {
+            return 'test';
+        }
+
+        if ($name === 'publicField' || $name === 'id') {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        return 'not defined';
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithScalarTypeAndRenamedParameter.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithScalarTypeAndRenamedParameter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ * @author Jan Barasek <jan@barasek.com>
+ */
+class MagicGetClassWithScalarTypeAndRenamedParameter
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @param string $n
+     *
+     * @return string
+     * @throws \BadMethodCallException
+     */
+    public function __get(string $n): string
+    {
+        if ($n === 'test') {
+            return 'test';
+        }
+
+        if ($n === 'publicField' || $n === 'id') {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        return 'not defined';
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithVoid.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicGetClassWithVoid.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Magic class asset test with void return type for getter
+ */
+class MagicGetClassWithVoid
+{
+
+    /**
+     * @param string $name
+     *
+     * @return void
+     * @throws \BadMethodCallException
+     */
+    public function __get(string $name): void
+    {
+        return;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithBoolean.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithBoolean.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ * @author Jan Barasek <jan@barasek.com>
+ */
+class MagicIssetClassWithBoolean
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     * @throws \BadMethodCallException
+     */
+    public function __isset(string $name): bool
+    {
+        if ('test' === $name) {
+            return true;
+        }
+
+        if ('publicField' === $name || 'id' === $name) {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        return false;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ * @author Jan Barasek <jan@barasek.com>
+ */
+class MagicIssetClassWithInteger
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @param string $name
+     *
+     * @return int
+     * @throws \BadMethodCallException
+     */
+    public function __isset(string $name): int
+    {
+        if ('test' === $name) {
+            return 1;
+        }
+
+        if ('publicField' === $name || 'id' === $name) {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        return 0;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicSetClassWithScalarType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicSetClassWithScalarType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ * @author Jan Barasek <jan@barasek.com>
+ */
+class MagicSetClassWithScalarType
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @var string|null
+     */
+    public $testAttribute;
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __set(string $name, $value)
+    {
+        if ($name === 'test') {
+            $this->testAttribute = $value;
+        }
+
+        if ($name === 'publicField' || $name === 'id') {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        $this->testAttribute = $value;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -74,6 +74,90 @@ class ProxyMagicMethodsTest extends \PHPUnit\Framework\TestCase
         self::assertSame(3, $counter);
     }
 
+    public function testInheritedMagicGetWithScalarType()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicGetClassWithScalarType::class);
+        $proxy          = new $proxyClassName(
+            function (Proxy $proxy, $method, $params) use (&$counter) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
+                    throw new InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
+                }
+
+                $initializer = $proxy->__getInitializer();
+
+                $proxy->__setInitializer(null);
+
+                $proxy->publicField = 'modifiedPublicField';
+                $counter           += 1;
+
+                $proxy->__setInitializer($initializer);
+            }
+        );
+
+        self::assertSame('id', $proxy->id);
+        self::assertSame('modifiedPublicField', $proxy->publicField);
+        self::assertSame('test', $proxy->test);
+        self::assertSame('not defined', $proxy->notDefined);
+
+        self::assertSame(3, $counter);
+    }
+
+    public function testInheritedMagicGetWithScalarTypeAndRenamedParameter()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicGetClassWithScalarTypeAndRenamedParameter::class);
+        $proxy          = new $proxyClassName(
+            function (Proxy $proxy, $method, $params) use (&$counter) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
+                    throw new InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
+                }
+
+                $initializer = $proxy->__getInitializer();
+
+                $proxy->__setInitializer(null);
+
+                $proxy->publicField = 'modifiedPublicField';
+                $counter           += 1;
+
+                $proxy->__setInitializer($initializer);
+            }
+        );
+
+        self::assertSame('id', $proxy->id);
+        self::assertSame('modifiedPublicField', $proxy->publicField);
+        self::assertSame('test', $proxy->test);
+        self::assertSame('not defined', $proxy->notDefined);
+
+        self::assertSame(3, $counter);
+    }
+
+    public function testInheritedMagicGetWithVoid()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicGetClassWithVoid::class);
+        $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
+            if (in_array($params[0], ['publicField', 'test'])) {
+                $initializer = $proxy->__getInitializer();
+
+                $proxy->__setInitializer(null);
+
+                $proxy->publicField = 'modifiedPublicField';
+                $counter           += 1;
+
+                $proxy->__setInitializer($initializer);
+
+                return;
+            }
+
+            throw new InvalidArgumentException(
+                sprintf('Should not be initialized when checking isset("%s")', $params[0])
+            );
+        });
+
+        self::assertNull($proxy->publicField);
+        self::assertNull($proxy->test);
+
+        self::assertSame(2, $counter);
+    }
+
     /**
      * @group DCOM-194
      */
@@ -99,6 +183,35 @@ class ProxyMagicMethodsTest extends \PHPUnit\Framework\TestCase
     public function testInheritedMagicSet()
     {
         $proxyClassName = $this->generateProxyClass(MagicSetClass::class);
+        $proxy          = new $proxyClassName(
+            function (Proxy  $proxy, $method, $params) use (&$counter) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
+                    throw new InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
+                }
+
+                $counter += 1;
+            }
+        );
+
+        self::assertSame('id', $proxy->id);
+
+        $proxy->publicField = 'publicFieldValue';
+
+        self::assertSame('publicFieldValue', $proxy->publicField);
+
+        $proxy->test = 'testValue';
+
+        self::assertSame('testValue', $proxy->testAttribute);
+
+        $proxy->notDefined = 'not defined';
+
+        self::assertSame('not defined', $proxy->testAttribute);
+        self::assertSame(3, $counter);
+    }
+
+    public function testInheritedMagicSetWithScalarType()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicSetClassWithScalarType::class);
         $proxy          = new $proxyClassName(
             function (Proxy  $proxy, $method, $params) use (&$counter) {
                 if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
@@ -166,6 +279,66 @@ class ProxyMagicMethodsTest extends \PHPUnit\Framework\TestCase
     public function testInheritedMagicIsset()
     {
         $proxyClassName = $this->generateProxyClass(MagicIssetClass::class);
+        $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
+            if (in_array($params[0], ['publicField', 'test', 'nonExisting'])) {
+                $initializer = $proxy->__getInitializer();
+
+                $proxy->__setInitializer(null);
+
+                $proxy->publicField = 'modifiedPublicField';
+                $counter           += 1;
+
+                $proxy->__setInitializer($initializer);
+
+                return;
+            }
+
+            throw new InvalidArgumentException(
+                sprintf('Should not be initialized when checking isset("%s")', $params[0])
+            );
+        });
+
+        self::assertTrue(isset($proxy->id));
+        self::assertTrue(isset($proxy->publicField));
+        self::assertTrue(isset($proxy->test));
+        self::assertFalse(isset($proxy->nonExisting));
+
+        self::assertSame(3, $counter);
+    }
+
+    public function testInheritedMagicIssetWithBoolean()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicIssetClassWithBoolean::class);
+        $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
+            if (in_array($params[0], ['publicField', 'test', 'nonExisting'])) {
+                $initializer = $proxy->__getInitializer();
+
+                $proxy->__setInitializer(null);
+
+                $proxy->publicField = 'modifiedPublicField';
+                $counter           += 1;
+
+                $proxy->__setInitializer($initializer);
+
+                return;
+            }
+
+            throw new InvalidArgumentException(
+                sprintf('Should not be initialized when checking isset("%s")', $params[0])
+            );
+        });
+
+        self::assertTrue(isset($proxy->id));
+        self::assertTrue(isset($proxy->publicField));
+        self::assertTrue(isset($proxy->test));
+        self::assertFalse(isset($proxy->nonExisting));
+
+        self::assertSame(3, $counter);
+    }
+
+    public function testInheritedMagicIssetWithInteger()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicIssetClassWithInteger::class);
         $proxy          = new $proxyClassName(function (Proxy $proxy, $method, $params) use (&$counter) {
             if (in_array($params[0], ['publicField', 'test', 'nonExisting'])) {
                 $initializer = $proxy->__getInitializer();


### PR DESCRIPTION
On PHP version 7.0 or newest automatically add scalar return type hints to magic methods for compatibility generated Proxy class with real entity.

More information: https://github.com/doctrine/common/issues/868