### PR TITLE
Fallback to 'copy' and 'unlink' instead of 'rename'

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -290,7 +290,11 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
 
         file_put_contents($tmpFileName, $proxyCode);
         @chmod($tmpFileName, 0664);
-        rename($tmpFileName, $fileName);
+
+        if (true !== @rename($tmpFileName, $fileName)) {
+            copy($tmpFileName, $fileName);
+            unlink($tmpFileName);
+        }
     }
 
     /**


### PR DESCRIPTION
...to move a file without side effects.

This gist reproduces the problem:
https://gist.github.com/alcaeus/a367e895e6c55f7fb93870dcba46efa9

Same issue is fixed in a similary way in symfony core:
https://github.com/symfony/symfony/issues/12533

resolves #6713