### PR TITLE
ProxyGenerator: Update regex pattern to match simple id getters with …

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -21,7 +21,7 @@ class ProxyGenerator
      * Used to match very simple id methods that don't need
      * to be decorated since the identifier is known.
      */
-    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\??\s*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
+    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\??((?:\\\\?[\w\x7f-\xff][\w\x7f-\xff]+)+)\s*)?{\s*return\s*(\$this->%2$s|new \g{4}\(\$this->%2$s\)|\g{4}::\w+\(\$this->%2$s\));\s*})';
 
     /**
      * The namespace that contains all proxy classes.


### PR DESCRIPTION
- [ ]  add tests
- [x]  test on production ready project

Currently, in ProxyGenerator there's support for generating simple (not triggering entity hydration) id getters in proxy class only for `return $this->identifier` 

```php
public function getId() { return $this->id; }
```
However, I also needed to support

```php
public function getId() { return MyId::new($this->id); }
```
and
```php
public function getId() { return new MyId($this->id); }
```

Would it make sense?