### PR TITLE
ProxyGenerator: Update regex pattern to match simple id getters with …

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -7,6 +7,8 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use function array_map;
 use function method_exists;
+use function preg_match;
+use function sprintf;
 
 /**
  * This factory is used to generate proxy classes.
@@ -20,8 +22,19 @@ class ProxyGenerator
     /**
      * Used to match very simple id methods that don't need
      * to be decorated since the identifier is known.
+     *
+     * @see https://regex101.com/r/u72479/2/
      */
-    const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\??\s*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
+    const PATTERN_MATCH_ID_METHOD = <<<REGEXP
+~(
+(public\s+)?
+(function\s+%s\s*\(\)\s*)\s*
+(?::\s*\??\s*((?:\\\\?[\w\\x7f-\\xff][\w\\x7f-\\xff]*)+)\s*)?
+{\s*
+return\s*(\\\$this->%2\$s|new\s+\g{4}\(\\\$this->%2\$s\)|\g{4}::\w+\(\\\$this->%2\$s\));
+\s*}
+)~x
+REGEXP;
 
     /**
      * The namespace that contains all proxy classes.

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithCustomIdType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithCustomIdType.php
@@ -1,0 +1,26 @@
+<?php
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine;
+
+/**
+ * Test asset representing a lazy loadable object
+ */
+class LazyLoadableObjectWithCustomIdType
+{
+    /** @var string */
+    private $identifierFieldWithStaticVOConstructor;
+
+    /** @var string */
+    private $identifierFieldWithVOConstructor;
+
+    public function getIdentifierFieldWithStaticVOConstructor() : ValueId
+    {
+        return ValueId::new($this->identifierFieldWithStaticVOConstructor);
+    }
+
+    public function getIdentifierFieldWithVOConstructor() : ValueId
+    {
+        return new ValueId($this->identifierFieldWithVOConstructor);
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithCustomIdTypeClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithCustomIdTypeClassMetadata.php
@@ -1,0 +1,164 @@
+<?php
+namespace Doctrine\Tests\Common\Proxy;
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use ReflectionClass;
+
+/**
+ * Class metadata test asset for @see LazyLoadableObject
+ */
+class LazyLoadableObjectWithCustomIdTypeClassMetadata implements ClassMetadata
+{
+    /**
+     * @var ReflectionClass
+     */
+    protected $reflectionClass;
+
+    /**
+     * @var array
+     */
+    protected $identifier = [
+        'identifierFieldWithStaticVOConstructor' => true,
+        'identifierFieldWithVOConstructor' => true,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $fields = [
+        'identifierFieldWithStaticVOConstructor' => true,
+        'identifierFieldWithVOConstructor' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if (null === $this->reflectionClass) {
+            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithCustomIdType');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
@@ -19,9 +19,10 @@ class ProxyLogicIdentifierGetterTest extends \PHPUnit\Framework\TestCase
      *
      * @param ClassMetadata $metadata
      * @param string        $fieldName
+     * @param mixed         $value
      * @param mixed         $expectedReturnedValue
      */
-    public function testNoLazyLoadingForIdentifier(ClassMetadata $metadata, $fieldName, $expectedReturnedValue)
+    public function testNoLazyLoadingForIdentifier(ClassMetadata $metadata, $fieldName, $value, $expectedReturnedValue = null)
     {
         $className      = $metadata->getName();
         $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\\' . $className;
@@ -47,9 +48,13 @@ class ProxyLogicIdentifierGetterTest extends \PHPUnit\Framework\TestCase
         $reflection = $metadata->getReflectionClass()->getProperty($fieldName);
 
         $reflection->setAccessible(true);
-        $reflection->setValue($proxy, $expectedReturnedValue);
+        $reflection->setValue($proxy, $value);
 
-        self::assertSame($expectedReturnedValue, $proxy->{'get' . $fieldName}());
+        if ($expectedReturnedValue === null) {
+            self::assertSame($value, $proxy->{'get' . $fieldName}());
+        } else {
+            self::assertEquals($expectedReturnedValue, $proxy->{'get' . $fieldName}());
+        }
     }
 
     /**
@@ -69,6 +74,8 @@ class ProxyLogicIdentifierGetterTest extends \PHPUnit\Framework\TestCase
             [new LazyLoadableObjectWithTraitClassMetadata(), 'identifierFieldInTrait', 123],
             [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullable', new stdClass()],
             [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullableWithSpace', new stdClass()],
+            [new LazyLoadableObjectWithCustomIdTypeClassMetadata(), 'identifierFieldWithStaticVOConstructor', 'a', ValueId::new('a')],
+            [new LazyLoadableObjectWithCustomIdTypeClassMetadata(), 'identifierFieldWithVOConstructor', 'b', ValueId::new('b')],
         ];
     }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ValueId.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ValueId.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+final class ValueId
+{
+    /** @var string */
+    private $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public static function new(string $id) : self
+    {
+        return new self($id);
+    }
+}


### PR DESCRIPTION
_Followup, couldn't reopen https://github.com/doctrine/common/pull/877_  
_I had to solve it anyway. It IMO improves current state. Feel free to close if not applicable._

- [x]  add tests
- [x]  test on production ready project

Currently, in ProxyGenerator there's support for generating simple (not triggering entity hydration) id getters in proxy class only for `return $this->identifier` 

```php
public function getId() { return $this->id; }
```
However, I also needed to support

```php
public function getId() { return MyId::new($this->id); }
```
and
```php
public function getId() { return new MyId($this->id); }
```
