### PR TITLE
Address deprecations from doctrine/persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/annotations": "^1.0",
         "doctrine/event-manager": "^1.0",
         "doctrine/reflection": "^1.0",
-        "doctrine/persistence": "^1.1"
+        "doctrine/persistence": "^1.3.3"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40bcfe4c5277cdfa06868ad21fd26d85",
+    "content-hash": "afcb00ca52b7e07004c7968712911857",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -413,16 +413,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "v1.1.0",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38"
+                "reference": "99b196bbd4715a94fa100fac664a351ffa46d6a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
-                "reference": "c0f1c17602afc18b4cbd8e1c8125f264c9cf7d38",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/99b196bbd4715a94fa100fac664a351ffa46d6a5",
+                "reference": "99b196bbd4715a94fa100fac664a351ffa46d6a5",
                 "shasum": ""
             },
             "require": {
@@ -437,19 +437,20 @@
                 "doctrine/common": "<2.10@dev"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "phpstan/phpstan": "^0.8",
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11",
                 "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                    "Doctrine\\Common\\": "lib/Doctrine/Common",
+                    "Doctrine\\Persistence\\": "lib/Doctrine/Persistence"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -458,16 +459,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -491,7 +492,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2018-11-21T00:33:13+00:00"
+            "time": "2019-12-13T10:43:02+00:00"
         },
         {
             "name": "doctrine/reflection",
@@ -1151,7 +1152,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",
@@ -3363,8 +3364,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -1,8 +1,8 @@
 <?php
 namespace Doctrine\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
 use Doctrine\Common\Util\ClassUtils;
@@ -61,7 +61,7 @@ abstract class AbstractProxyFactory
     ];
 
     /**
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory
+     * @var \Doctrine\Persistence\Mapping\ClassMetadataFactory
      */
     private $metadataFactory;
 
@@ -81,9 +81,9 @@ abstract class AbstractProxyFactory
     private $definitions = [];
 
     /**
-     * @param \Doctrine\Common\Proxy\ProxyGenerator                     $proxyGenerator
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory $metadataFactory
-     * @param bool|int                                                  $autoGenerate
+     * @param \Doctrine\Common\Proxy\ProxyGenerator              $proxyGenerator
+     * @param \Doctrine\Persistence\Mapping\ClassMetadataFactory $metadataFactory
+     * @param bool|int                                           $autoGenerate
      *
      * @throws \Doctrine\Common\Proxy\Exception\InvalidArgumentException When auto generate mode is not valid.
      */
@@ -131,8 +131,8 @@ abstract class AbstractProxyFactory
     /**
      * Generates proxy classes for all given classes.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata[] $classes The classes (ClassMetadata instances)
-     *                                                                      for which to generate proxies.
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata[] $classes The classes (ClassMetadata instances)
+     *                                                               for which to generate proxies.
      * @param string $proxyDir The target directory of the proxy classes. If not specified, the
      *                         directory configured on the Configuration of the EntityManager used
      *                         by this factory is used.
@@ -230,7 +230,7 @@ abstract class AbstractProxyFactory
     /**
      * Determine if this class should be skipped during proxy generation.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $metadata
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $metadata
      *
      * @return bool
      */
@@ -243,3 +243,6 @@ abstract class AbstractProxyFactory
      */
     abstract protected function createProxyDefinition($className);
 }
+
+interface_exists(ClassMetadata::class);
+interface_exists(ClassMetadataFactory::class);

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Common\Proxy\Exception;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 use InvalidArgumentException as BaseInvalidArgumentException;
 
 /**
@@ -104,3 +104,5 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
         return new self(sprintf('Invalid auto generate mode "%s" given.', $value));
     }
 }
+
+interface_exists(Proxy::class);

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Common\Proxy;
 
 use Closure;
-use Doctrine\Common\Persistence\Proxy as BaseProxy;
+use Doctrine\Persistence\Proxy as BaseProxy;
 
 /**
  * Interface for proxy classes.

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
@@ -80,7 +80,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * @var boolean flag indicating if this object was already initialized
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     * @see \Doctrine\Persistence\Proxy::__isInitialized
      */
     public $__isInitialized__ = false;
 
@@ -237,8 +237,8 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates a proxy class file.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class    Metadata for the original class.
-     * @param string|bool                                        $fileName Filename (full path) for the generated class. If none is given, eval() is used.
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class    Metadata for the original class.
+     * @param string|bool                                 $fileName Filename (full path) for the generated class. If none is given, eval() is used.
      *
      * @throws InvalidArgumentException
      * @throws UnexpectedValueException
@@ -312,7 +312,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates the proxy short class name to be used in the template.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -327,7 +327,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates the proxy namespace.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -342,7 +342,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates the original class name.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -354,7 +354,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates the array representation of lazy loaded public properties and their default values.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -373,7 +373,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Generates the constructor code (un-setting public lazy loaded properties, setting identifier field values).
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -408,7 +408,7 @@ EOT;
     /**
      * Generates the magic getter invoked when lazy loaded public properties are requested.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -477,7 +477,7 @@ EOT;
     /**
      * Generates the magic setter (currently unused).
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -534,7 +534,7 @@ EOT;
     /**
      * Generates the magic issetter invoked when lazy loaded public properties are checked against isset().
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -588,7 +588,7 @@ EOT;
     /**
      * Generates implementation for the `__sleep` method of proxies.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -659,7 +659,7 @@ EOT;
     /**
      * Generates implementation for the `__wakeup` method of proxies.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -714,7 +714,7 @@ EOT;
     /**
      * Generates implementation for the `__clone` method of proxies.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -738,7 +738,7 @@ EOT;
     /**
      * Generates decorated methods by picking those available in the parent class.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return string
      */
@@ -837,8 +837,8 @@ EOT;
      * ID is interesting for the userland code (for example in views that
      * generate links to the entity, but do not display anything else).
      *
-     * @param \ReflectionMethod                                  $method
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \ReflectionMethod                           $method
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return boolean
      */
@@ -872,7 +872,7 @@ EOT;
     /**
      * Generates the list of public properties to be lazy loaded, with their default values.
      *
-     * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
+     * @param \Doctrine\Persistence\Mapping\ClassMetadata $class
      *
      * @return mixed[]
      */
@@ -1060,3 +1060,5 @@ EOT;
         return $name;
     }
 }
+
+interface_exists(ClassMetadata::class);

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Common\Util;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 
 /**
  * Class and reflection related functionality for objects that

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Common\Util;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 
 /**
  * Static class containing most used debug methods.

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Proxy;
@@ -203,3 +203,6 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         $proxyFactory->getProxy('Class', []);
     }
 }
+
+interface_exists(ClassMetadata::class);
+interface_exists(ClassMetadataFactory::class);

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectClassMetadata.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Tests\Common\Proxy;
 
 use ReflectionClass;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Class metadata test asset for @see LazyLoadableObject

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithNullableTypehintsClassMetadata.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Tests\Common\Proxy;
 
 use ReflectionClass;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Class metadata test asset for @see LazyLoadableObject

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTraitClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTraitClassMetadata.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionClass;
 
 /**

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypehintsClassMetadata.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Tests\Common\Proxy;
 
 use ReflectionClass;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Class metadata test asset for @see LazyLoadableObject

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithVoidClassMetadata.php
@@ -2,7 +2,7 @@
 namespace Doctrine\Tests\Common\Proxy;
 
 use ReflectionClass;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 /**
  * Class metadata test asset for @see LazyLoadableObjectWithVoid

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Proxy\ProxyGenerator;

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use stdClass;
 

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Common\Proxy\ProxyGenerator;

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use stdClass;

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\Tests\Common\Proxy;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use InvalidArgumentException;


### PR DESCRIPTION
The `Common` portion of the namespace has been removed following a split
of `doctrine/common` into several packages.