### PR TITLE
Bugfix: ProxyGenerator incompatible with public typed properties and lazy loading

### DIFF
--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -69,24 +69,6 @@ interface Proxy extends BaseProxy
      *
      * @return array Keys are the property names, and values are the default values
      *               for those properties.
-     *
-     * @deprecated Use __getLazyPropertiesNames() and __getLazyPropertiesDefaultValues() instead.
      */
     public function __getLazyProperties();
-
-    /**
-     * Retrieves the list of lazy loaded properties names for a given proxy
-     *
-     * @return array
-     */
-    public function __getLazyPropertiesNames();
-
-    /**
-     * Retrieves the list of default values of lazy loaded properties for a given proxy
-     *
-     * @return array Keys are the property names, and values are the default values
-     *               for those properties.
-     *               Note: typed not nullable properties has no default value.
-     */
-    public function __getLazyPropertiesDefaultValues();
 }

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -69,6 +69,24 @@ interface Proxy extends BaseProxy
      *
      * @return array Keys are the property names, and values are the default values
      *               for those properties.
+     *
+     * @deprecated Use __getLazyPropertiesNames() and __getLazyPropertiesDefaultValues() instead.
      */
     public function __getLazyProperties();
+
+    /**
+     * Retrieves the list of lazy loaded properties names for a given proxy
+     *
+     * @return array
+     */
+    public function __getLazyPropertiesNames();
+
+    /**
+     * Retrieves the list of default values of lazy loaded properties for a given proxy
+     *
+     * @return array Keys are the property names, and values are the default values
+     *               for those properties.
+     *               Note: typed not nullable properties has no default value.
+     */
+    public function __getLazyPropertiesDefaultValues();
 }

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -89,14 +89,14 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      *
      * @see \Doctrine\Common\Proxy\Proxy::__getLazyPropertiesNames
      */
-    public static $lazyProperties = [<lazyProperties>];
+    public static $lazyPropertiesNames = [<lazyPropertiesNames>];
 
     /**
      * @var array default values of properties to be lazy loaded, with keys being the property names
      *
-     * @see \Doctrine\Common\Proxy\Proxy::__getLazyPropertiesDefaultValues
+     * @see \Doctrine\Common\Proxy\Proxy::__getLazyProperties
      */
-    public static $lazyPropertiesDefaults = [<lazyPropertiesDefaults>];
+    public static $lazyProperties = [<lazyPropertiesDefaults>];
 
 <additionalProperties>
 
@@ -183,27 +183,17 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      */
     public function __getLazyProperties()
     {
-        return self::$lazyPropertiesDefaults;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @internal generated method: use only when explicitly handling proxy specific loading logic
-     * @static
-     */
-    public function __getLazyPropertiesNames()
-    {
         return self::$lazyProperties;
     }
 
     /**
-     * {@inheritDoc}
-     * @internal generated method: use only when explicitly handling proxy specific loading logic
-     * @static
+     * Retrieves the list of lazy loaded properties names for a given proxy
+     *
+     * @return array
      */
-    public function __getLazyPropertiesDefaultValues()
+    private function __getLazyPropertiesNames()
     {
-        return self::$lazyPropertiesDefaults;
+        return self::$lazyPropertiesNames;
     }
 
     <methods>
@@ -384,9 +374,9 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      *
      * @return string
      */
-    private function generateLazyProperties(ClassMetadata $class)
+    private function generateLazyPropertiesNames(ClassMetadata $class)
     {
-        $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $values               = [];
 
         foreach ($lazyPublicProperties as $name) {
@@ -397,7 +387,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     }
 
     /**
-     * Generates the array representation of default values of lazy loaded public properties.
+     * Generates the array representation of lazy loaded public properties names.
      *
      * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $class
      *
@@ -405,7 +395,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      */
     private function generateLazyPropertiesDefaults(ClassMetadata $class)
     {
-        $lazyPublicPropertiesDefaultValues = $this->getLazyLoadedPublicPropertiesDefaultValues($class);
+        $lazyPublicPropertiesDefaultValues = $this->getLazyLoadedPublicProperties($class);
         $values                            = [];
 
         foreach ($lazyPublicPropertiesDefaultValues as $key => $value) {
@@ -435,7 +425,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
 EOT;
         $toUnset         = [];
 
-        foreach ($this->getLazyLoadedPublicProperties($class) as $lazyPublicProperty) {
+        foreach ($this->getLazyLoadedPublicPropertiesNames($class) as $lazyPublicProperty) {
             $toUnset[] = '$this->' . $lazyPublicProperty;
         }
 
@@ -459,7 +449,7 @@ EOT;
      */
     private function generateMagicGet(ClassMetadata $class)
     {
-        $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $reflectionClass      = $class->getReflectionClass();
         $hasParentGet         = false;
         $returnReference      = '';
@@ -528,7 +518,7 @@ EOT;
      */
     private function generateMagicSet(ClassMetadata $class)
     {
-        $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $hasParentSet         = $class->getReflectionClass()->hasMethod('__set');
 
         if (empty($lazyPublicProperties) && ! $hasParentSet) {
@@ -585,7 +575,7 @@ EOT;
      */
     private function generateMagicIsset(ClassMetadata $class)
     {
-        $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $hasParentIsset       = $class->getReflectionClass()->hasMethod('__isset');
 
         if (empty($lazyPublicProperties) && ! $hasParentIsset) {
@@ -677,7 +667,7 @@ EOT;
                 : $prop->getName();
         }
 
-        $lazyPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $protectedProperties  = array_diff($allProperties, $lazyPublicProperties);
 
         foreach ($allProperties as &$property) {
@@ -713,7 +703,7 @@ EOT;
         $unsetPublicProperties = [];
         $hasWakeup             = $class->getReflectionClass()->hasMethod('__wakeup');
 
-        foreach ($this->getLazyLoadedPublicProperties($class) as $lazyPublicProperty) {
+        foreach ($this->getLazyLoadedPublicPropertiesNames($class) as $lazyPublicProperty) {
             $unsetPublicProperties[] = '$this->' . $lazyPublicProperty;
         }
 
@@ -732,7 +722,7 @@ EOT;
 
                 \$existingProperties = get_object_vars(\$proxy);
 
-                foreach (\$proxy->__getLazyPropertiesDefaultValues() as \$property => \$defaultValue) {
+                foreach (\$proxy->__getLazyProperties() as \$property => \$defaultValue) {
                     if ( ! array_key_exists(\$property, \$existingProperties)) {
                         \$proxy->\$property = \$defaultValue;
                     }
@@ -921,7 +911,7 @@ EOT;
      *
      * @return mixed[]
      */
-    private function getLazyLoadedPublicProperties(ClassMetadata $class)
+    private function getLazyLoadedPublicPropertiesNames(ClassMetadata $class)
     {
         $properties = [];
 
@@ -943,10 +933,10 @@ EOT;
      *
      * @return mixed[]
      */
-    private function getLazyLoadedPublicPropertiesDefaultValues(ClassMetadata $class)
+    private function getLazyLoadedPublicProperties(ClassMetadata $class)
     {
         $defaultProperties          = $class->getReflectionClass()->getDefaultProperties();
-        $lazyLoadedPublicProperties = $this->getLazyLoadedPublicProperties($class);
+        $lazyLoadedPublicProperties = $this->getLazyLoadedPublicPropertiesNames($class);
         $defaultValues              = [];
 
         foreach ($class->getReflectionClass()->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -952,7 +952,7 @@ EOT;
         foreach ($class->getReflectionClass()->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
             $name = $property->getName();
 
-            if (! in_array($name, $lazyLoadedPublicProperties, true)) {
+            if ( ! in_array($name, $lazyLoadedPublicProperties, true)) {
                 continue;
             }
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,8 @@ parameters:
         - %currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/InvalidTypeHintClass.php
         - %currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/SerializedClass.php
         - %currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/VariadicTypeHintClass.php
+        - %currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php
+        - %currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
     ignoreErrors:
         - '#Access to an undefined property Doctrine\\Common\\Proxy\\Proxy::\$publicField#'
         -

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,6 +28,9 @@ parameters:
         -
             message: '#^Property Doctrine\\Tests\\Common\\Proxy\\ProxyLogicVoidReturnTypeTest::\$initializerCallbackMock \(callable&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject&stdClass\.$#'
             path: '%currentWorkingDirectory%/tests/Doctrine/Tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
+        -
+            message: '#^Call to an undefined method ReflectionProperty::getType\(\)\.$#'
+            path: '%currentWorkingDirectory%/lib/Doctrine/Common/Proxy/ProxyGenerator.php'
 
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
@@ -1,0 +1,67 @@
+<?php
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset representing a lazy loadable object with typed properties
+ */
+class LazyLoadableObjectWithTypedProperties
+{
+    public string $publicIdentifierField;
+
+    protected string $protectedIdentifierField;
+
+    public string $publicTransientField = 'publicTransientFieldValue';
+
+    protected string $protectedTransientField = 'protectedTransientFieldValue';
+
+    public ?string $publicPersistentField = 'publicPersistentFieldValue';
+
+    protected string $protectedPersistentField = 'protectedPersistentFieldValue';
+
+    public string $publicAssociation = 'publicAssociationValue';
+
+    protected string $protectedAssociation = 'protectedAssociationValue';
+
+    /**
+     * @return string
+     */
+    public function getProtectedIdentifierField()
+    {
+        return $this->protectedIdentifierField;
+    }
+
+    /**
+     * @return string
+     */
+    public function testInitializationTriggeringMethod()
+    {
+        return 'testInitializationTriggeringMethod';
+    }
+
+    /**
+     * @return string
+     */
+    public function getProtectedAssociation()
+    {
+        return $this->protectedAssociation;
+    }
+
+    /**
+     * @param \stdClass $param
+     */
+    public function publicTypeHintedMethod(\stdClass $param)
+    {
+    }
+
+    public function &byRefMethod()
+    {
+    }
+
+    /**
+     * @param mixed $thisIsNotByRef
+     * @param mixed $thisIsByRef
+     */
+    public function byRefParamMethod($thisIsNotByRef, &$thisIsByRef)
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedPropertiesClassMetadata.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedPropertiesClassMetadata.php
@@ -1,0 +1,174 @@
+<?php
+namespace Doctrine\Tests\Common\Proxy;
+
+use ReflectionClass;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+
+/**
+ * Class metadata test asset for @see LazyLoadableObjectWithTypedProperties
+ */
+class LazyLoadableObjectWithTypedPropertiesClassMetadata implements ClassMetadata
+{
+    /**
+     * @var ReflectionClass
+     */
+    protected $reflectionClass;
+
+    /**
+     * @var array
+     */
+    protected $identifier = [
+        'publicIdentifierField'    => true,
+        'protectedIdentifierField' => true,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $fields = [
+        'publicIdentifierField'    => true,
+        'protectedIdentifierField' => true,
+        'publicPersistentField'    => true,
+        'protectedPersistentField' => true,
+    ];
+
+    /**
+     * @var array
+     */
+    protected $associations = [
+        'publicAssociation'        => true,
+        'protectedAssociation'     => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if (null === $this->reflectionClass) {
+            $this->reflectionClass = new \ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithTypedProperties');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return isset($this->associations[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return array_keys($this->associations);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new \BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -713,7 +713,7 @@ class ProxyLogicTest extends \PHPUnit\Framework\TestCase
                 return;
             }
 
-            $properties = $proxy->__getLazyPropertiesDefaultValues();
+            $properties = $proxy->__getLazyProperties();
 
             foreach ($properties as $propertyName => $property) {
                 if ( ! isset($proxy->$propertyName)) {

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -594,7 +594,7 @@ class ProxyLogicTest extends \PHPUnit\Framework\TestCase
         // creating the proxy class
         if ( ! class_exists($proxyClassName, false)) {
             $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
-            $proxyGenerator->generateProxyClass($metadata);
+            $proxyGenerator->generateProxyClass($metadata, $proxyGenerator->getProxyFileName($metadata->getName()));
             require_once $proxyGenerator->getProxyFileName($metadata->getName());
         }
 

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -713,7 +713,7 @@ class ProxyLogicTest extends \PHPUnit\Framework\TestCase
                 return;
             }
 
-            $properties = $proxy->__getLazyProperties();
+            $properties = $proxy->__getLazyPropertiesDefaultValues();
 
             foreach ($properties as $propertyName => $property) {
                 if ( ! isset($proxy->$propertyName)) {


### PR DESCRIPTION
Added separate methods to get the list of public properties that will be lazy loaded, and to get default values these properties. Typed not nullable properties in php 7.4 have no default value.

Issue: #881 