### PR TITLE
ProxyGenerator: remove confusing name convention for simple ID getters

### DIFF
--- a/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObject.php
+++ b/tests/Doctrine/Tests/Common/Proxy/LazyLoadableObject.php
@@ -60,6 +60,14 @@ class LazyLoadableObject
     /**
      * @return string
      */
+    public function getProtectedIdentifierFieldWithDifferentName()
+    {
+        return $this->protectedIdentifierField;
+    }
+
+    /**
+     * @return string
+     */
     public function testInitializationTriggeringMethod()
     {
         return 'testInitializationTriggeringMethod';

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyLogicTest.php
@@ -112,6 +112,13 @@ class ProxyLogicTest extends \PHPUnit\Framework\TestCase
         self::assertSame('protectedIdentifierFieldValue', $this->lazyObject->getProtectedIdentifierField());
     }
 
+    public function testFetchingIdentifiersViaPublicGetterWithDifferentNameDoesNotCauseLazyLoading()
+    {
+        $this->configureInitializerMock(0);
+
+        self::assertSame('protectedIdentifierFieldValue', $this->lazyObject->getProtectedIdentifierFieldWithDifferentName());
+    }
+
     public function testCallingMethodCausesLazyLoading()
     {
         $this->configureInitializerMock(


### PR DESCRIPTION
Currently, ProxyGenerator supports generating simple ID getters (without entity hydration) in proxy class only if method name exactly matches the field name—for example: `$locationIdentifier` with `getLocationIdentifier`. This PR enables this functionality in a broader range of scenarios, e.g.

```
class Entity
{
    protected $location_id;

    public function getLocationIdentifier()
    {
        return $this->location_id;
    }
}
```

This is a very small change in the code, but I believe this would be a significant improvement. Moreover, I would consider it a **bugfix**, as this required naming convention hasn't been documented anywhere.