### PR TITLE
Update deprecations

### DIFF
--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -18,7 +18,7 @@ use const E_USER_DEPRECATED;
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
  *
- * @deprecated The ClassLoader is deprecated and will be removed in version 3.0 of doctrine/common.
+ * @deprecated The ClassLoader is deprecated and will be removed in version 4.0 of doctrine/common.
  */
 class ClassLoader
 {

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -11,8 +11,6 @@ use Doctrine\Common\Util\ClassUtils;
  * Abstract factory for proxy objects.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 abstract class AbstractProxyFactory
 {

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -9,8 +9,6 @@ use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  *
  * @internal
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class Autoloader
 {

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -10,8 +10,6 @@ use InvalidArgumentException as BaseInvalidArgumentException;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class InvalidArgumentException extends BaseInvalidArgumentException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
@@ -8,8 +8,6 @@ use OutOfBoundsException as BaseOutOfBoundsException;
  *
  * @link   www.doctrine-project.org
  * @author Fredrik Wendel <fredrik_w@users.sourceforge.net>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class OutOfBoundsException extends BaseOutOfBoundsException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/ProxyException.php
@@ -7,8 +7,6 @@ namespace Doctrine\Common\Proxy\Exception;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 interface ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -9,8 +9,6 @@ use UnexpectedValueException as BaseUnexpectedValueException;
  * @link   www.doctrine-project.org
  * @since  2.4
  * @author Marco Pivetta <ocramius@gmail.com>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class UnexpectedValueException extends BaseUnexpectedValueException implements ProxyException
 {

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -10,8 +10,6 @@ use Doctrine\Persistence\Proxy as BaseProxy;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Marco Pivetta  <ocramius@gmail.com>
  * @since  2.4
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 interface Proxy extends BaseProxy
 {

--- a/lib/Doctrine/Common/Proxy/ProxyDefinition.php
+++ b/lib/Doctrine/Common/Proxy/ProxyDefinition.php
@@ -5,8 +5,6 @@ namespace Doctrine\Common\Proxy;
  * Definition structure how to create a proxy.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class ProxyDefinition
 {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -14,8 +14,6 @@ use function method_exists;
  *
  * @author Marco Pivetta <ocramius@gmail.com>
  * @since  2.4
- *
- * @deprecated The Doctrine\Common\Proxy component is deprecated, please use ocramius/proxy-manager instead.
  */
 class ProxyGenerator
 {

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -9,8 +9,6 @@ use Doctrine\Persistence\Proxy;
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @author Johannes Schmitt <schmittjoh@gmail.com>
- *
- * @deprecated The ClassUtils class is deprecated.
  */
 class ClassUtils
 {


### PR DESCRIPTION
* Undeprecate proxy logic: since this is still in active use in ORM 2, there's no point bothering folks with deprecations. We can always revisit these deprecations once the logic has been dropped from ORM.
* Update deprecation message for ClassLoader: we missed dropping this in 3.0, so I'm updating the deprecation message to account for this.