### PR TITLE
Fixes #896: Undefined variable: name in generated Proxy

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -447,7 +447,7 @@ EOT;
             $methodParameters = $methodReflection->getParameters();
             $name             = '$' . $methodParameters[0]->getName();
 
-            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $parametersString = $this->buildParametersString($methodReflection->getParameters(), ['name']);
             $returnTypeHint   = $this->getMethodReturnType($methodReflection);
         }
 
@@ -458,7 +458,7 @@ EOT;
         $magicGet = <<<EOT
     /**
      * $inheritDoc
-     * @param string $name
+     * @param string \$name
      */
     public function {$returnReference}__get($parametersString)$returnTypeHint
     {
@@ -466,16 +466,15 @@ EOT;
 EOT;
 
         if ( ! empty($lazyPublicProperties)) {
-            $magicGet .= sprintf(<<<'EOT'
-        if (\array_key_exists(%s, self::$lazyPropertiesNames)) {
-            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [%s]);
-EOT
-                , $name, $name);
+            $magicGet .= <<<'EOT'
+        if (\array_key_exists($name, self::$lazyPropertiesNames)) {
+            $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
+EOT;
 
             if ($returnTypeHint === ': void') {
                 $magicGet .= "\n            return;";
             } else {
-                $magicGet .= "\n            return \$this->$name;";
+                $magicGet .= "\n            return \$this->\$name;";
             }
 
             $magicGet .= <<<'EOT'
@@ -487,24 +486,21 @@ EOT;
         }
 
         if ($hasParentGet) {
-            $magicGet .= sprintf(<<<'EOT'
-        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [%s]);
-EOT
-                , $name);
+            $magicGet .= <<<'EOT'
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__get', [$name]);
+EOT;
 
             if ($returnTypeHint === ': void') {
-                $magicGet .= sprintf(<<<'EOT'
+                $magicGet .= <<<'EOT'
 
-        parent::__get(%s);
+        parent::__get($name);
         return;
-EOT
-                    , $name);
+EOT;
             } else {
-                $magicGet .= sprintf(<<<'EOT'
+                $magicGet .= <<<'EOT'
 
-        return parent::__get(%s);
-EOT
-                    , $name);
+        return parent::__get($name);
+EOT;
             }
         } else {
             $magicGet .= sprintf(<<<EOT
@@ -533,7 +529,7 @@ EOT
 
         if ($hasParentSet) {
             $methodReflection = $class->getReflectionClass()->getMethod('__set');
-            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $parametersString = $this->buildParametersString($methodReflection->getParameters(), ['name', 'value']);
             $returnTypeHint   = $this->getMethodReturnType($methodReflection);
         }
 
@@ -597,7 +593,7 @@ EOT;
 
         if ($hasParentIsset) {
             $methodReflection = $class->getReflectionClass()->getMethod('__isset');
-            $parametersString = $this->buildParametersString($methodReflection->getParameters());
+            $parametersString = $this->buildParametersString($methodReflection->getParameters(), ['name']);
             $returnTypeHint   = $this->getMethodReturnType($methodReflection);
         }
 
@@ -983,15 +979,18 @@ EOT;
 
     /**
      * @param \ReflectionParameter[] $parameters
+     * @param string[]               $renameParameters
      *
      * @return string
      */
-    private function buildParametersString(array $parameters)
+    private function buildParametersString(array $parameters, $renameParameters = [])
     {
         $parameterDefinitions = [];
 
         /* @var $param \ReflectionParameter */
+        $i = -1;
         foreach ($parameters as $param) {
+            $i++;
             $parameterDefinition = '';
 
             if ($parameterType = $this->getParameterType($param)) {
@@ -1006,7 +1005,7 @@ EOT;
                 $parameterDefinition .= '...';
             }
 
-            $parameterDefinition .= '$' . $param->getName();
+            $parameterDefinition .= '$' . (isset($renameParameters[$i]) ? $renameParameters[$i] : $param->getName());
 
             if ($param->isDefaultValueAvailable()) {
                 $parameterDefinition .= ' = ' . var_export($param->getDefaultValue(), true);

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -979,7 +979,7 @@ EOT;
 
     /**
      * @param \ReflectionParameter[] $parameters
-     * @param list<string>     $renameParameters
+     * @param string[]               $renameParameters
      *
      * @return string
      */

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -979,11 +979,11 @@ EOT;
 
     /**
      * @param \ReflectionParameter[] $parameters
-     * @param array<int, string>     $renameParameters
+     * @param list<string>     $renameParameters
      *
      * @return string
      */
-    private function buildParametersString(array $parameters, $renameParameters = [])
+    private function buildParametersString(array $parameters, array $renameParameters = [])
     {
         $parameterDefinitions = [];
 
@@ -1005,7 +1005,7 @@ EOT;
                 $parameterDefinition .= '...';
             }
 
-            $parameterDefinition .= '$' . (isset($renameParameters[$i]) ? $renameParameters[$i] : $param->getName());
+            $parameterDefinition .= '$' . ($renameParameters ? $renameParameters[$i] : $param->getName());
 
             if ($param->isDefaultValueAvailable()) {
                 $parameterDefinition .= ' = ' . var_export($param->getDefaultValue(), true);

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -979,7 +979,7 @@ EOT;
 
     /**
      * @param \ReflectionParameter[] $parameters
-     * @param string[]               $renameParameters
+     * @param array<int, string>     $renameParameters
      *
      * @return string
      */

--- a/tests/Doctrine/Tests/Common/Proxy/MagicSetClassWithScalarTypeAndRenamedParameters.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicSetClassWithScalarTypeAndRenamedParameters.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class MagicSetClassWithScalarTypeAndRenamedParameters
+{
+    /**
+     * @var string
+     */
+    public $id = 'id';
+
+    /**
+     * @var string
+     */
+    public $publicField = 'publicField';
+
+    /**
+     * @var string|null
+     */
+    public $testAttribute;
+
+    /**
+     * @param string $n
+     * @param mixed  $val
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __set($n, $val)
+    {
+        if ($n === 'test') {
+            $this->testAttribute = $val;
+        }
+
+        if ($n === 'publicField' || $n === 'id') {
+            throw new \BadMethodCallException('Should never be called for "publicField" or "id"');
+        }
+
+        $this->testAttribute = $val;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -238,6 +238,35 @@ class ProxyMagicMethodsTest extends \PHPUnit\Framework\TestCase
         self::assertSame(3, $counter);
     }
 
+    public function testInheritedMagicSetWithScalarTypeAndRenamedParameters()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicSetClassWithScalarTypeAndRenamedParameters::class);
+        $proxy          = new $proxyClassName(
+            function (Proxy  $proxy, $method, $params) use (&$counter) {
+                if ( ! in_array($params[0], ['publicField', 'test', 'notDefined'])) {
+                    throw new InvalidArgumentException('Unexpected access to field "' . $params[0] . '"');
+                }
+
+                $counter += 1;
+            }
+        );
+
+        self::assertSame('id', $proxy->id);
+
+        $proxy->publicField = 'publicFieldValue';
+
+        self::assertSame('publicFieldValue', $proxy->publicField);
+
+        $proxy->test = 'testValue';
+
+        self::assertSame('testValue', $proxy->testAttribute);
+
+        $proxy->notDefined = 'not defined';
+
+        self::assertSame('not defined', $proxy->testAttribute);
+        self::assertSame(3, $counter);
+    }
+
     public function testInheritedMagicSleep()
     {
         $proxyClassName = $this->generateProxyClass(MagicSleepClass::class);


### PR DESCRIPTION
Renaming __get(), __set() and __isset() parameters is safer (due to potential conflicts with existing var names)

Related to: issue #868 and PR #869 