### PR TITLE
Remove master from website config

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,9 +5,9 @@
     "docsSlug": "doctrine-common",
     "versions": [
         {
-            "name": "master",
-            "branchName": "master",
-            "slug": "latest",
+            "name": "3.0",
+            "branchName": "3.0.x",
+            "slug": "3.0",
             "upcoming": true
         },
         {


### PR DESCRIPTION
The build failed and the doctrine/common website config is one of the reasons.