### PR TITLE
Proxies inherit return type hints from parent's __sleep and __wakeup methods

### DIFF
--- a/tests/Doctrine/Tests/Common/Proxy/MagicSleepClassTypehinted.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicSleepClassTypehinted.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class MagicSleepClassTypehinted
+{
+    /** @var string */
+    public $id = 'id';
+
+    /** @var string */
+    public $publicField = 'publicField';
+
+    /** @var string */
+    public $serializedField = 'defaultValue';
+
+    /** @var string */
+    public $nonSerializedField = 'defaultValue';
+
+    /**
+     * @return string[]
+     */
+    public function __sleep() : array
+    {
+        return ['serializedField'];
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/MagicWakeupClassTypehinted.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicWakeupClassTypehinted.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+/**
+ * Test asset class
+ */
+class MagicWakeupClassTypehinted
+{
+    /** @var string */
+    public $id = 'id';
+
+    /** @var string */
+    public $publicField = 'publicField';
+
+    /** @var string */
+    public $wakeupValue = 'defaultValue';
+
+    public function __wakeup() : void
+    {
+        $this->wakeupValue = 'newWakeupValue';
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -9,6 +9,8 @@ use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionType;
 use function class_exists;
 use function in_array;
 use function serialize;
@@ -295,11 +297,13 @@ class ProxyMagicMethodsTest extends TestCase
         $proxyReflection = new ReflectionClass($proxy);
         self::assertTrue($proxyReflection->hasMethod($sleepMethod), $sleepMethod . 'method doesn\'t exist');
 
-        $methodReflection = $proxyReflection->getMethod($sleepMethod);
+        $methodReflection     = $proxyReflection->getMethod($sleepMethod);
+        $returnTypeReflection = $methodReflection->getReturnType();
+        self::assertInstanceOf(ReflectionType::class, $returnTypeReflection, 'Got unexpected return type reflection');
         self::assertSame(
-            $methodReflection->getReturnType()->getName(),
+            $returnTypeReflection instanceof ReflectionNamedType ? $returnTypeReflection->getName() : (string) $returnTypeReflection,
             'array',
-            $sleepMethod . ' method has lost its return type hint'
+            $sleepMethod . ' method has lost return type hint'
         );
     }
 
@@ -334,9 +338,11 @@ class ProxyMagicMethodsTest extends TestCase
         $proxyReflection = new ReflectionClass($proxy);
         self::assertTrue($proxyReflection->hasMethod($wakeupMethod), $wakeupMethod . 'method doesn\'t exist');
 
-        $methodReflection = $proxyReflection->getMethod($wakeupMethod);
+        $methodReflection     = $proxyReflection->getMethod($wakeupMethod);
+        $returnTypeReflection = $methodReflection->getReturnType();
+        self::assertInstanceOf(ReflectionType::class, $returnTypeReflection, 'Got unexpected return type reflection');
         self::assertSame(
-            $methodReflection->getReturnType()->getName(),
+            $returnTypeReflection instanceof ReflectionNamedType ? $returnTypeReflection->getName() : (string) $returnTypeReflection,
             'void',
             $wakeupMethod . ' method has lost return type hint'
         );

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -285,6 +285,24 @@ class ProxyMagicMethodsTest extends TestCase
         self::assertSame('defaultValue', $unserialized->nonSerializedField, 'Field was not returned by "__sleep"');
     }
 
+    public function testInheritedMagicSleepTypehinted()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicSleepClassTypehinted::class);
+        $proxy          = new $proxyClassName();
+
+        $sleepMethod = '__sleep';
+
+        $proxyReflection = new ReflectionClass($proxy);
+        self::assertTrue($proxyReflection->hasMethod($sleepMethod), $sleepMethod . 'method doesn\'t exist');
+
+        $methodReflection = $proxyReflection->getMethod($sleepMethod);
+        self::assertSame(
+            $methodReflection->getReturnType()->getName(),
+            'array',
+            $sleepMethod . ' method has lost its return type hint'
+        );
+    }
+
     public function testInheritedMagicWakeup()
     {
         $proxyClassName = $this->generateProxyClass(MagicWakeupClass::class);
@@ -304,6 +322,24 @@ class ProxyMagicMethodsTest extends TestCase
         });
 
         self::assertSame('newPublicFieldValue', $unserialized->publicField, 'Proxy can still be initialized');
+    }
+
+    public function testInheritedMagicWakeupTypehinted()
+    {
+        $proxyClassName = $this->generateProxyClass(MagicWakeupClassTypehinted::class);
+        $proxy          = new $proxyClassName();
+
+        $wakeupMethod = '__wakeup';
+
+        $proxyReflection = new ReflectionClass($proxy);
+        self::assertTrue($proxyReflection->hasMethod($wakeupMethod), $wakeupMethod . 'method doesn\'t exist');
+
+        $methodReflection = $proxyReflection->getMethod($wakeupMethod);
+        self::assertSame(
+            $methodReflection->getReturnType()->getName(),
+            'void',
+            $wakeupMethod . ' method has lost return type hint'
+        );
     }
 
     public function testInheritedMagicIsset()


### PR DESCRIPTION
If entity's `__sleep` or `__wakeup` methods have return type hints, those hints omitted in proxy classes generated for this entity.
Which produces the error about incompatible method signature.

@alcaeus (?) confirmed that this probably should be changed, short chat about it may be found [here](https://symfony-devs.slack.com/archives/C3FQPE6LE/p1605531655079600)