### PR TITLE
Add support for union types and mixed type in ProxyGenerator

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.0"
 
     steps:
       - name: "Checkout code"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,3 +43,4 @@ jobs:
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse"
+        continue-on-error: true

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
         "doctrine/coding-standard": "^6.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^4.0.5"

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -10,6 +10,8 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
+use ReflectionType;
+use ReflectionUnionType;
 
 use function array_combine;
 use function array_diff;
@@ -1112,6 +1114,15 @@ EOT;
         ReflectionMethod $method,
         ?ReflectionParameter $parameter = null
     ) {
+        if ($type instanceof ReflectionUnionType) {
+            return implode('|', array_map(
+                function (ReflectionType $unionedType) use ($method, $parameter) {
+                    return $this->formatType($unionedType, $method, $parameter);
+                },
+                $type->getTypes()
+            ));
+        }
+
         $name      = $type->getName();
         $nameLower = strtolower($name);
 
@@ -1145,6 +1156,7 @@ EOT;
         if (
             $type->allowsNull()
             && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
+            && $name !== 'mixed'
         ) {
             $name = '?' . $name;
         }

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -7,7 +7,6 @@ use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionMethod;
-use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
 use ReflectionType;
@@ -1110,7 +1109,7 @@ EOT;
      * @return string
      */
     private function formatType(
-        ReflectionNamedType $type,
+        ReflectionType $type,
         ReflectionMethod $method,
         ?ReflectionParameter $parameter = null
     ) {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
 use ReflectionType;
@@ -1121,6 +1122,8 @@ EOT;
                 $type->getTypes()
             ));
         }
+
+        assert($type instanceof ReflectionNamedType);
 
         $name      = $type->getName();
         $nameLower = strtolower($name);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,10 +8,14 @@ parameters:
         - lib/vendor/doctrine-build-common
         - tests/Doctrine/Tests/Common/Proxy/InvalidReturnTypeClass.php
         - tests/Doctrine/Tests/Common/Proxy/InvalidTypeHintClass.php
+        - tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
+        - tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
+        - tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
+        - tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
+        - tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+        - tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php
         - tests/Doctrine/Tests/Common/Proxy/SerializedClass.php
         - tests/Doctrine/Tests/Common/Proxy/VariadicTypeHintClass.php
-        - tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php
-        - tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
         - tests/Doctrine/Tests/Common/Proxy/generated
     ignoreErrors:
         - '#Access to an undefined property Doctrine\\Common\\Proxy\\Proxy::\$publicField#'

--- a/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
+++ b/tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
@@ -1,33 +1,37 @@
 <?php
 
+if (PHP_VERSION_ID < 80000) {
+    eval(<<<'BROKEN_CODE'
 namespace Doctrine\Tests\Common\Proxy;
 
 use BadMethodCallException;
-
-/**
- * Test asset class
- */
-class MagicIssetClassWithInteger
-{
-    /** @var string */
-    public $id = 'id';
-
-    /** @var string */
-    public $publicField = 'publicField';
-
     /**
-     * @throws BadMethodCallException
+     * Test asset class
      */
-    public function __isset(string $name) : int
+    class MagicIssetClassWithInteger
     {
-        if ($name === 'test') {
-            return 1;
-        }
+        /** @var string */
+        public $id = 'id';
 
-        if ($name === 'publicField' || $name === 'id') {
-            throw new BadMethodCallException('Should never be called for "publicField" or "id"');
-        }
+        /** @var string */
+        public $publicField = 'publicField';
 
-        return 0;
+        /**
+         * @throws BadMethodCallException
+         */
+        public function __isset(string $name) : int
+        {
+            if ($name === 'test') {
+                return 1;
+            }
+
+            if ($name === 'publicField' || $name === 'id') {
+                throw new BadMethodCallException('Should never be called for "publicField" or "id"');
+            }
+
+            return 0;
+        }
     }
+BROKEN_CODE
+    );
 }

--- a/tests/Doctrine/Tests/Common/Proxy/Php8MixedType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php8MixedType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class Php8MixedType
+{
+    public function foo(mixed $bar) : mixed
+    {
+        return 1;
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use stdClass;
+
+class Php8UnionTypes
+{
+    public string|int $foo;
+
+    public function setValue(stdClass|array $value) : bool|float
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -17,6 +17,8 @@ use function file_get_contents;
 use function is_subclass_of;
 use function substr_count;
 
+use const PHP_VERSION_ID;
+
 /**
  * Test the proxy generator. Its work is generating on-the-fly subclasses of a given model, which implement the Proxy
  * pattern.
@@ -401,6 +403,48 @@ class ProxyGeneratorTest extends TestCase
 
         $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
         $proxyGenerator->generateProxyClass($this->createClassMetadata(FinalClass::class, []));
+    }
+
+    public function testPhp8UnionTypes()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Requires PHP 8.0');
+        }
+
+        $className = Php8UnionTypes::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8UnionTypes', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            'setValue(\stdClass|array $value): float|bool',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8UnionTypes.php')
+        );
+    }
+
+    public function testPhp8MixedType()
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this->markTestSkipped('Requires PHP 8.0');
+        }
+
+        $className = Php8MixedType::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8MixedType', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            'foo(mixed $bar): mixed',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8MixedType.php'),
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -405,12 +405,11 @@ class ProxyGeneratorTest extends TestCase
         $proxyGenerator->generateProxyClass($this->createClassMetadata(FinalClass::class, []));
     }
 
+    /**
+     * @requires PHP >= 8.0.0
+     */
     public function testPhp8UnionTypes()
     {
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('Requires PHP 8.0');
-        }
-
         $className = Php8UnionTypes::class;
 
         if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8UnionTypes', false)) {
@@ -426,12 +425,11 @@ class ProxyGeneratorTest extends TestCase
         );
     }
 
+    /**
+     * @requires PHP >= 8.0.0
+     */
     public function testPhp8MixedType()
     {
-        if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('Requires PHP 8.0');
-        }
-
         $className = Php8MixedType::class;
 
         if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8MixedType', false)) {

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -443,7 +443,7 @@ class ProxyGeneratorTest extends TestCase
 
         self::assertStringContainsString(
             'foo(mixed $bar): mixed',
-            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8MixedType.php'),
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8MixedType.php')
         );
     }
 


### PR DESCRIPTION
Adds support for generating proxies for classes using the following new PHP 8 syntax constructs:

- Union Types
- Mixed type