### PR TITLE
Update doctrine/coding-standard to 6.0|8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^7.5.20 || ^8.0 || ^9.0",
-        "doctrine/coding-standard": "^6.0",
+        "doctrine/coding-standard": "^6.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.0",
         "symfony/phpunit-bridge": "^4.0.5"
     },

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -255,11 +255,8 @@ class ClassLoader
             }
 
             $classLoader = reset($loader);
-            if (
-                $classLoader
-                && $classLoader instanceof ClassLoader
-                && $classLoader->canLoadClass($className)
-            ) {
+
+            if ($classLoader instanceof ClassLoader && $classLoader->canLoadClass($className)) {
                 return $classLoader;
             }
         }

--- a/lib/Doctrine/Common/ClassLoader.php
+++ b/lib/Doctrine/Common/ClassLoader.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Common;
 
-use const DIRECTORY_SEPARATOR;
-use const E_USER_DEPRECATED;
 use function class_exists;
 use function interface_exists;
 use function is_array;
@@ -17,6 +15,9 @@ use function stream_resolve_include_path;
 use function strpos;
 use function trait_exists;
 use function trigger_error;
+
+use const DIRECTORY_SEPARATOR;
+use const E_USER_DEPRECATED;
 
 @trigger_error(ClassLoader::class . ' is deprecated.', E_USER_DEPRECATED);
 
@@ -254,9 +255,10 @@ class ClassLoader
             }
 
             $classLoader = reset($loader);
-            if ($classLoader
-               && $classLoader instanceof ClassLoader
-               && $classLoader->canLoadClass($className)
+            if (
+                $classLoader
+                && $classLoader instanceof ClassLoader
+                && $classLoader->canLoadClass($className)
             ) {
                 return $classLoader;
             }

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Proxy\Exception\OutOfBoundsException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+
 use function class_exists;
 use function file_exists;
 use function in_array;
@@ -188,6 +189,7 @@ abstract class AbstractProxyFactory
                     if (! file_exists($fileName)) {
                         $this->proxyGenerator->generateProxyClass($classMetadata, $fileName);
                     }
+
                     require $fileName;
                     break;
 

--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -86,8 +86,8 @@ abstract class AbstractProxyFactory
      * Gets a reference proxy instance for the entity of the given type and identified by
      * the given identifier.
      *
-     * @param  string  $className
-     * @param  mixed[] $identifier
+     * @param  string       $className
+     * @param  array<mixed> $identifier
      *
      * @return Proxy
      *

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -4,7 +4,7 @@ namespace Doctrine\Common\Proxy;
 
 use Closure;
 use Doctrine\Common\Proxy\Exception\InvalidArgumentException;
-use const DIRECTORY_SEPARATOR;
+
 use function call_user_func;
 use function file_exists;
 use function is_callable;
@@ -14,6 +14,8 @@ use function str_replace;
 use function strlen;
 use function strpos;
 use function substr;
+
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Special Autoloader for Proxy classes, which are not PSR-0 compliant.

--- a/lib/Doctrine/Common/Proxy/Autoloader.php
+++ b/lib/Doctrine/Common/Proxy/Autoloader.php
@@ -19,6 +19,8 @@ use const DIRECTORY_SEPARATOR;
 
 /**
  * Special Autoloader for Proxy classes, which are not PSR-0 compliant.
+ *
+ * @internal
  */
 class Autoloader
 {

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -4,6 +4,7 @@ namespace Doctrine\Common\Proxy\Exception;
 
 use Doctrine\Persistence\Proxy;
 use InvalidArgumentException as BaseInvalidArgumentException;
+
 use function get_class;
 use function gettype;
 use function interface_exists;
@@ -97,7 +98,7 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
     /**
      * @param mixed $value
      */
-    public static function invalidAutoGenerateMode($value) : self
+    public static function invalidAutoGenerateMode($value): self
     {
         return new self(sprintf('Invalid auto generate mode "%s" given.', $value));
     }

--- a/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/OutOfBoundsException.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Common\Proxy\Exception;
 
 use OutOfBoundsException as BaseOutOfBoundsException;
+
 use function sprintf;
 
 /**

--- a/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/UnexpectedValueException.php
@@ -4,6 +4,7 @@ namespace Doctrine\Common\Proxy\Exception;
 
 use Throwable;
 use UnexpectedValueException as BaseUnexpectedValueException;
+
 use function sprintf;
 
 /**

--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -58,8 +58,8 @@ interface Proxy extends BaseProxy
     /**
      * Retrieves the list of lazy loaded properties for a given proxy
      *
-     * @return array<string,mixed> Keys are the property names, and values are
-     *                             the default values for those properties.
+     * @return array<string, mixed> Keys are the property names, and values are the default values
+     *                              for those properties.
      */
     public function __getLazyProperties();
 }

--- a/lib/Doctrine/Common/Proxy/ProxyDefinition.php
+++ b/lib/Doctrine/Common/Proxy/ProxyDefinition.php
@@ -12,7 +12,7 @@ class ProxyDefinition
     /** @var string */
     public $proxyClassName;
 
-    /** @var mixed[] */
+    /** @var array<string> */
     public $identifierFields;
 
     /** @var ReflectionProperty[] */
@@ -25,11 +25,11 @@ class ProxyDefinition
     public $cloner;
 
     /**
-     * @param string   $proxyClassName
-     * @param mixed[]  $identifierFields
-     * @param mixed[]  $reflectionFields
-     * @param callable $initializer
-     * @param callable $cloner
+     * @param string                            $proxyClassName
+     * @param array<string>                     $identifierFields
+     * @param array<string, ReflectionProperty> $reflectionFields
+     * @param callable                          $initializer
+     * @param callable                          $cloner
      */
     public function __construct($proxyClassName, array $identifierFields, array $reflectionFields, $initializer, $cloner)
     {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -7,9 +7,9 @@ use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionMethod;
-use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
+use ReflectionType;
 
 use function array_combine;
 use function array_diff;
@@ -693,7 +693,7 @@ EOT;
 
         $allProperties = ['__isInitialized__'];
 
-        foreach ($reflectionClass->getProperties() as $prop) {
+        foreach ($class->getReflectionClass()->getProperties() as $prop) {
             assert($prop instanceof ReflectionProperty);
             if ($prop->isStatic()) {
                 continue;
@@ -999,13 +999,14 @@ EOT;
     {
         $parameterDefinitions = [];
 
+        /** @var ReflectionParameter $param */
         $i = -1;
         foreach ($parameters as $param) {
             $i++;
             $parameterDefinition = '';
+            $parameterType       = $this->getParameterType($param);
 
-            $parameterType = $this->getParameterType($param);
-            if ($parameterType) {
+            if ($parameterType !== null) {
                 $parameterDefinition .= $parameterType . ' ';
             }
 
@@ -1107,7 +1108,7 @@ EOT;
      * @return string
      */
     private function formatType(
-        ReflectionNamedType $type,
+        ReflectionType $type,
         ReflectionMethod $method,
         ?ReflectionParameter $parameter = null
     ) {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -10,12 +10,13 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
-use const DIRECTORY_SEPARATOR;
+
 use function array_combine;
 use function array_diff;
 use function array_key_exists;
 use function array_map;
 use function array_slice;
+use function assert;
 use function call_user_func;
 use function chmod;
 use function class_exists;
@@ -47,6 +48,8 @@ use function substr;
 use function trim;
 use function uniqid;
 use function var_export;
+
+use const DIRECTORY_SEPARATOR;
 
 /**
  * This factory is used to generate proxy classes.
@@ -425,7 +428,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
 
 EOT;
 
-        $toUnset = array_map(static function (string $name) : string {
+        $toUnset = array_map(static function (string $name): string {
             return '$this->' . $name;
         }, $this->getLazyLoadedPublicPropertiesNames($class));
 
@@ -690,8 +693,8 @@ EOT;
 
         $allProperties = ['__isInitialized__'];
 
-        /** @var ReflectionProperty $prop */
         foreach ($reflectionClass->getProperties() as $prop) {
+            assert($prop instanceof ReflectionProperty);
             if ($prop->isStatic()) {
                 continue;
             }
@@ -825,7 +828,8 @@ EOT;
         foreach ($reflectionMethods as $method) {
             $name = $method->getName();
 
-            if ($method->isConstructor() ||
+            if (
+                $method->isConstructor() ||
                 isset($skippedMethods[strtolower($name)]) ||
                 isset($methodNames[$name]) ||
                 $method->isFinal() ||
@@ -916,7 +920,7 @@ EOT;
             && substr($method->getName(), 0, 3) === 'get'
             && in_array($identifier, $class->getIdentifier(), true)
             && $class->hasField($identifier)
-            && (($endLine - $startLine) <= 4);
+            && ($endLine - $startLine <= 4);
 
         if ($cheapCheck) {
             $code = file($method->getFileName());
@@ -937,7 +941,7 @@ EOT;
      *
      * @return array<int, string>
      */
-    private function getLazyLoadedPublicPropertiesNames(ClassMetadata $class) : array
+    private function getLazyLoadedPublicPropertiesNames(ClassMetadata $class): array
     {
         $properties = [];
 
@@ -1137,7 +1141,8 @@ EOT;
             $name = '\\' . $name;
         }
 
-        if ($type->allowsNull()
+        if (
+            $type->allowsNull()
             && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
         ) {
             $name = '?' . $name;

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -7,9 +7,9 @@ use Doctrine\Common\Proxy\Exception\UnexpectedValueException;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty;
-use ReflectionType;
 
 use function array_combine;
 use function array_diff;
@@ -999,9 +999,9 @@ EOT;
     {
         $parameterDefinitions = [];
 
-        /** @var ReflectionParameter $param */
         $i = -1;
         foreach ($parameters as $param) {
+            assert($param instanceof ReflectionParameter);
             $i++;
             $parameterDefinition = '';
             $parameterType       = $this->getParameterType($param);
@@ -1108,7 +1108,7 @@ EOT;
      * @return string
      */
     private function formatType(
-        ReflectionType $type,
+        ReflectionNamedType $type,
         ReflectionMethod $method,
         ?ReflectionParameter $parameter = null
     ) {

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -28,6 +28,7 @@ class ClassUtils
     public static function getRealClass($class)
     {
         $pos = strrpos($class, '\\' . Proxy::MARKER . '\\');
+
         if ($pos === false) {
             return $class;
         }

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -4,6 +4,7 @@ namespace Doctrine\Common\Util;
 
 use Doctrine\Persistence\Proxy;
 use ReflectionClass;
+
 use function get_class;
 use function get_parent_class;
 use function ltrim;

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Persistence\Proxy;
 use stdClass;
+
 use function array_keys;
 use function count;
 use function end;
@@ -163,6 +164,7 @@ final class Debug
             if ($aux[0] === '') {
                 $name .= ':' . ($aux[1] === '*' ? 'protected' : $aux[1] . ':private');
             }
+
             $return->$name = self::export($clone[$key], $maxDepth - 1);
         }
 

--- a/lib/Doctrine/Common/Util/Debug.php
+++ b/lib/Doctrine/Common/Util/Debug.php
@@ -61,7 +61,7 @@ final class Debug
         $html = ini_get('html_errors');
 
         if ($html !== true) {
-            ini_set('html_errors', true);
+            ini_set('html_errors', 'on');
         }
 
         if (extension_loaded('xdebug')) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,20 +6,42 @@
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors" />
 
+    <config name="php_version" value="70100"/>
+
     <!-- Ignore warnings and show progress of the run -->
     <arg value="np"/>
 
     <file>lib</file>
     <file>tests</file>
 
-    <exclude-pattern>*/tests/Doctrine/Tests/Common/Proxy/generated/*</exclude-pattern>
+    <exclude-pattern>tests/Doctrine/Tests/Common/Proxy/*</exclude-pattern>
+    <exclude-pattern>tests/Doctrine/Tests/Common/ClassLoaderTest/*</exclude-pattern>
+    <exclude-pattern>tests/Doctrine/Tests/Common/Util/TestAsset/*</exclude-pattern>
 
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+    </rule>
+
+    <!-- Disable the rules that will require PHP 7.4 -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
+    </rule>
+
+
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
+        <exclude-pattern>lib/Doctrine/Common/Proxy/ProxyGenerator.php</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>*/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php</exclude-pattern>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -35,7 +35,6 @@
         </properties>
     </rule>
 
-
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
         <exclude-pattern>lib/Doctrine/Common/Proxy/ProxyGenerator.php</exclude-pattern>
     </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -26,6 +26,7 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+        <exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
     </rule>
 
     <!-- Disable the rules that will require PHP 7.4 -->

--- a/tests/Doctrine/Tests/Common/ClassLoaderTest.php
+++ b/tests/Doctrine/Tests/Common/ClassLoaderTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\Common;
 use ClassLoaderTest\ExternalLoader;
 use Doctrine\Common\ClassLoader;
 use Doctrine\Tests\DoctrineTestCase;
+
 use function interface_exists;
 use function spl_autoload_register;
 use function spl_autoload_unregister;

--- a/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
+++ b/tests/Doctrine/Tests/Common/Util/ClassUtilsTest.php
@@ -9,6 +9,9 @@ namespace Doctrine\Tests\Common\Util
 
     class ClassUtilsTest extends DoctrineTestCase
     {
+        /**
+         * @psalm-return list<array{class-string, class-string}>
+         */
         public static function dataGetClass()
         {
             return [
@@ -23,7 +26,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testGetRealClass($className, $expectedClassName)
+        public function testGetRealClass(string $className, string $expectedClassName): void
         {
             self::assertEquals($expectedClassName, ClassUtils::getRealClass($className));
         }
@@ -31,19 +34,19 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testGetClass($className, $expectedClassName)
+        public function testGetClass(string $className, string $expectedClassName): void
         {
             $object = new $className();
             self::assertEquals($expectedClassName, ClassUtils::getClass($object));
         }
 
-        public function testGetParentClass()
+        public function testGetParentClass(): void
         {
             $parentClass = ClassUtils::getParentClass('MyProject\Proxies\__CG__\OtherProject\Proxies\__CG__\Doctrine\Tests\Common\Util\ChildObject');
             self::assertEquals('stdClass', $parentClass);
         }
 
-        public function testGenerateProxyClassName()
+        public function testGenerateProxyClassName(): void
         {
             self::assertEquals('Proxies\__CG__\stdClass', ClassUtils::generateProxyClassName('stdClass', 'Proxies'));
         }
@@ -51,7 +54,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testNewReflectionClass($className, $expectedClassName)
+        public function testNewReflectionClass(string $className, string $expectedClassName): void
         {
             $reflClass = ClassUtils::newReflectionClass($className);
             self::assertEquals($expectedClassName, $reflClass->getName());
@@ -60,7 +63,7 @@ namespace Doctrine\Tests\Common\Util
         /**
          * @dataProvider dataGetClass
          */
-        public function testNewReflectionObject($className, $expectedClassName)
+        public function testNewReflectionObject(string $className, string $expectedClassName): void
         {
             $object    = new $className();
             $reflClass = ClassUtils::newReflectionObject($object);

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -139,6 +139,9 @@ class DebugTest extends DoctrineTestCase
         self::assertSame($expected, $var);
     }
 
+    /**
+     * @psalm-return array<string, array{TestAsset\ParentClass, mixed[]}>
+     */
     public function provideAttributesCases()
     {
         return [

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -10,6 +10,7 @@ use DateTimeZone;
 use Doctrine\Common\Util\Debug;
 use Doctrine\Tests\DoctrineTestCase;
 use stdClass;
+
 use function ob_end_clean;
 use function ob_get_contents;
 use function ob_start;

--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -2,16 +2,18 @@
 /*
  * This file bootstraps the test environment.
  */
+
 namespace Doctrine\Tests;
 
-use const E_ALL;
-use const E_STRICT;
 use function error_reporting;
 use function is_file;
 use function is_readable;
 use function spl_autoload_register;
 use function strpos;
 use function strtr;
+
+use const E_ALL;
+use const E_STRICT;
 
 error_reporting(E_ALL | E_STRICT);
 


### PR DESCRIPTION
This upgrades the coding-standard and fixes all the new violations to pass it.

Add exclusions for coding styles to all of the test dummy classes needed for proxy as their changes would break tests.