### PR TITLE
Better PHP8 type handling

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1112,13 +1112,12 @@ EOT;
     private function formatType(
         ReflectionType $type,
         ReflectionMethod $method,
-        ?ReflectionParameter $parameter = null,
-        bool $isUnionPart = false
+        ?ReflectionParameter $parameter = null
     ) {
         if ($type instanceof ReflectionUnionType) {
             return implode('|', array_map(
                 function (ReflectionType $unionedType) use ($method, $parameter) {
-                    return $this->formatType($unionedType, $method, $parameter, true);
+                    return $this->formatType($unionedType, $method, $parameter);
                 },
                 $type->getTypes()
             ));
@@ -1161,10 +1160,9 @@ EOT;
         }
 
         if (
-            ! $isUnionPart
-            && $type->allowsNull()
+            $type->allowsNull()
+            && ! in_array($name, ['mixed', 'null'], true)
             && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
-            && $name !== 'mixed'
         ) {
             $name = '?' . $name;
         }

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1112,12 +1112,13 @@ EOT;
     private function formatType(
         ReflectionType $type,
         ReflectionMethod $method,
-        ?ReflectionParameter $parameter = null
+        ?ReflectionParameter $parameter = null,
+	    bool $isUnionPart = false
     ) {
         if ($type instanceof ReflectionUnionType) {
             return implode('|', array_map(
                 function (ReflectionType $unionedType) use ($method, $parameter) {
-                    return $this->formatType($unionedType, $method, $parameter);
+                    return $this->formatType($unionedType, $method, $parameter, true);
                 },
                 $type->getTypes()
             ));
@@ -1156,7 +1157,8 @@ EOT;
         }
 
         if (
-            $type->allowsNull()
+        	!$isUnionPart
+            && $type->allowsNull()
             && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
             && $name !== 'mixed'
         ) {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1129,6 +1129,10 @@ EOT;
         $name      = $type->getName();
         $nameLower = strtolower($name);
 
+        if ($nameLower === 'static') {
+        	$name = 'static';
+        }
+
         if ($nameLower === 'self') {
             $name = $method->getDeclaringClass()->getName();
         }
@@ -1137,7 +1141,7 @@ EOT;
             $name = $method->getDeclaringClass()->getParentClass()->getName();
         }
 
-        if (! $type->isBuiltin() && ! class_exists($name) && ! interface_exists($name)) {
+        if (! $type->isBuiltin() && ! class_exists($name) && ! interface_exists($name) && $name !== 'static') {
             if ($parameter !== null) {
                 throw UnexpectedValueException::invalidParameterTypeHint(
                     $method->getDeclaringClass()->getName(),
@@ -1152,7 +1156,7 @@ EOT;
             );
         }
 
-        if (! $type->isBuiltin()) {
+        if (! $type->isBuiltin() && $name !== 'static') {
             $name = '\\' . $name;
         }
 

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1113,7 +1113,7 @@ EOT;
         ReflectionType $type,
         ReflectionMethod $method,
         ?ReflectionParameter $parameter = null,
-	    bool $isUnionPart = false
+        bool $isUnionPart = false
     ) {
         if ($type instanceof ReflectionUnionType) {
             return implode('|', array_map(
@@ -1130,7 +1130,7 @@ EOT;
         $nameLower = strtolower($name);
 
         if ($nameLower === 'static') {
-        	$name = 'static';
+            $name = 'static';
         }
 
         if ($nameLower === 'self') {
@@ -1161,7 +1161,7 @@ EOT;
         }
 
         if (
-        	!$isUnionPart
+            ! $isUnionPart
             && $type->allowsNull()
             && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
             && $name !== 'mixed'

--- a/tests/Doctrine/Tests/Common/Proxy/Php8StaticType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php8StaticType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class Php8StaticType
+{
+    public function foo(mixed $bar) : static
+    {
+        return $this;
+    }
+
+	public function fooNull(mixed $bar) : ?static
+	{
+		return $this;
+	}
+}

--- a/tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
@@ -8,7 +8,14 @@ class Php8UnionTypes
 {
     public string|int $foo;
 
+    public string|int|null $bar;
+
     public function setValue(stdClass|array $value) : bool|float
     {
     }
+
+    public function setNullableValue(stdClass|array|null $value) : bool|float|null
+    {
+    }
+
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -423,6 +423,11 @@ class ProxyGeneratorTest extends TestCase
             'setValue(\stdClass|array $value): float|bool',
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8UnionTypes.php')
         );
+
+        self::assertStringContainsString(
+            'setNullableValue(\stdClass|array|null $value): float|bool|null',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8UnionTypes.php')
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -451,6 +451,31 @@ class ProxyGeneratorTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 8.0.0
+     */
+    public function testPhp8StaticType()
+    {
+        $className = Php8StaticType::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8StaticType', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            'foo(mixed $bar): static',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8StaticType.php')
+        );
+
+        self::assertStringContainsString(
+            'fooNull(mixed $bar): ?static',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8StaticType.php')
+        );
+    }
+
+    /**
      * @param string  $className
      * @param mixed[] $ids
      *


### PR DESCRIPTION
I've found two type declaration related problems in proxy generator, when using it with PHP8.

First is the usage of static keyword, which should be "copied" to the proxy class, and also can be nullable.
`function setId(int $id): ?static`
This is supported in this pull request.

Second is a fix for union types of PHP8, because in case of nullable union types the '?' sign is nut supported. It should be used in this way:
`float|int|null`
But the proxy generator prepended the '?' to the null part of the union type:
`float|int|?null`
This problem has been fixed with an optional argument in case of recursive call of formatType function.
