### PR TITLE
Fix #922, ProxyGenerator missing assert

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1041,7 +1041,11 @@ EOT;
             return null;
         }
 
-        return $this->formatType($parameter->getType(), $parameter->getDeclaringFunction(), $parameter);
+        $declaringFunction = $parameter->getDeclaringFunction();
+
+        assert($declaringFunction instanceof ReflectionMethod);
+
+        return $this->formatType($parameter->getType(), $declaringFunction, $parameter);
     }
 
     /**


### PR DESCRIPTION
> Upon suggestion I've copied this description from the Ticket.

Hello everyone,

while working on #917 I noticed a missing `assert()` in the method `getParameterType()` of the `ProxyGenerator`.

The [`ReflectionParameter::getDeclaringFunction()`](https://www.php.net/manual/en/reflectionparameter.getdeclaringfunction.php) method returns a [`ReflectionFunctionAbstract`](https://www.php.net/manual/en/class.reflectionfunctionabstract.php), the type hint of `ProxyGenerator::formatType(...)` is [`ReflectionMethod`](https://www.php.net/manual/en/class.reflectionmethod.php), one of two possible implementations, the other is [`ReflectionFunction`](https://www.php.net/manual/en/class.reflectionfunction.php).

```php
    /**
     * @return string|null
     */
    private function getParameterType(ReflectionParameter $parameter)
    {
        if (! $parameter->hasType()) {
            return null;
        }

        return $this->formatType($parameter->getType(), $parameter->getDeclaringFunction(), $parameter);
    }
```

I'd propose a change from the above code to the code below:

```php
    /**
     * @return string|null
     */
    private function getParameterType(ReflectionParameter $parameter)
    {
        if (! $parameter->hasType()) {
            return null;
        }

        $declaringFunction = $parameter->getDeclaringFunction();

        assert($declaringFunction instanceof ReflectionMethod);

        return $this->formatType($parameter->getType(), $declaringFunction, $parameter);
    }
```

[3v4l.org snippet](https://3v4l.org/l97hT)

Of course the assertion will always be true, but this theoretical type mismatch was pointed out by my IDE, which confused me at first. In my opinion this would make the code more clean and prevent any future confusion about what type is expected.
