### PR TITLE
Add generics to ClassUtils::getClass

### DIFF
--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -25,8 +25,9 @@ class ClassUtils
      *
      * @return string
      *
-     * @psalm-param class-string $className
-     * @psalm-return class-string
+     * @template T of object
+     * @psalm-param class-string<T> $className
+     * @psalm-return class-string<T>
      */
     public static function getRealClass($className)
     {
@@ -46,7 +47,9 @@ class ClassUtils
      *
      * @return string
      *
-     * @psalm-return class-string
+     * @template T of object
+     * @psalm-param T $object
+     * @psalm-return class-string<T>
      */
     public static function getClass($object)
     {


### PR DESCRIPTION
This PR tries to add generics to `ClassUtils::getClass` and `ClassUtils::getRealClass`, but what I'm not really sure is if this is strictly right since calling this method using a proxy instance, it won't return the `class-string` of the proxy but the real class.

Calling it with an instance of: `MyProxy\Subdir\__CG__\RealClass` would return `RealClass`.