### PR TITLE
Fixed doctrine/persistence dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/persistence": "^2.0"
+        "doctrine/persistence": "^3.0@dev"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
`doctrine/persistence` dependency has been updated to `3.0@dev` version for `3.0.x` branch.

That problem leads to 

```
 Your lock file does not contain a compatible set of packages. Please run composer update.
 
   Problem 1
     - doctrine/common is locked to version 3.0.2 and an update of this package was not requested.
     - doctrine/common 3.0.2 requires doctrine/persistence ^2.0 -> found doctrine/persistence[3.0.x-dev] but it does not match the constraint.
```

while installing dependency for doctrine/persistence