### PR TITLE
Add generics to ClassUtils::getClass

### DIFF
--- a/lib/Doctrine/Common/Proxy/Proxy.php
+++ b/lib/Doctrine/Common/Proxy/Proxy.php
@@ -7,6 +7,9 @@ use Doctrine\Persistence\Proxy as BaseProxy;
 
 /**
  * Interface for proxy classes.
+ *
+ * @template T of object
+ * @template-extends BaseProxy<T>
  */
 interface Proxy extends BaseProxy
 {

--- a/lib/Doctrine/Common/Util/ClassUtils.php
+++ b/lib/Doctrine/Common/Util/ClassUtils.php
@@ -25,14 +25,16 @@ class ClassUtils
      *
      * @return string
      *
-     * @psalm-param class-string $className
-     * @psalm-return class-string
+     * @template T of object
+     * @psalm-param class-string<Proxy<T>>|class-string<T> $className
+     * @psalm-return class-string<T>
      */
     public static function getRealClass($className)
     {
         $pos = strrpos($className, '\\' . Proxy::MARKER . '\\');
 
         if ($pos === false) {
+            /** @psalm-var class-string<T> */
             return $className;
         }
 
@@ -46,7 +48,9 @@ class ClassUtils
      *
      * @return string
      *
-     * @psalm-return class-string
+     * @template T of object
+     * @psalm-param Proxy<T>|T $object
+     * @psalm-return class-string<T>
      */
     public static function getClass($object)
     {


### PR DESCRIPTION
Ref: https://github.com/doctrine/common/pull/926

There has been a release of [`doctrine/persistence`](https://github.com/doctrine/persistence): `2.2`, in that version `Proxy` interface is generic.