### PR TITLE
ProxyFactory > Add `FILE_NOT_EXISTS_OR_CHANGED` mode

### DIFF
--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -31,6 +31,7 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
             [1, 1],
             [2, 2],
             [3, 3],
+            [4, 4],
             ['2', 2],
             [true, 1],
             [false, 0],
@@ -214,6 +215,167 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         $this->expectException(OutOfBoundsException::class);
 
         $proxyFactory->getProxy('Class', []);
+    }
+
+    public function testGetProxyFileWhenProxyDoesNotExist() : void
+    {
+        $proxyFile = tempnam(sys_get_temp_dir(), 'proxy');
+        unlink($proxyFile);
+
+        $metadata        = $this->createMock(ClassMetadata::class);
+        $definition      = new ProxyDefinition('MyObject1', [], [], null, null);
+        $proxyGenerator  = $this->createMock(ProxyGenerator::class);
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->willReturn($metadata);
+
+        $metadata
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('MyObject1');
+
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('getProxyFileName')
+            ->willReturn($proxyFile);
+
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('generateProxyClass')
+            ->willReturnCallback(function() use ($proxyFile) {
+                file_put_contents($proxyFile, '<?php class MyObject1 {} ');
+            });
+
+        /** @var MockObject&AbstractProxyFactory $proxyFactory */
+        $proxyFactory = $this->getMockForAbstractClass(
+            AbstractProxyFactory::class,
+            [$proxyGenerator, $metadataFactory, AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED]
+        );
+
+        $proxyFactory
+            ->method('createProxyDefinition')
+            ->willReturn($definition);
+
+        $generatedProxy = $proxyFactory->getProxy('Class', ['id' => 1]);
+
+        self::assertInstanceOf('MyObject1', $generatedProxy);
+    }
+
+    public function testGetProxyFileWhenProxyIsOlderThanSource() : void
+    {
+        $proxyFile = tempnam(sys_get_temp_dir(), 'proxy');
+        file_put_contents($proxyFile, '<?php class MyObject2 {} ');
+        sleep(1);
+        $sourceFile = tempnam(sys_get_temp_dir(), 'source');
+
+        $metadata        = $this->createMock(ClassMetadata::class);
+        $definition      = new ProxyDefinition('MyObject2', [], [], null, null);
+        $proxyGenerator  = $this->createMock(ProxyGenerator::class);
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $reflection      = $this->createMock(ReflectionClass::class);
+
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->willReturn($metadata);
+
+        $metadata
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('MyObject2');
+
+        $metadata
+            ->expects($this->once())
+            ->method('getReflectionClass')
+            ->willReturn($reflection);
+
+        $reflection
+            ->expects($this->once())
+            ->method('getFileName')
+            ->willReturn($sourceFile);
+
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('getProxyFileName')
+            ->willReturn($proxyFile);
+
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('generateProxyClass');
+
+        /** @var MockObject&AbstractProxyFactory $proxyFactory */
+        $proxyFactory = $this->getMockForAbstractClass(
+            AbstractProxyFactory::class,
+            [$proxyGenerator, $metadataFactory, AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED]
+        );
+
+        $proxyFactory
+            ->method('createProxyDefinition')
+            ->willReturn($definition);
+
+        $generatedProxy = $proxyFactory->getProxy('Class', ['id' => 1]);
+
+        self::assertInstanceOf('MyObject2', $generatedProxy);
+    }
+
+    public function testGetProxyFileWhenProxyIsNewerThanSource() : void
+    {
+        $sourceFile = tempnam(sys_get_temp_dir(), 'source');
+        sleep(1);
+        $proxyFile = tempnam(sys_get_temp_dir(), 'proxy');
+        file_put_contents($proxyFile, '<?php class MyObject3 {} ');
+
+        $metadata        = $this->createMock(ClassMetadata::class);
+        $definition      = new ProxyDefinition('MyObject3', [], [], null, null);
+        $proxyGenerator  = $this->createMock(ProxyGenerator::class);
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $reflection      = $this->createMock(ReflectionClass::class);
+
+        $metadataFactory
+            ->expects($this->once())
+            ->method('getMetadataFor')
+            ->willReturn($metadata);
+
+        $metadata
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('MyObject3');
+
+        $metadata
+            ->expects($this->once())
+            ->method('getReflectionClass')
+            ->willReturn($reflection);
+
+        $reflection
+            ->expects($this->once())
+            ->method('getFileName')
+            ->willReturn($sourceFile);
+
+        $proxyGenerator
+            ->expects($this->once())
+            ->method('getProxyFileName')
+            ->willReturn($proxyFile);
+
+        $proxyGenerator
+            ->expects($this->never())
+            ->method('generateProxyClass');
+
+        /** @var MockObject&AbstractProxyFactory $proxyFactory */
+        $proxyFactory = $this->getMockForAbstractClass(
+            AbstractProxyFactory::class,
+            [$proxyGenerator, $metadataFactory, AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS_OR_CHANGED]
+        );
+
+        $proxyFactory
+            ->method('createProxyDefinition')
+            ->willReturn($definition);
+
+        $generatedProxy = $proxyFactory->getProxy('Class', ['id' => 1]);
+
+        self::assertInstanceOf('MyObject3', $generatedProxy);
     }
 }
 


### PR DESCRIPTION
We have a fairly large Symfony application with ±230 entities.

While profiling for performance bottlenecks in development I noticed that proxies were always
regenerated. This was due the fact that we run the application in debug mode and by default, the
DoctrineBundle chooses `AUTOGENERATE_ALWAYS` when run in debug mode.

After changing the value to `AUTOGENERATE_FILE_NOT_EXISTS` I was able to shave of 37ms of a single
query. Great!

But this has a big drawback. Whenever we make changes to the proxied entity, the proxy is never
updated anymore.

To solve this, I think it makes sense to look at the file modification times of both the proxy and
the proxied entity.

When the proxied entity is newer than the proxy, it should regenerate the proxy.

<img width="942" alt="Screenshot 2021-10-13 at 09 29 46@2x" src="https://user-images.githubusercontent.com/104180/137087384-f8f89a09-ff97-42f4-b82b-73bd7225078e.png">

## Todo

- [ ] When this is merged, add support to DoctrineBundle 