### PR TITLE
Remove autoload calls 

### DIFF
--- a/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
+++ b/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php
@@ -11,7 +11,6 @@ use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use function class_exists;
 use function file_exists;
 use function in_array;
-use function interface_exists;
 
 /**
  * Abstract factory for proxy objects.
@@ -225,6 +224,3 @@ abstract class AbstractProxyFactory
      */
     abstract protected function createProxyDefinition($className);
 }
-
-interface_exists(ClassMetadata::class);
-interface_exists(ClassMetadataFactory::class);

--- a/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
+++ b/lib/Doctrine/Common/Proxy/Exception/InvalidArgumentException.php
@@ -7,7 +7,6 @@ use InvalidArgumentException as BaseInvalidArgumentException;
 
 use function get_class;
 use function gettype;
-use function interface_exists;
 use function is_object;
 use function sprintf;
 
@@ -109,5 +108,3 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
         return new self(sprintf('Invalid auto generate mode "%s" given.', $value));
     }
 }
-
-interface_exists(Proxy::class);

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1190,5 +1190,3 @@ EOT;
         return $name;
     }
 }
-
-interface_exists(ClassMetadata::class);

--- a/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/AbstractProxyFactoryTest.php
@@ -216,6 +216,3 @@ class AbstractProxyFactoryTest extends DoctrineTestCase
         $proxyFactory->getProxy('Class', []);
     }
 }
-
-interface_exists(ClassMetadata::class);
-interface_exists(ClassMetadataFactory::class);


### PR DESCRIPTION
These were necessary when we had to support doctrine/persistence 1 and
2, and should have been removed in https://github.com/doctrine/common/pull/890 (my bad)

See https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf