### PR TITLE
fallback getFileName() to declaring class

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -941,7 +941,7 @@ EOT;
             && ($endLine - $startLine <= 4);
 
         if ($cheapCheck) {
-            $code = file($method->getFileName());
+            $code = file($method->getFileName() ? $method->getFileName():$method->getDeclaringClass()->getFileName());
             $code = trim(implode(' ', array_slice($code, $startLine - 1, $endLine - $startLine + 1)));
 
             $pattern = sprintf(self::PATTERN_MATCH_ID_METHOD, $method->getName(), $identifier);


### PR DESCRIPTION
When `Entity` source encoded with ioncube, `$method->getFileName()` returns `false`. This error occur when generating proxy: `Warning: file(): Filename cannot be empty` 

Reference: https://github.com/doctrine/common/commit/59374594248862ccfb418bbb5fc2cf91c5ef8dd0