### PR TITLE
Handle PHP 8.1 types in proxies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,4 +17,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.1.1"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,8 @@ parameters:
         - tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php
         - tests/Doctrine/Tests/Common/Proxy/MagicIssetClassWithInteger.php
         - tests/Doctrine/Tests/Common/Proxy/NullableNonOptionalHintClass.php
+        - tests/Doctrine/Tests/Common/Proxy/PHP81NeverType.php
+        - tests/Doctrine/Tests/Common/Proxy/PHP81IntersectionTypes.php
         - tests/Doctrine/Tests/Common/Proxy/Php8UnionTypes.php
         - tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
         - tests/Doctrine/Tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,11 +5,13 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    phpVersion="8.0"
+    phpVersion="8.1"
 >
     <projectFiles>
         <directory name="lib/Doctrine/Common" />
         <ignoreFiles>
+            <!-- Remove ProxyGeneratorTest once Psalm supports native intersection https://github.com/vimeo/psalm/issues/6413 -->
+            <file name="tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php" />
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>

--- a/tests/Doctrine/Tests/Common/Proxy/PHP81IntersectionTypes.php
+++ b/tests/Doctrine/Tests/Common/Proxy/PHP81IntersectionTypes.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class PHP81IntersectionTypes
+{
+    public \Traversable&\Countable $foo;
+
+    public function setFoo(\Traversable&\Countable $foo) : \Traversable&\Countable
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/PHP81NeverType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/PHP81NeverType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class PHP81NeverType
+{
+    public function __get($name) : never
+    {
+        die('Please do not use __get');
+    }
+
+    public function __set($name, $value) : never
+    {
+        die('Please do not use __set');
+    }
+
+    public function finishHim() : never
+    {
+        die('Finish him');
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -476,6 +476,56 @@ class ProxyGeneratorTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 8.1.0
+     */
+    public function testPhp81IntersectionType()
+    {
+        $className = PHP81IntersectionTypes::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\PHP81IntersectionTypes', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            'setFoo(\Traversable&\Countable $foo): \Traversable&\Countable',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81IntersectionTypes.php')
+        );
+    }
+
+    /**
+     * @requires PHP >= 8.1.0
+     */
+    public function testPhp81NeverType()
+    {
+        $className = PHP81NeverType::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\PHP81NeverType', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            '__get($name): never',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NeverType.php')
+        );
+
+        self::assertStringContainsString(
+            '__set($name, $value): never',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NeverType.php')
+        );
+
+        self::assertStringContainsString(
+            'finishHim(): never',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NeverType.php')
+        );
+    }
+
+    /**
      * @param string  $className
      * @param mixed[] $ids
      *

--- a/tests/Doctrine/Tests/Common/Util/DebugTest.php
+++ b/tests/Doctrine/Tests/Common/Util/DebugTest.php
@@ -121,6 +121,8 @@ class DebugTest extends DoctrineTestCase
      * @param array<string, int> $expected
      *
      * @dataProvider provideAttributesCases
+     *
+     * @requires PHP < 8.1.0
      */
     public function testExportParentAttributes(TestAsset\ParentClass $class, array $expected)
     {


### PR DESCRIPTION
This allows using `never` and intersection types in proxied classes. Fixes #948