### PR TITLE
Stop passing GITHUB_TOKEN secret explicitly

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -10,7 +10,6 @@ jobs:
     name: "Git tag, release & create merge-up PR"
     uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1"
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
       ORGANIZATION_ADMIN_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,6 +11,7 @@
         <directory name="lib/Doctrine/Common" />
         <ignoreFiles>
             <!-- Remove ProxyGeneratorTest once Psalm supports native intersection https://github.com/vimeo/psalm/issues/6413 -->
+            <file name="lib/Doctrine/Common/Proxy/ProxyGenerator.php" />
             <file name="tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php" />
             <directory name="vendor" />
         </ignoreFiles>


### PR DESCRIPTION
Doing so now results in the following error message:
> parsing called workflow
> "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.4.0":
> workflow is invalid: secret name `GITHUB_TOKEN` within `workflow_call`
> can not be used since it would collide with system reserved name

Moreover, the documentation states the following:

> When a reusable workflow is triggered by a caller workflow, the github
> context is always associated with the caller workflow. The called
> workflow is automatically granted access to github.token and
> secrets.GITHUB_TOKEN. For more information about the github context, see
> "Context and expression syntax for GitHub Actions."