### PR TITLE
Add return types to generated proxies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/persistence": "^2.0"
+        "doctrine/persistence": "^2.0 || ^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4.1",

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -162,7 +162,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
     /**
      * Forces initialization of the proxy
      */
-    public function __load()
+    public function __load(): void
     {
         $this->__initializer__ && $this->__initializer__->__invoke($this, \'__load\', []);
     }
@@ -171,7 +171,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __isInitialized()
+    public function __isInitialized(): bool
     {
         return $this->__isInitialized__;
     }
@@ -180,7 +180,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setInitialized($initialized)
+    public function __setInitialized($initialized): void
     {
         $this->__isInitialized__ = $initialized;
     }
@@ -189,7 +189,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setInitializer(\Closure $initializer = null)
+    public function __setInitializer(\Closure $initializer = null): void
     {
         $this->__initializer__ = $initializer;
     }
@@ -198,7 +198,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __getInitializer()
+    public function __getInitializer(): ?\Closure
     {
         return $this->__initializer__;
     }
@@ -207,7 +207,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setCloner(\Closure $cloner = null)
+    public function __setCloner(\Closure $cloner = null): void
     {
         $this->__cloner__ = $cloner;
     }
@@ -216,7 +216,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific cloning logic
      */
-    public function __getCloner()
+    public function __getCloner(): ?\Closure
     {
         return $this->__cloner__;
     }
@@ -227,7 +227,7 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
      * @deprecated no longer in use - generated code now relies on internal components rather than generated public API
      * @static
      */
-    public function __getLazyProperties()
+    public function __getLazyProperties(): array
     {
         return self::$lazyPropertiesDefaults;
     }


### PR DESCRIPTION
This PR adds return types to the code template for generated proxies. This makes the codebase compatible with the return types added in `doctrine/persistence` 3.