### PR TITLE
Don't Generate Set or Unset on Proxy of Readonly Public Properties

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1017,7 +1017,8 @@ EOT;
         foreach ($class->getReflectionClass()->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
             $name = $property->getName();
 
-            if ((! $class->hasField($name) && ! $class->hasAssociation($name))
+            if (
+                (! $class->hasField($name) && ! $class->hasAssociation($name))
                 || $class->isIdentifier($name)
                 || (method_exists($property, 'isReadOnly') && $property->isReadOnly())
             ) {

--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -1008,7 +1008,7 @@ EOT;
     /**
      * Generates the list of public properties to be lazy loaded, that are writable.
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public function getWriteableLazyLoadedPublicPropertiesNames(ClassMetadata $class): array
     {

--- a/tests/Doctrine/Tests/Common/Proxy/Php81ReadonlyPublicPropertyType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php81ReadonlyPublicPropertyType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class Php81ReadonlyPublicPropertyType
+{
+    public readonly string $readable;
+    public string $writeable = 'default';
+
+    public function __construct(
+        public readonly string $id,
+    ) {}
+}

--- a/tests/Doctrine/Tests/Common/Proxy/Php81ReadonlyPublicPropertyType.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php81ReadonlyPublicPropertyType.php
@@ -9,5 +9,8 @@ class Php81ReadonlyPublicPropertyType
 
     public function __construct(
         public readonly string $id,
-    ) {}
+        string $readable = 'readable-default'
+    ) {
+        $this->readable = $readable;
+    }
 }

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -528,6 +528,41 @@ class ProxyGeneratorTest extends TestCase
     /**
      * @requires PHP >= 8.1.0
      */
+    public function testPhp81ReadonlyPublicProperties()
+    {
+        $className = Php81ReadonlyPublicPropertyType::class;
+        $proxyClassName = 'Doctrine\Tests\Common\ProxyProxy\__CG__\Php81ReadonlyPublicPropertyType';
+
+        if ( ! class_exists($proxyClassName, false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $metadata
+                ->expects($this->any())
+                ->method('hasField')
+                ->will($this->returnCallback(static function ($fieldName) {
+                    return in_array($fieldName, ['id', 'readable', 'writeable']);
+                }));
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        // Readonly properties are removed from unset.
+        self::assertStringContainsString(
+            'unset($this->writeable);',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp81ReadonlyPublicPropertyType.php')
+        );
+
+        // But remain in property listings.
+        self::assertStringContainsString(
+            "'readable' => NULL",
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp81ReadonlyPublicPropertyType.php')
+        );
+    }
+
+    /**
+     * @requires PHP >= 8.1.0
+     */
     public function testEnumDefaultInPublicProperty() : void
     {
         $className = Php81EnumPublicPropertyType::class;

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -543,9 +543,8 @@ class ProxyGeneratorTest extends TestCase
             $metadata = $this->createClassMetadata($className, ['id']);
 
             $metadata
-                ->expects($this->any())
                 ->method('hasField')
-                ->will($this->returnCallback(static function ($fieldName) use ($initializationData) {
+                ->will($this->returnCallback(static function (string $fieldName) use ($initializationData): bool {
                     return in_array($fieldName, array_keys($initializationData));
                 }));
 
@@ -572,24 +571,20 @@ class ProxyGeneratorTest extends TestCase
             $proxy->__setInitializer($initializer);
         });
 
-        var_dump($proxy->id);
-
         self::assertTrue(isset($proxy->id));
         self::assertTrue(isset($proxy->readable));
         self::assertTrue(isset($proxy->writeable));
         self::assertFalse(isset($proxy->nonExisting));
 
+        self::assertSame('c0b5cb93-f01b-43f8-bc66-bc943b1ebcfd', $proxy->id);
         self::assertSame('This field is writeable.', $proxy->writeable);
         $proxy->writeable = 'Updated string contents.';
         self::assertSame('Updated string contents.', $proxy->writeable);
 
-        try {
-            $proxy->readable = 'Invalid';
-            self::fail('Should not be able to update readonly property.');
-        } catch (\Error) {
-        }
-
         self::assertSame(3, $counter);
+
+        self::expectError();
+        $proxy->readable = 'Invalid';
     }
 
     /**


### PR DESCRIPTION
Attempting to fix doctrine/common#954.

- Create another private method `getWriteableLazyLoadedPublicPropertiesNames()`
- Use this method when generating `__set` or generating calls to `unset()` in `__construct` and `__wakeup`
- Leave all other methods that referenced `getLazyLoadedPublicPropertiesNames()` as they were.

Would like input on these changes as I don't have enough knowledge to know if omitting these properties will have unintended side-effects elsewhere.