### PR TITLE
Add doctrine/collections to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "doctrine/persistence": "^2.0 || ^3.0"
     },
     "require-dev": {
+        "doctrine/collections": "^1",
         "phpstan/phpstan": "^1.4.1",
         "phpstan/phpstan-phpunit": "^1",
         "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",


### PR DESCRIPTION
`doctrine/collections` used to be a transient dependency pulled by `doctrine/persistence`. Now that persistence does not depend on it anymore, static analysis fails because of unknown classes. This PR fixes the issue.