### PR TITLE
Support void return type for __clone magic method

### DIFF
--- a/lib/Doctrine/Common/Proxy/ProxyGenerator.php
+++ b/lib/Doctrine/Common/Proxy/ProxyGenerator.php
@@ -860,7 +860,9 @@ EOT;
      */
     private function generateCloneImpl(ClassMetadata $class)
     {
-        $hasParentClone  = $class->getReflectionClass()->hasMethod('__clone');
+        $reflectionClass = $class->getReflectionClass();
+        $hasParentClone  = $reflectionClass->hasMethod('__clone');
+        $returnTypeHint  = $hasParentClone ? $this->getMethodReturnType($reflectionClass->getMethod('__clone')) : '';
         $inheritDoc      = $hasParentClone ? '{@inheritDoc}' : '';
         $callParentClone = $hasParentClone ? "\n        parent::__clone();\n" : '';
 
@@ -868,7 +870,7 @@ EOT;
     /**
      * $inheritDoc
      */
-    public function __clone()
+    public function __clone()$returnTypeHint
     {
         \$this->__cloner__ && \$this->__cloner__->__invoke(\$this, '__clone', []);
 $callParentClone    }

--- a/tests/Doctrine/Tests/Common/Proxy/Php8MagicCloneClass.php
+++ b/tests/Doctrine/Tests/Common/Proxy/Php8MagicCloneClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class Php8MagicCloneClass
+{
+    public function __clone(): void
+    {
+    }
+}

--- a/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php
@@ -408,6 +408,26 @@ class ProxyGeneratorTest extends TestCase
     /**
      * @requires PHP >= 8.0.0
      */
+    public function testPhp8CloneWithVoidReturnType()
+    {
+        $className = Php8MagicCloneClass::class;
+
+        if ( ! class_exists('Doctrine\Tests\Common\ProxyProxy\__CG__\Php8MagicCloneClass', false)) {
+            $metadata = $this->createClassMetadata($className, ['id']);
+
+            $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+            $this->generateAndRequire($proxyGenerator, $metadata);
+        }
+
+        self::assertStringContainsString(
+            'public function __clone(): void',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8MagicCloneClass.php')
+        );
+    }
+
+    /**
+     * @requires PHP >= 8.0.0
+     */
     public function testPhp8UnionTypes()
     {
         $className = Php8UnionTypes::class;


### PR DESCRIPTION
Starting PHP 8.0, `void` an be type-hinted as return for `__clone` method.
But proxy generated doesn't add this return type, which breaks the inherited contract. 