### PR TITLE
Remove reference to submodule

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
         - lib
         - tests
     excludePaths:
-        - lib/vendor/doctrine-build-common
         - tests/Doctrine/Tests/Common/Proxy/InvalidReturnTypeClass.php
         - tests/Doctrine/Tests/Common/Proxy/InvalidTypeHintClass.php
         - tests/Doctrine/Tests/Common/Proxy/LazyLoadableObjectWithTypedProperties.php


### PR DESCRIPTION
It should have been removed in 4167060592de4dce2b955c6b6dded9a1b43a04b9.

See https://github.com/doctrine/common/pull/718#issuecomment-220356761