### PR TITLE
Remove useless ignore rules

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -10,10 +10,7 @@
     <projectFiles>
         <directory name="lib/Doctrine/Common" />
         <ignoreFiles>
-            <!-- Remove ProxyGeneratorTest once Psalm supports native intersection https://github.com/vimeo/psalm/issues/6413 -->
             <file name="lib/Doctrine/Common/Proxy/ProxyGenerator.php" />
-            <file name="tests/Doctrine/Tests/Common/Proxy/ProxyGeneratorTest.php" />
-            <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
 </psalm>


### PR DESCRIPTION
The referenced issue is fixed, but the fix is not released yet. However,
since the "tests" directory is not currently analyzed, the ignore rule
is useless.


Also, the rule about ignoring the vendor directory is useless.