### PR TITLE
Use var_export for scalar default values

### DIFF
--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -36,6 +36,7 @@ use function in_array;
 use function interface_exists;
 use function is_callable;
 use function is_dir;
+use function is_scalar;
 use function is_string;
 use function is_writable;
 use function lcfirst;
@@ -1122,7 +1123,7 @@ EOT;
             return '';
         }
 
-        if (PHP_VERSION_ID < 80100) {
+        if (PHP_VERSION_ID < 80100 || is_scalar($parameter->getDefaultValue())) {
             return ' = ' . var_export($parameter->getDefaultValue(), true);
         }
 

--- a/tests/Common/Proxy/PHP81NewInInitializers.php
+++ b/tests/Common/Proxy/PHP81NewInInitializers.php
@@ -23,7 +23,22 @@ class PHP81NewInInitializers
 
     }
 
-    public function constInDefault(string $foo = ConstProvider::FOO): void
+    public function scalarConstInDefault(string $foo = ConstProvider::FOO_SCALAR): void
+    {
+
+    }
+
+    public function constInDefault(array $foo = ConstProvider::FOO): void
+    {
+
+    }
+
+    public function globalEolInDefault(string $foo = \PHP_EOL): void
+    {
+
+    }
+
+    public function specialCharacterInDefault(string $foo = "\n"): void
     {
 
     }

--- a/tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Common/Proxy/ProxyGeneratorTest.php
@@ -602,7 +602,22 @@ class ProxyGeneratorTest extends TestCase
         );
 
         self::assertStringContainsString(
-            'constInDefault(string $foo = \Doctrine\Tests\Common\Util\TestAsset\ConstProvider::FOO): void',
+            'scalarConstInDefault(string $foo = \'foo\'): void',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NewInInitializers.php')
+        );
+
+        self::assertStringContainsString(
+            'constInDefault(array $foo = \Doctrine\Tests\Common\Util\TestAsset\ConstProvider::FOO): void',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NewInInitializers.php')
+        );
+
+        self::assertStringContainsString(
+            "globalEolInDefault(string \$foo = '\n'): void",
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NewInInitializers.php')
+        );
+
+        self::assertStringContainsString(
+            "specialCharacterInDefault(string \$foo = '\n'): void",
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPHP81NewInInitializers.php')
         );
     }

--- a/tests/Common/Util/TestAsset/ConstProvider.php
+++ b/tests/Common/Util/TestAsset/ConstProvider.php
@@ -6,5 +6,6 @@ namespace Doctrine\Tests\Common\Util\TestAsset;
 
 class ConstProvider
 {
-    public const FOO = 'foo';
+    public const FOO = ['foo'];
+    public const FOO_SCALAR = 'foo';
 }


### PR DESCRIPTION
This PR will be good enough to cut a 3.4.2 release. It will:

- fix #987 (also changes will need to stay until https://github.com/php/php-src/issues/9622 is resolved)
- stop breaking existing code like mentioned in #988 and give us more time to deal with current approach's shenanigans

It is worth mentioning that we will NOT support correctly double-quoted strings in complex default values until a fix in PHP is present (or a workaround is found). Given people never really had a chance to start using such values, I believe this is OK.

@ampaze @Lustmored may I ask you to test your apps with this PR instead of released 3.4.1?