### PR TITLE
Fix nullable union type identifier lazy load

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,4 +17,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.1.1"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    phpVersion: 80100
+    phpVersion: 80200
     level: 3
     paths:
         - src

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -1224,6 +1224,10 @@ EOT;
         if ($type instanceof ReflectionUnionType) {
             return implode('|', array_map(
                 function (ReflectionType $unionedType) use ($method, $parameter) {
+                    if ($unionedType instanceof ReflectionIntersectionType) {
+                        return '(' . $this->formatType($unionedType, $method, $parameter) . ')';
+                    }
+
                     return $this->formatType($unionedType, $method, $parameter);
                 },
                 $type->getTypes()

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -74,7 +74,13 @@ class ProxyGenerator
      * Used to match very simple id methods that don't need
      * to be decorated since the identifier is known.
      */
-    public const PATTERN_MATCH_ID_METHOD = '((public\s+)?(function\s+%s\s*\(\)\s*)\s*(?::\s*\??\s*\\\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*\s*)?{\s*return\s*\$this->%s;\s*})i';
+    public const PATTERN_MATCH_ID_METHOD = <<<'EOT'
+((?(DEFINE)
+  (?<type>\\?[a-z_\x7f-\xff][\w\x7f-\xff]*(?:\\[a-z_\x7f-\xff][\w\x7f-\xff]*)*)
+  (?<intersection_type>(?&type)\s*&\s*(?&type))
+  (?<union_type>(?:(?:\(\s*(?&intersection_type)\s*\))|(?&type))(?:\s*\|\s*(?:(?:\(\s*(?&intersection_type)\s*\))|(?&type)))+)
+)(?:public\s+)?(?:function\s+%s\s*\(\)\s*)\s*(?::\s*(?:(?&union_type)|(?&intersection_type)|(?:\??(?&type)))\s*)?{\s*return\s*\$this->%s;\s*})i
+EOT;
 
     /**
      * The namespace that contains all proxy classes.

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP81IntersectionType.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP81IntersectionType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class LazyLoadableObjectWithPHP81IntersectionType
+{
+    private \stdClass&\Stringable $identifierFieldIntersectionType;
+
+    public function getIdentifierFieldIntersectionType(): \stdClass&\Stringable
+    {
+        return $this->identifierFieldIntersectionType;
+    }
+}

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP81IntersectionTypeClassMetadata.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP81IntersectionTypeClassMetadata.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use BadMethodCallException;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use ReflectionClass;
+use function array_keys;
+
+class LazyLoadableObjectWithPHP81IntersectionTypeClassMetadata implements ClassMetadata
+{
+    /** @var ReflectionClass */
+    protected $reflectionClass;
+
+    /** @var array<string,bool> */
+    protected $identifier = [
+        'identifierFieldIntersectionType' => true,
+    ];
+
+    /** @var array<string,bool> */
+    protected $fields = [
+        'identifierFieldIntersectionType' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if ($this->reflectionClass === null) {
+            $this->reflectionClass = new ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithPHP81IntersectionType');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP82UnionAndIntersectionType.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP82UnionAndIntersectionType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class LazyLoadableObjectWithPHP82UnionAndIntersectionType
+{
+    private (\stdClass&\Stringable)|null $identifierFieldUnionAndIntersectionType = null;
+
+    public function getIdentifierFieldUnionAndIntersectionType(): (\stdClass&\Stringable)|null
+    {
+        return $this->identifierFieldUnionAndIntersectionType;
+    }
+}

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP82UnionAndIntersectionTypeClassMetadata.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP82UnionAndIntersectionTypeClassMetadata.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use BadMethodCallException;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use ReflectionClass;
+use function array_keys;
+
+class LazyLoadableObjectWithPHP82UnionAndIntersectionTypeClassMetadata implements ClassMetadata
+{
+    /** @var ReflectionClass */
+    protected $reflectionClass;
+
+    /** @var array<string,bool> */
+    protected $identifier = [
+        'identifierFieldUnionAndIntersectionType' => true,
+    ];
+
+    /** @var array<string,bool> */
+    protected $fields = [
+        'identifierFieldUnionAndIntersectionType' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if ($this->reflectionClass === null) {
+            $this->reflectionClass = new ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithPHP82UnionAndIntersectionType');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP8UnionType.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP8UnionType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+class LazyLoadableObjectWithPHP8UnionType
+{
+    private int|string|null $identifierFieldUnionType = null;
+
+    public function getIdentifierFieldUnionType(): int|string|null
+    {
+        return $this->identifierFieldUnionType;
+    }
+}

--- a/tests/Common/Proxy/LazyLoadableObjectWithPHP8UnionTypeClassMetadata.php
+++ b/tests/Common/Proxy/LazyLoadableObjectWithPHP8UnionTypeClassMetadata.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+use BadMethodCallException;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use ReflectionClass;
+use function array_keys;
+
+class LazyLoadableObjectWithPHP8UnionTypeClassMetadata implements ClassMetadata
+{
+    /** @var ReflectionClass */
+    protected $reflectionClass;
+
+    /** @var array<string,bool> */
+    protected $identifier = [
+        'identifierFieldUnionType' => true,
+    ];
+
+    /** @var array<string,bool> */
+    protected $fields = [
+        'identifierFieldUnionType' => true,
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return $this->getReflectionClass()->getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifier()
+    {
+        return array_keys($this->identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getReflectionClass()
+    {
+        if ($this->reflectionClass === null) {
+            $this->reflectionClass = new ReflectionClass(__NAMESPACE__ . '\LazyLoadableObjectWithPHP8UnionType');
+        }
+
+        return $this->reflectionClass;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isIdentifier($fieldName)
+    {
+        return isset($this->identifier[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasField($fieldName)
+    {
+        return isset($this->fields[$fieldName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAssociation($fieldName)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isSingleValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isCollectionValuedAssociation($fieldName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFieldNames()
+    {
+        return array_keys($this->fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierFieldNames()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationNames()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTypeOfField($fieldName)
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationTargetClass($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isAssociationInverseSide($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAssociationMappedByTargetField($assocName)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIdentifierValues($object)
+    {
+        throw new BadMethodCallException('not implemented');
+    }
+}

--- a/tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
+++ b/tests/Common/Proxy/ProxyLogicIdentifierGetterTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use function class_exists;
 
+use const PHP_VERSION_ID;
+
 /**
  * Test that identifier getter does not cause lazy loading.
  * These tests make assumptions about the structure of LazyLoadableObjectWithTypehints
@@ -58,7 +60,7 @@ class ProxyLogicIdentifierGetterTest extends TestCase
      */
     public function methodsForWhichLazyLoadingShouldBeDisabled()
     {
-        return [
+        $data = [
             [new LazyLoadableObjectClassMetadata(), 'protectedIdentifierField', 'foo'],
             [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldNoReturnTypehint', 'noTypeHint'],
             [new LazyLoadableObjectWithTypehintsClassMetadata(), 'identifierFieldReturnTypehintScalar', 'scalarValue'],
@@ -71,5 +73,30 @@ class ProxyLogicIdentifierGetterTest extends TestCase
             [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullable', new stdClass()],
             [new LazyLoadableObjectWithNullableTypehintsClassMetadata(), 'identifierFieldReturnClassOneLetterNullableWithSpace', new stdClass()],
         ];
+
+        if (PHP_VERSION_ID >= 80000) {
+            $data[] = [new LazyLoadableObjectWithPHP8UnionTypeClassMetadata(), 'identifierFieldUnionType', 123];
+            $data[] = [new LazyLoadableObjectWithPHP8UnionTypeClassMetadata(), 'identifierFieldUnionType', 'string'];
+        }
+
+        if (PHP_VERSION_ID >= 80100) {
+            $data[] = [new LazyLoadableObjectWithPHP81IntersectionTypeClassMetadata(), 'identifierFieldIntersectionType', new class extends \stdClass implements \Stringable {
+                public function __toString(): string
+                {
+                    return '';
+                }
+            }];
+        }
+
+        if (PHP_VERSION_ID >= 80200) {
+            $data[] = [new LazyLoadableObjectWithPHP82UnionAndIntersectionTypeClassMetadata(), 'identifierFieldUnionAndIntersectionType', new class extends \stdClass implements \Stringable {
+                public function __toString(): string
+                {
+                    return '';
+                }
+            }];
+        }
+
+        return $data;
     }
 }

--- a/tests/Common/Proxy/ProxyLogicTest.php
+++ b/tests/Common/Proxy/ProxyLogicTest.php
@@ -219,6 +219,10 @@ class ProxyLogicTest extends TestCase
 
     public function testNoErrorWhenSettingNonExistentProperty()
     {
+        if (PHP_VERSION_ID >= 80200) {
+            $this->markTestSkipped('access to a dynamic property trigger a deprecation notice on PHP 8.2+');
+        }
+
         $this->configureInitializerMock(0);
 
         $this->lazyObject->non_existing_property = 'now has a value';

--- a/tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php
+++ b/tests/Common/Proxy/ProxyLogicTypedPropertiesTest.php
@@ -226,6 +226,10 @@ class ProxyLogicTypedPropertiesTest extends TestCase
 
     public function testNoErrorWhenSettingNonExistentProperty()
     {
+        if (PHP_VERSION_ID >= 80200) {
+            $this->markTestSkipped('access to a dynamic property trigger a deprecation notice on PHP 8.2+');
+        }
+
         $this->configureInitializerMock(0);
 
         $this->lazyObject->non_existing_property = 'now has a value';

--- a/tests/Common/Proxy/ProxyMagicMethodsTest.php
+++ b/tests/Common/Proxy/ProxyMagicMethodsTest.php
@@ -135,6 +135,10 @@ class ProxyMagicMethodsTest extends TestCase
 
     public function testInheritedMagicGetWithVoid()
     {
+        if (PHP_VERSION_ID >= 80200) {
+            $this->markTestSkipped('access to a dynamic property trigger a deprecation notice on PHP 8.2+');
+        }
+
         $proxyClassName = $this->generateProxyClass(MagicGetClassWithVoid::class);
         $proxy          = new $proxyClassName(static function (Proxy $proxy, $method, $params) use (&$counter) {
             if (in_array($params[0], ['publicField', 'test'])) {


### PR DESCRIPTION
Currently using union type for identifiers method doesn't permit to lazy load the entity.

With this fix, only a union type for a single type and null is supported. `null` can be at first position or at last.

For example:

This will enable lazy-loading (which previously was not): 

```php
public function getId(): int|null;
public function getId(): null|int;
public function getId(): \stdClass|null;
public function getId(): RelativeNamespace\Class|null;
public function getId(): \AbsoluteNamespace\Class|null;
```