### PR TITLE
Don't allow generating proxies for readonly classes

### DIFF
--- a/src/Proxy/Exception/InvalidArgumentException.php
+++ b/src/Proxy/Exception/InvalidArgumentException.php
@@ -91,6 +91,17 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
         return new self(sprintf('Unable to create a proxy for a final class "%s".', $className));
     }
 
+    /**
+     * @param string $className
+     * @psalm-param class-string $className
+     *
+     * @return self
+     */
+    public static function classMustNotBeReadOnly($className)
+    {
+        return new self(sprintf('Unable to create a proxy for a readonly class "%s".', $className));
+    }
+
     /** @param mixed $value */
     public static function invalidAutoGenerateMode($value): self
     {

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -361,6 +361,10 @@ class <proxyShortClassName> extends \<className> implements \<baseProxyInterface
         if ($class->getReflectionClass()->isAbstract()) {
             throw InvalidArgumentException::classMustNotBeAbstract($class->getName());
         }
+
+        if (PHP_VERSION_ID >= 80200 && $class->getReflectionClass()->isReadOnly()) {
+            throw InvalidArgumentException::classMustNotBeReadOnly($class->getName());
+        }
     }
 
     /**

--- a/tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Common/Proxy/ProxyGeneratorTest.php
@@ -406,6 +406,18 @@ class ProxyGeneratorTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 8.2.0
+     */
+    public function testReadOnlyClassThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unable to create a proxy for a readonly class "' . ReadOnlyClass::class . '".');
+
+        $proxyGenerator = new ProxyGenerator(__DIR__ . '/generated', __NAMESPACE__ . 'Proxy');
+        $proxyGenerator->generateProxyClass($this->createClassMetadata(ReadOnlyClass::class, []));
+    }
+
+    /**
      * @requires PHP >= 8.0.0
      */
     public function testPhp8CloneWithVoidReturnType()

--- a/tests/Common/Proxy/ReadOnlyClass.php
+++ b/tests/Common/Proxy/ReadOnlyClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Doctrine\Tests\Common\Proxy;
+
+readonly class ReadOnlyClass
+{
+}


### PR DESCRIPTION
Readonly classes cannot be proxied, let's reject them early on before we start generating broken proxies for them.