### PR TITLE
Test of missing aliases

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -8,7 +8,11 @@
             "name": "3.4",
             "branchName": "3.4.x",
             "slug": "3.4",
-            "current": true
+            "current": true,
+            "aliases": [
+                "current",
+                "stable"
+            ]
         },
         {
             "name": "3.3",


### PR DESCRIPTION
There is currently a failing integration test of the Doctrine website that (probably) depends on the aliases of multiple projects. I'd like to test it on the Doctrine Common project to see if these aliases are supposed to be mandatory. 