### PR TITLE
fix: proxy with BackedEnum integer on identifier

### DIFF
--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -27,6 +27,7 @@ use function call_user_func;
 use function chmod;
 use function class_exists;
 use function dirname;
+use function enum_exists;
 use function explode;
 use function file;
 use function file_put_contents;
@@ -940,7 +941,12 @@ EOT;
             if ($this->isShortIdentifierGetter($method, $class)) {
                 $identifier = lcfirst(substr($name, 3));
                 $fieldType  = $class->getTypeOfField($identifier);
-                $cast       = in_array($fieldType, ['integer', 'smallint'], true) ? '(int) ' : '';
+
+                if (ClassUtils::containsEnumType($method->getReturnType())) {
+                    $cast = '';
+                } else {
+                    $cast = in_array($fieldType, ['integer', 'smallint'], true) ? '(int) ' : '';
+                }
 
                 $methods .= '        if ($this->__isInitialized__ === false) {' . "\n";
                 $methods .= '            ';


### PR DESCRIPTION
If entity identifier return an int BackedEnum, Proxy Generator generate method with cast to int. But it's impossible to cast a BackedEnum to int.

Call `getId()` on proxy throw an error : 
`Warning: Object of class App\\Enum\\ProviderId could not be converted to int`

Original entity:
```php
    public function getId(): ProviderId
    {
        return $this->id;
    }
```

Generated proxy method **before fix**:
```php
    /**
     * {@inheritDoc}
     */
    public function getId(): \App\Enum\ProviderId
    {
        if ($this->__isInitialized__ === false) {
            return (int)  parent::getId();
        }


        $this->__initializer__ && $this->__initializer__->__invoke($this, 'getId', []);

        return parent::getId();
    }
```



Generated proxy method **after fix**:
```php
    /**
     * {@inheritDoc}
     */
    public function getId(): \App\Enum\ProviderId
    {
        if ($this->__isInitialized__ === false) {
            return  parent::getId();
        }


        $this->__initializer__ && $this->__initializer__->__invoke($this, 'getId', []);

        return parent::getId();
    }
```