### PR TITLE
Deprecate all symbols in the Doctrine\Common\Proxy namespace

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,21 +26,13 @@ parameters:
             message: '#^Result of method Doctrine\\Tests\\Common\\Proxy\\LazyLoadableObjectWithVoid::(adding|incrementing)AndReturningVoid\(\) \(void\) is used\.$#'
             path: 'tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
         -
-            message: '#^Property Doctrine\\Tests\\Common\\Proxy\\ProxyLogicTest::\$initializerCallbackMock \(callable\(\): mixed&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject&stdClass\.$#'
-            path: 'tests/Common/Proxy/ProxyLogicTest.php'
-        -
             message: '#.*LazyLoadableObject.*#'
-            paths:
-               - 'tests/Common/Proxy/ProxyLogicTest.php'
-               - 'tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
+            path: 'tests/Common/Proxy/ProxyLogicTest.php'
         -
             message: '#^Instantiated class Doctrine\\Tests\\Common\\ProxyProxy\\__CG__\\Doctrine\\Tests\\Common\\Proxy\\.* not found.$#'
             path: 'tests/Common/Proxy/ProxyLogicTest.php'
         -
             message: '#^Instantiated class Doctrine\\Tests\\Common\\ProxyProxy\\__CG__\\Doctrine\\Tests\\Common\\Proxy\\.* not found.$#'
-            path: 'tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
-        -
-            message: '#^Property Doctrine\\Tests\\Common\\Proxy\\ProxyLogicVoidReturnTypeTest::\$initializerCallbackMock \(callable\(\): mixed&PHPUnit\\Framework\\MockObject\\MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject&stdClass\.$#'
             path: 'tests/Common/Proxy/ProxyLogicVoidReturnTypeTest.php'
         -
             message: '#^Method Doctrine\\Tests\\Common\\Proxy\\MagicIssetClassWithInteger::__isset\(\) should return bool but returns int\.$#'

--- a/src/Proxy/AbstractProxyFactory.php
+++ b/src/Proxy/AbstractProxyFactory.php
@@ -15,6 +15,8 @@ use function in_array;
 
 /**
  * Abstract factory for proxy objects.
+ *
+ * @deprecated The AbstractProxyFactory class is deprecated since doctrine/common 3.5.
  */
 abstract class AbstractProxyFactory
 {

--- a/src/Proxy/Autoloader.php
+++ b/src/Proxy/Autoloader.php
@@ -21,6 +21,7 @@ use const DIRECTORY_SEPARATOR;
  * Special Autoloader for Proxy classes, which are not PSR-0 compliant.
  *
  * @internal
+ * @deprecated The Autoloader class is deprecated since doctrine/common 3.5.
  */
 class Autoloader
 {

--- a/src/Proxy/Exception/InvalidArgumentException.php
+++ b/src/Proxy/Exception/InvalidArgumentException.php
@@ -13,7 +13,7 @@ use function sprintf;
 /**
  * Proxy Invalid Argument Exception.
  *
- * @link   www.doctrine-project.org
+ * @deprecated The InvalidArgumentException class is deprecated since doctrine/common 3.5.
  */
 class InvalidArgumentException extends BaseInvalidArgumentException implements ProxyException
 {

--- a/src/Proxy/Exception/OutOfBoundsException.php
+++ b/src/Proxy/Exception/OutOfBoundsException.php
@@ -9,7 +9,7 @@ use function sprintf;
 /**
  * Proxy Invalid Argument Exception.
  *
- * @link   www.doctrine-project.org
+ * @deprecated The OutOfBoundsException class is deprecated since doctrine/common 3.5.
  */
 class OutOfBoundsException extends BaseOutOfBoundsException implements ProxyException
 {

--- a/src/Proxy/Exception/ProxyException.php
+++ b/src/Proxy/Exception/ProxyException.php
@@ -5,7 +5,7 @@ namespace Doctrine\Common\Proxy\Exception;
 /**
  * Base exception interface for proxy exceptions.
  *
- * @link   www.doctrine-project.org
+ * @deprecated The ProxyException interface is deprecated since doctrine/common 3.5.
  */
 interface ProxyException
 {

--- a/src/Proxy/Exception/UnexpectedValueException.php
+++ b/src/Proxy/Exception/UnexpectedValueException.php
@@ -10,7 +10,7 @@ use function sprintf;
 /**
  * Proxy Unexpected Value Exception.
  *
- * @link   www.doctrine-project.org
+ * @deprecated The UnexpectedValueException class is deprecated since doctrine/common 3.5.
  */
 class UnexpectedValueException extends BaseUnexpectedValueException implements ProxyException
 {

--- a/src/Proxy/Proxy.php
+++ b/src/Proxy/Proxy.php
@@ -8,6 +8,8 @@ use Doctrine\Persistence\Proxy as BaseProxy;
 /**
  * Interface for proxy classes.
  *
+ * @deprecated The Proxy interface is deprecated since doctrine/common 3.5.
+ *
  * @template T of object
  * @template-extends BaseProxy<T>
  */

--- a/src/Proxy/ProxyDefinition.php
+++ b/src/Proxy/ProxyDefinition.php
@@ -6,6 +6,8 @@ use ReflectionProperty;
 
 /**
  * Definition structure how to create a proxy.
+ *
+ * @deprecated The ProxyDefinition class is deprecated since doctrine/common 3.5.
  */
 class ProxyDefinition
 {

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -67,6 +67,8 @@ use const PREG_SPLIT_DELIM_CAPTURE;
 /**
  * This factory is used to generate proxy classes.
  * It builds proxies from given parameters, a template and class metadata.
+ *
+ * @deprecated The ProxyGenerator class is deprecated since doctrine/common 3.5.
  */
 class ProxyGenerator
 {


### PR DESCRIPTION
Allowed by https://github.com/doctrine/orm/pull/10837