### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,6 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@5.1.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"

--- a/src/Proxy/ProxyGenerator.php
+++ b/src/Proxy/ProxyGenerator.php
@@ -1282,7 +1282,6 @@ EOT;
         if (
             $type->allowsNull()
             && ! in_array($name, ['mixed', 'null'], true)
-            && ($parameter === null || ! $parameter->isDefaultValueAvailable() || $parameter->getDefaultValue() !== null)
         ) {
             $name = '?' . $name;
         }

--- a/tests/Common/Proxy/Php8UnionTypes.php
+++ b/tests/Common/Proxy/Php8UnionTypes.php
@@ -12,10 +12,16 @@ class Php8UnionTypes
 
     public function setValue(stdClass|array $value) : bool|float
     {
+        return true;
     }
 
     public function setNullableValue(stdClass|array|null $value) : bool|float|null
     {
+        return true;
     }
 
+    public function setNullableValueDefaultNull(stdClass|array|null $value = null) : bool|float|null
+    {
+        return true;
+    }
 }

--- a/tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Common/Proxy/ProxyGeneratorTest.php
@@ -259,7 +259,7 @@ class ProxyGeneratorTest extends TestCase
         }
 
         self::assertStringContainsString(
-            'public function midSignatureNullableParameter(\stdClass $param = NULL, $secondParam)',
+            'public function midSignatureNullableParameter(?\stdClass $param = NULL, $secondParam)',
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyNullableNonOptionalHintClass.php')
         );
 

--- a/tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Common/Proxy/ProxyGeneratorTest.php
@@ -287,7 +287,7 @@ class ProxyGeneratorTest extends TestCase
         }
 
         self::assertStringContainsString(
-            'public function midSignatureNullableParameter(string $param = NULL, $secondParam)',
+            'public function midSignatureNullableParameter(?string $param = NULL, $secondParam)',
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp71NullableDefaultedNonOptionalHintClass.php'),
             'Signature allows nullable type, although explicit "?" marker isn\'t used in the proxy'
         );

--- a/tests/Common/Proxy/ProxyGeneratorTest.php
+++ b/tests/Common/Proxy/ProxyGeneratorTest.php
@@ -180,7 +180,7 @@ class ProxyGeneratorTest extends TestCase
         self::assertEquals(1, substr_count($classCode, 'function combinationOfTypeHintsAndNormal(\stdClass $a, \Countable $b, $c, int $d)'));
         self::assertEquals(1, substr_count($classCode, 'function typeHintsWithVariadic(int ...$foo)'));
         self::assertEquals(1, substr_count($classCode, 'function withDefaultValue(int $foo = 123)'));
-        self::assertEquals(1, substr_count($classCode, 'function withDefaultValueNull(int $foo = NULL)'));
+        self::assertEquals(1, substr_count($classCode, 'function withDefaultValueNull(?int $foo = NULL)'));
     }
 
     public function testClassWithReturnTypesOnProxiedMethods()
@@ -220,8 +220,8 @@ class ProxyGeneratorTest extends TestCase
         self::assertEquals(1, substr_count($classCode, 'function nullableTypeHintObject(?\stdClass $param)'));
         self::assertEquals(1, substr_count($classCode, 'function nullableTypeHintSelf(?\\' . $className . ' $param)'));
         self::assertEquals(1, substr_count($classCode, 'function nullableTypeHintWithDefault(?int $param = 123)'));
-        self::assertEquals(1, substr_count($classCode, 'function nullableTypeHintWithDefaultNull(int $param = NULL)'));
-        self::assertEquals(1, substr_count($classCode, 'function notNullableTypeHintWithDefaultNull(int $param = NULL)'));
+        self::assertEquals(1, substr_count($classCode, 'function nullableTypeHintWithDefaultNull(?int $param = NULL)'));
+        self::assertEquals(1, substr_count($classCode, 'function notNullableTypeHintWithDefaultNull(?int $param = NULL)'));
     }
 
     public function testClassWithNullableReturnTypesOnProxiedMethods()
@@ -458,6 +458,11 @@ class ProxyGeneratorTest extends TestCase
 
         self::assertStringContainsString(
             'setNullableValue(\stdClass|array|null $value): float|bool|null',
+            file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8UnionTypes.php')
+        );
+
+        self::assertStringContainsString(
+            'setNullableValueDefaultNull(\stdClass|array|null $value = NULL): float|bool|null',
             file_get_contents(__DIR__ . '/generated/__CG__DoctrineTestsCommonProxyPhp8UnionTypes.php')
         );
     }


### PR DESCRIPTION
This fixes the Proxy Generator creating an overwrite method with an implicit null deprecation.