### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,14 +5,16 @@
     "docsSlug": "doctrine-common",
     "versions": [
         {
+            "name": "3.5",
+            "branchName": "3.5.x",
+            "slug": "3.5",
+            "current": true
+        },
+        {
             "name": "3.4",
             "branchName": "3.4.x",
             "slug": "3.4",
-            "current": true,
-            "aliases": [
-                "current",
-                "stable"
-            ]
+            "maintained": false
         },
         {
             "name": "3.3",


### PR DESCRIPTION
- 3.5.x is now the current/stable branch
- 3.4.x is no longer maintained

Although 3.6.x and 4.0.x exist, hopefully they will not receive any commits before we decide to abandon this package.